### PR TITLE
Fix coreml issues in macos15 ios restricted

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Ensure you have the following before you start:
 
 - **Xcode:** The Ultralytics YOLO iOS App requires Xcode installed on your macOS machine. Download it from the [Mac App Store](https://apps.apple.com/us/app/xcode/id497799835).
 
-- **An iOS Device:** For testing the app, you'll need an iPhone or iPad running [iOS 14.0](https://www.apple.com/ios/ios-18/) or later.
+- **An iOS Device:** For testing the app, you'll need an iPhone or iPad running [iOS 14.0](https://www.apple.com/ios/ios-18/) or later. Note: custom, fine-tuned models can only work on iPhone or iPad running **iOS 17.0** or later.
 
 - **An Apple Developer Account:** A free Apple Developer account will suffice for device testing. Sign up [here](https://developer.apple.com/) if you haven't already.
 
@@ -62,7 +62,7 @@ Ensure you have the following before you start:
 
 3. **Add YOLO11 Models to the Project:**
 
-   Export CoreML INT8 models using the `ultralytics` Python package (with `pip install ultralytics`), or download them from our [GitHub release assets](https://github.com/ultralytics/yolo-ios-app/releases). You should have 5 YOLO11 models in total. Place these in the `YOLO/Models` directory as seen in the Xcode screenshot below.
+   Since the YOLO CoreML models are not versionned in this repository, you'll need to create them by exporting CoreML INT8 models using the `ultralytics` Python package (with `pip install ultralytics`), or download them from our [GitHub release assets](https://github.com/ultralytics/yolo-ios-app/releases). You should have 5 YOLO11 models in total. Place these in the `YOLO/Models` directory as seen in the Xcode screenshot below.
 
    ```python
    from ultralytics import YOLO

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Ensure you have the following before you start:
 
 - **Xcode:** The Ultralytics YOLO iOS App requires Xcode installed on your macOS machine. Download it from the [Mac App Store](https://apps.apple.com/us/app/xcode/id497799835).
 
-- **An iOS Device:** For testing the app, you'll need an iPhone or iPad running [iOS 14.0](https://www.apple.com/ios/ios-18/) or later. Note: custom, fine-tuned models can only work on iPhone or iPad running **iOS 17.0** or later.
+- **An iOS Device:** For testing the app, you'll need an iPhone or iPad running [iOS 14.0](https://www.apple.com/ios/ios-18/) or later. Note: trained models can only work on iPhone or iPad running **iOS 17.0** or later.
 
 - **An Apple Developer Account:** A free Apple Developer account will suffice for device testing. Sign up [here](https://developer.apple.com/) if you haven't already.
 
@@ -62,19 +62,36 @@ Ensure you have the following before you start:
 
 3. **Add YOLO11 Models to the Project:**
 
-   Since the YOLO CoreML models are not versionned in this repository, you'll need to create them by exporting CoreML INT8 models using the `ultralytics` Python package (with `pip install ultralytics`), or download them from our [GitHub release assets](https://github.com/ultralytics/yolo-ios-app/releases). You should have 5 YOLO11 models in total. Place these in the `YOLO/Models` directory as seen in the Xcode screenshot below.
+   Since the YOLO CoreML models are not versionned in this repository, you'll need to either:
+   
+   1. Create them by exporting your trained models to CoreML INT8 models using the `ultralytics` Python package (with `pip install ultralytics`).
 
-   ```python
-   from ultralytics import YOLO
+      ```python
+      from ultralytics import YOLO
 
-   # Loop through all YOLO11 model sizes
-   for size in ("n", "s", "m", "l", "x"):
-       # Load a YOLO11 PyTorch model
-       model = YOLO(f"yolo11{size}.pt")
+      # Load a trained YOLO11 PyTorch model
+      model = YOLO(f"path/to/your/trained/model.pt")
+      
+      # Export the PyTorch model to CoreML INT8 format with NMS layers
+      # The imgsz property may be adjusted when you export a trained model
+      model.export(format="coreml", int8=True, nms=True, imgsz=640)
+      ```
 
-       # Export the PyTorch model to CoreML INT8 format with NMS layers
-       model.export(format="coreml", int8=True, nms=True, imgsz=[640, 384])
-   ```
+   2. Download the base models from our [GitHub release assets](https://github.com/ultralytics/yolo-ios-app/releases).
+
+      ```python
+      from ultralytics import YOLO
+
+      # Loop through all YOLO11 model sizes and exclude any trained models from the loop
+      for size in ("n", "s", "m", "l", "x"):
+         # Load a base YOLO11 PyTorch model
+         model = YOLO(f"yolo11{size}.pt")
+         
+         # Export the PyTorch model to CoreML INT8 format with NMS layers
+         model.export(format="coreml", int8=True, nms=True)
+      ```
+   
+   You should have 5 YOLO11 models in total. Place these in the `YOLO/Models` directory as seen in the Xcode screenshot below.
 
 4. **Run the Ultralytics YOLO iOS App:**
 

--- a/README.md
+++ b/README.md
@@ -62,16 +62,16 @@ Ensure you have the following before you start:
 
 3. **Add YOLO11 Models to the Project:**
 
-   Since the YOLO CoreML models are not versionned in this repository, you'll need to either:
-   
+   Since the YOLO CoreML models are not versioned in this repository, you'll need to either:
+
    1. Create them by exporting your trained models to CoreML INT8 models using the `ultralytics` Python package (with `pip install ultralytics`).
 
       ```python
       from ultralytics import YOLO
 
       # Load a trained YOLO11 PyTorch model
-      model = YOLO(f"path/to/your/trained/model.pt")
-      
+      model = YOLO("path/to/your/trained/model.pt")
+
       # Export the PyTorch model to CoreML INT8 format with NMS layers
       # The imgsz property may be adjusted when you export a trained model
       model.export(format="coreml", int8=True, nms=True, imgsz=640)
@@ -84,13 +84,13 @@ Ensure you have the following before you start:
 
       # Loop through all YOLO11 model sizes and exclude any trained models from the loop
       for size in ("n", "s", "m", "l", "x"):
-         # Load a base YOLO11 PyTorch model
-         model = YOLO(f"yolo11{size}.pt")
-         
-         # Export the PyTorch model to CoreML INT8 format with NMS layers
-         model.export(format="coreml", int8=True, nms=True)
+          # Load a base YOLO11 PyTorch model
+          model = YOLO(f"yolo11{size}.pt")
+
+          # Export the PyTorch model to CoreML INT8 format with NMS layers
+          model.export(format="coreml", int8=True, nms=True)
       ```
-   
+
    You should have 5 YOLO11 models in total. Place these in the `YOLO/Models` directory as seen in the Xcode screenshot below.
 
 4. **Run the Ultralytics YOLO iOS App:**

--- a/YOLO/ViewController.swift
+++ b/YOLO/ViewController.swift
@@ -17,7 +17,16 @@ import CoreMedia
 import UIKit
 import Vision
 
-var mlModel = try! yolo11m(configuration: .init()).model
+var mlModel = try! yolo11m(configuration: mlmodelConfig).model
+var mlmodelConfig: MLModelConfiguration = {
+  let config = MLModelConfiguration()
+    
+    if #available(iOS 17.0, *) {
+      config.setValue(1, forKey: "experimentalMLE5EngineUsage")
+    }
+  
+  return config
+}()
 
 class ViewController: UIViewController {
   @IBOutlet var videoPreview: UIView!

--- a/YOLO/ViewController.swift
+++ b/YOLO/ViewController.swift
@@ -20,11 +20,11 @@ import Vision
 var mlModel = try! yolo11m(configuration: mlmodelConfig).model
 var mlmodelConfig: MLModelConfiguration = {
   let config = MLModelConfiguration()
-    
-    if #available(iOS 17.0, *) {
-      config.setValue(1, forKey: "experimentalMLE5EngineUsage")
-    }
-  
+
+  if #available(iOS 17.0, *) {
+    config.setValue(1, forKey: "experimentalMLE5EngineUsage")
+  }
+
   return config
 }()
 


### PR DESCRIPTION
This fix addresses a bug affecting trained models on macOS 15, which caused incorrect results during the inferences. By disabling experimentalMLE5EngineUsage in MLModelConfiguration, trained models will function normally. Note that this modification is only available for iOS 17 and later versions. The `README.md` has been updated accordingly.

```swift
let config = MLModelConfiguration()

if #available(iOS 17.0, *) {
   config.setValue(1, forKey: "experimentalMLE5EngineUsage")
}
```

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
This PR updates compatibility requirements for the YOLO iOS app and introduces an optimized configuration for CoreML models on iOS 17+ devices. 🚀

### 📊 Key Changes  
- **Updated Requirements**: The README now specifies that trained models require **iOS 17.0 or later** for operation.  
- **ML Model Configuration**: Introduced a new `MLModelConfiguration` with experimental settings specifically for **iOS 17+**.  
- **CoreML Model Export**: Enhanced instructions for exporting YOLO models in INT8 format, covering trained and base models distinctly.

### 🎯 Purpose & Impact  
- **Improved Compatibility**: Ensures YOLO models leverage **iOS 17-specific features**, unlocking better performance with Apple's machine learning engine. 🚀  
- **Clearer Setup Instructions**: Offers streamlined and detailed guidance on preparing CoreML models, reducing user confusion during setup. 🛠️  
- **Enhanced Performance**: The experimental CoreML configuration potentially improves **model inference speed and accuracy on iOS 17+ devices**. 📈  

This update is essential for iOS developers using YOLO models, ensuring they maximize device capabilities while receiving better guidance. 💡