### PR TITLE
Add Swift codeblocks highlighting

### DIFF
--- a/Sources/YOLO/README.md
+++ b/Sources/YOLO/README.md
@@ -151,6 +151,7 @@ Then, run the following Python script to export the desired models:
 
 ```python
 from ultralytics import YOLO
+
 # Export for all YOLO11 model sizes
 for size in ("n", "s", "m", "l", "x"):
     # Load a YOLO11 PyTorch model
@@ -166,7 +167,9 @@ for size in ("n", "s", "m", "l", "x"):
     # model = YOLO(f"yolo11{size}-obb.pt")   # oriented bounding box
 
     # Export the PyTorch model to CoreML INT8 format (without NMS layers)
-    model.export(format="coreml", int8=True, imgsz=[640, 384]) # For use with the package, do not add NMS to any models other than detection.
+    model.export(
+        format="coreml", int8=True, imgsz=[640, 384]
+    )  # For use with the package, do not add NMS to any models other than detection.
 ```
 
 Note: CoreMLTools' NMS is only applicable to detection models, so models for segment, pose, and obb tasks need to write NMS in Swift. This library includes NMS for these tasks.

--- a/Sources/YOLO/README.md
+++ b/Sources/YOLO/README.md
@@ -1,4 +1,4 @@
-# YOLO Package:Simple, Powerful YOLO Integration in Swift
+# YOLO Package: Simple, Powerful YOLO Integration in Swift
 
 YOLO Package is a Swift package that makes it easy to integrate Core ML-exported YOLO models into your app. It supports multiple tasks such as Object Detection, Segmentation, Classification, Pose Estimation, and Oriented Bounding Box Detection. With minimal code, you can add YOLO-based features to your app and even use real-time inference with camera streams in both SwiftUI and UIKit
 
@@ -13,13 +13,10 @@ YOLO Package is a Swift package that makes it easy to integrate Core ML-exported
 
 ## Features
 
-✅ **Simple API**: Easily utilize Core ML YOLO models with Python-like code in Swift.
-
-✅ **Multiple Task Support**: Object Detection, Segmentation, Classification, Pose Estimation, and Oriented Bounding Box Detection.
-
-✅ **SwiftUI / UIKit Integration**: Pre-built view components for real-time camera inference.
-
-✅ **Lightweight & Extensible**: Installs quickly via Swift Package Manager with no extra dependencies.
+- ✅ **Simple API**: Easily utilize Core ML YOLO models with Python-like code in Swift.
+- ✅ **Multiple Task Support**: Object Detection, Segmentation, Classification, Pose Estimation, and Oriented Bounding Box Detection.
+- ✅ **SwiftUI / UIKit Integration**: Pre-built view components for real-time camera inference.
+- ✅ **Lightweight & Extensible**: Installs quickly via Swift Package Manager with no extra dependencies.
 
 ## Requirements
 
@@ -44,7 +41,7 @@ Required to leverage Core ML and the latest Swift Concurrency features.
 
 In Xcode, go to File > Add Packages... and enter the URL of this repository:
 
-```
+```swift
 dependencies: [
     .package(url: "https://github.com/ultralytics/yolo-ios-app.git")
 ]
@@ -52,7 +49,7 @@ dependencies: [
 
 Then, specify it in your target:
 
-```
+```swift
 .target(
     name: "YourTarget",
     dependencies: [
@@ -69,7 +66,7 @@ YOLO Package primarily provides two main components: the **YOLO class** and **YO
 
 ### Import
 
-```
+```swift
 import YOLO
 ```
 
@@ -77,9 +74,9 @@ import YOLO
 
 **(Inference)**
 
-Use the YOLO class for inference on static images, image files, or other UIImage inputs. It supports tasks like Object Detection, Segmentation, Classification, Pose Estimation, and Oriented Bounding Box Detection. Simply provide a valid YOLOv8 model (either .mlmodelc or a local path/string).
+Use the YOLO class for inference on static images, image files, or other UIImage inputs. It supports tasks like Object Detection, Segmentation, Classification, Pose Estimation, and Oriented Bounding Box Detection. Simply provide a valid YOLO model (either .mlmodelc or a local path/string).
 
-```
+```swift
 let model = YOLO("yolo11n", task: .detect) # bundle file name, local path
 let result = model(image) # SwifUIImage, UIImage, CIImage, CGImage, bundle name, local path, remote URL
 ```
@@ -92,7 +89,7 @@ YOLO Package also provides SwiftUI and UIKit components for real-time inference 
 
 SwiftUI Example
 
-```
+```swift
 import YOLOSwift
 import SwiftUI
 
@@ -110,7 +107,7 @@ struct CameraView: View {
 
 UIKit Example
 
-```
+```swift
 import YOLOSwift
 import UIKit
 

--- a/Sources/YOLO/README.md
+++ b/Sources/YOLO/README.md
@@ -90,7 +90,7 @@ YOLO Package also provides SwiftUI and UIKit components for real-time inference 
 SwiftUI Example
 
 ```swift
-import YOLOSwift
+import YOLO
 import SwiftUI
 
 struct CameraView: View {
@@ -108,7 +108,7 @@ struct CameraView: View {
 UIKit Example
 
 ```swift
-import YOLOSwift
+import YOLO
 import UIKit
 
 class CameraViewController: UIViewController {
@@ -149,7 +149,7 @@ pip install ultralytics
 
 Then, run the following Python script to export the desired models:
 
-```
+```python
 from ultralytics import YOLO
 # Export for all YOLO11 model sizes
 for size in ("n", "s", "m", "l", "x"):


### PR DESCRIPTION
@john-rocky @asabri97 make sure to use correct highlighting for codeblocks. I've added `swift` here to Swift codeblocks but please add any other codeblock highlights in the READMEs if they are missing them.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improved documentation formatting and code snippet clarity for the YOLO iOS app's README.

### 📊 Key Changes  
- Enhanced formatting for the README, including consistent spacing and alignment.  
- Updated code snippets to specify the language (`swift`) for better syntax highlighting.  
- Minor text adjustments for improved readability and clarity.  

### 🎯 Purpose & Impact  
- 📚 **Improved Readability**: Clearer and more professional documentation makes it easier for developers to understand and use the YOLO iOS package.  
- 🚀 **Better Developer Experience**: Syntax-highlighted code snippets improve usability, especially for Swift developers integrating YOLO models.  
- 🛠️ **Streamlined Onboarding**: These changes help new users quickly grasp the package's features and implementation steps.