### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -5,6 +5,9 @@
 
 name: Tag and Release
 
+permissions:
+  contents: write
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/ultralytics/yolo-ios-app/security/code-scanning/1](https://github.com/ultralytics/yolo-ios-app/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimum required permissions. Based on the operations performed in the workflow, the following permissions are necessary:
- `contents: write` for creating and pushing tags.
- `issues: write` for adding comments to issues (if applicable in the future).
- `actions: read` for accessing workflow artifacts or logs (if needed).
- `pull-requests: write` for interacting with pull requests (if applicable in the future).

We will add the `permissions` block at the root of the workflow to apply it to all jobs. This ensures that the `GITHUB_TOKEN` is restricted to the least privileges required for the workflow to function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved GitHub workflow permissions for tagging and releasing the YOLO iOS app. 🚀

### 📊 Key Changes
- Added explicit write permissions for repository contents in the tag and release workflow.

### 🎯 Purpose & Impact
- Ensures the workflow can successfully create tags and releases without permission issues.
- Streamlines the release process, reducing the chance of errors and making updates smoother for users.