### PR TITLE
Fixed access modifiers for OBBResult

### DIFF
--- a/Sources/YOLO/YOLOResult.swift
+++ b/Sources/YOLO/YOLOResult.swift
@@ -142,16 +142,16 @@ public struct Keypoints {
 /// (rotated) bounding box, including its class, confidence score, and OBB parameters.
 public struct OBBResult {
   /// The oriented bounding box parameters.
-  var box: OBB
+  public var box: OBB
 
   /// The confidence score (0.0 to 1.0) for the detection.
-  var confidence: Float
+  public var confidence: Float
 
   /// The class label (category name) of the detected object.
-  var cls: String
+  public var cls: String
 
   /// The index of the class in the model's class list.
-  var index: Int
+  public var index: Int
 }
 
 /// Represents an oriented (rotated) bounding box.


### PR DESCRIPTION
Hi ultralytics team.

I have marked as public OBBResult access modifiers based on this issue:
https://github.com/ultralytics/yolo-ios-app/issues/142

Now we should be able to access these variables.

Best regards.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Made OBBResult properties public to improve access and integration with other parts of the app. 🚀

### 📊 Key Changes
- Changed the `OBBResult` struct's properties (`box`, `confidence`, `cls`, `index`) from internal to public.

### 🎯 Purpose & Impact
- Allows other modules and developers to directly access detection results, making it easier to use and extend the app.
- Enhances flexibility for integrating YOLO-based object detection with other features or external tools.
- Improves support for developers building on top of the Ultralytics iOS app framework.