### PR TITLE
Change all ExampleApp default models to nano

### DIFF
--- a/ExampleApps/YOLORealTimeSwiftUI/YOLORealTimeSwiftUI/ContentView.swift
+++ b/ExampleApps/YOLORealTimeSwiftUI/YOLORealTimeSwiftUI/ContentView.swift
@@ -18,8 +18,8 @@ import YOLO
 struct ContentView: View {
   var body: some View {
     YOLOCamera(
-      modelPathOrName: "yolo11n-seg",
-      task: .segment,
+      modelPathOrName: "yolo11n",
+      task: .detect,
       cameraPosition: .back
     )
     .ignoresSafeArea()

--- a/ExampleApps/YOLOSingleImageSwiftUI/YOLOSingleImageSwiftUI/ContentView.swift
+++ b/ExampleApps/YOLOSingleImageSwiftUI/YOLOSingleImageSwiftUI/ContentView.swift
@@ -21,7 +21,7 @@ struct ContentView: View {
   @State private var inputImage: UIImage?
   @State private var yoloResult: YOLOResult?
 
-  let yolo = YOLO("yolo11n-seg", task: .segment)
+  let yolo = YOLO("yolo11n", task: .detect)
 
   var body: some View {
     VStack {

--- a/ExampleApps/YOLOSingleImageUIKit/YOLOSingleImageUIKit/ViewController.swift
+++ b/ExampleApps/YOLOSingleImageUIKit/YOLOSingleImageUIKit/ViewController.swift
@@ -38,7 +38,7 @@ class ViewController: UIViewController, PHPickerViewControllerDelegate {
     //      view.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(presentPhPicker)))
     // Initialize YOLO model with a segmentation task
     // You can change the model or task type to use detection, classification, etc.
-    model = YOLO("yolo11l-seg", task: .segment) { [self] result in
+    model = YOLO("yolo11n", task: .detect) { [self] result in
       switch result {
       case .success(_):
         print("predictor initialized")

--- a/YOLOiOSApp/YOLOiOSApp/Info.plist
+++ b/YOLOiOSApp/YOLOiOSApp/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>478</string>
+	<string>477</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/YOLOiOSApp/YOLOiOSApp/Info.plist
+++ b/YOLOiOSApp/YOLOiOSApp/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>477</string>
+	<string>478</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
Change all ExampleApp default models to nano
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
This update switches the example iOS apps to use the YOLO11n detection model instead of segmentation models, making object detection the default demo task. 🚀

### 📊 Key Changes
- Changed the default model in all example apps from "yolo11n-seg" or "yolo11l-seg" (segmentation) to "yolo11n" (detection).
- Updated the task parameter from `.segment` to `.detect` in SwiftUI and UIKit sample apps.

### 🎯 Purpose & Impact
- **Simplifies Demos:** Makes object detection the default, which is more familiar and accessible for most users.
- **Consistency:** Ensures all example apps demonstrate the same detection workflow, reducing confusion.
- **User-Friendly:** New users can now see instant object detection results without needing to understand segmentation.
- **Easier Onboarding:** Lowers the barrier for trying out YOLO11n in iOS apps, making it easier to get started.