### PR TITLE
Squash commits into `testflight`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -132,27 +132,31 @@ jobs:
           sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
           xcodebuild -version
 
-      - name: Prepare testflight branch (reset to source branch)
+      - name: Prepare testflight branch (single commit)
         run: |
           git config user.name "UltralyticsAssistant"
           git config user.email "web@ultralytics.com"
           git fetch origin
-          git checkout -B testflight origin/${{ inputs.source_branch || 'main' }}
-
-      - name: Resolve dependencies and commit changes
-        run: |
+          
+          # Delete existing testflight branch
+          git branch -D testflight 2>/dev/null || true
+          
+          # Create clean testflight branch from source
+          git checkout -b testflight origin/${{ inputs.source_branch || 'main' }}
+          
+          # Resolve dependencies  
           INFO_PLIST="YOLOiOSApp/YOLOiOSApp/Info.plist"
           CURRENT_BUILD=$(/usr/libexec/PlistBuddy -c "Print CFBundleVersion" "$INFO_PLIST")
           MARKETING_VERSION="${{ needs.check.outputs.marketing_version }}"
-
-          # Resolve package dependencies
+          
           cd YOLOiOSApp
           xcodebuild -resolvePackageDependencies -project YOLOiOSApp.xcodeproj -scheme YOLOiOSApp
           cd ..
-
-          # Commit resolved dependencies
+          
+          # Squash all commits into single commit
+          git reset --soft $(git rev-list --max-parents=0 HEAD)
           git add -f YOLOiOSApp/YOLOiOSApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
-          git commit --allow-empty -m "Prepare v$MARKETING_VERSION ($CURRENT_BUILD) for Xcode Cloud"
+          git commit -m "Prepare v$MARKETING_VERSION ($CURRENT_BUILD) for Xcode Cloud"
 
       - name: Push to Xcode Cloud
         run: git push --force origin testflight

--- a/YOLOiOSApp/YOLOiOSApp/Info.plist
+++ b/YOLOiOSApp/YOLOiOSApp/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>476</string>
+	<string>477</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improves the TestFlight release workflow for the YOLO iOS app by streamlining branch management and ensuring cleaner builds. 🚀

### 📊 Key Changes
- Refines the TestFlight branch creation process to always start from a clean state.
- Squashes all changes into a single commit before pushing to the testflight branch.
- Updates the app’s build number from 476 to 477.

### 🎯 Purpose & Impact
- Ensures TestFlight releases are always based on the latest source branch, reducing the risk of leftover changes or conflicts.
- Makes the TestFlight branch history cleaner and easier to track, simplifying troubleshooting and audits.
- Keeps build numbers up to date, helping users and testers identify the latest version quickly.