### PR TITLE
Test: CI Simulator Availability Check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <a href="https://www.ultralytics.com/"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
 
 # 🚀 Ultralytics YOLO for iOS: App and Swift Package
+<!-- Testing CI simulator availability 2024-12-20 -->
 
 [![Ultralytics Actions](https://github.com/ultralytics/yolo-ios-app/actions/workflows/format.yml/badge.svg)](https://github.com/ultralytics/yolo-ios-app/actions/workflows/format.yml)
 [![CI](https://github.com/ultralytics/yolo-ios-app/actions/workflows/ci.yml/badge.svg)](https://github.com/ultralytics/yolo-ios-app/actions/workflows/ci.yml)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <a href="https://www.ultralytics.com/"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
 
 # 🚀 Ultralytics YOLO for iOS: App and Swift Package
+
 <!-- Testing CI simulator availability 2024-12-20 -->
 
 [![Ultralytics Actions](https://github.com/ultralytics/yolo-ios-app/actions/workflows/format.yml/badge.svg)](https://github.com/ultralytics/yolo-ios-app/actions/workflows/format.yml)


### PR DESCRIPTION
Testing if iOS Simulator is available in CI environment. This is a minimal change to trigger CI tests.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Minor README tweak to trigger and verify CI simulator availability—no app or SDK behavior changes. ✅

### 📊 Key Changes
- Added a non-functional HTML comment in README: “Testing CI simulator availability 2024-12-20.” 📝
- No code, build, or runtime modifications to the iOS app or Swift Package. 🛠️

### 🎯 Purpose & Impact
- Ensures CI pipelines correctly detect and run iOS simulators. 🧪
- Improves maintainers’ visibility into CI health without affecting users. 🛡️
- No impact on app functionality, performance, or API—safe to adopt. 🚀