### PR TITLE
ci: 👷 Update CI workflow to run on macOS 26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: macos-14
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   actions:
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - name: Run Ultralytics Actions
         uses: ultralytics/actions@main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -114,7 +114,7 @@ jobs:
   testflight:
     needs: check
     if: github.event_name == 'push' || inputs.testflight == true
-    runs-on: macos-latest
+    runs-on: macos-26
     permissions:
       contents: write
     environment:


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Switches all GitHub Actions workflows to use a specific macOS runner label (“macos-26”) for testing, formatting, and TestFlight publishing ⚙️🍏

### 📊 Key Changes
- CI tests: `runs-on` changed from `macos-14` to `macos-26` in `.github/workflows/ci.yml`
- Formatting workflow: `runs-on` changed from `macos-latest` to `macos-26` in `.github/workflows/format.yml`
- TestFlight publishing: `runs-on` changed from `macos-latest` to `macos-26` in `.github/workflows/publish.yml`

### 🎯 Purpose & Impact
- Ensures a consistent, controlled macOS/Xcode environment across all workflows ✅
- Reduces build flakiness from image updates on `macos-latest` and OS variations 🔒
- Likely improves reliability and speed by targeting a dedicated or self-hosted runner ⚡
- Potential caveat: forks or external contributors may not have access to the `macos-26` runner and could see workflow failures unless run in the main repo context ⚠️