### PR TITLE
Fix publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -165,7 +165,7 @@ jobs:
 
   notify:
     needs: [check, release, testflight]
-    if: always() && secrets.SLACK_WEBHOOK_URL_HUBWEB != ''
+    if: always()
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -188,7 +188,7 @@ jobs:
           echo "PR_NUMBER=${PR_NUMBER}" >> "${GITHUB_ENV}"
           echo "PR_TITLE=${PR_TITLE}" >> "${GITHUB_ENV}"
       - name: Notify Success
-        if: (needs.release.result == 'success' && github.event_name == 'push') || (needs.testflight.result == 'success' && github.event_name == 'pull_request')
+        if: secrets.SLACK_WEBHOOK_URL_HUBWEB != '' && ((needs.release.result == 'success' && github.event_name == 'push') || (needs.testflight.result == 'success' && github.event_name == 'pull_request'))
         uses: slackapi/slack-github-action@v2.0.0
         with:
           webhook-type: incoming-webhook
@@ -196,7 +196,7 @@ jobs:
           payload: |
             text: "<!channel> GitHub Actions success for ${{ github.workflow }} ✅\n\n\n*Repository:* https://github.com/${{ github.repository }}\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n*Event:* ${{ github.event_name == 'push' && format('NEW `YOLO iOS {0}` release published 🎉', needs.check.outputs.current_tag) || 'TestFlight build triggered for PR 🚀' }}\n*Job Status:* ${{ job.status }}\n*Pull Request:* <https://github.com/${{ github.repository }}/pull/${{ env.PR_NUMBER }}> ${{ env.PR_TITLE }}\n${{ github.event_name == 'push' && format('*Release Notes:* https://github.com/{0}/releases/tag/{1}', github.repository, needs.check.outputs.current_tag) || '' }}\n"
       - name: Notify Failure
-        if: (needs.release.result != 'success' && github.event_name == 'push') || (needs.testflight.result != 'success' && github.event_name == 'pull_request')
+        if: secrets.SLACK_WEBHOOK_URL_HUBWEB != '' && ((needs.release.result != 'success' && github.event_name == 'push') || (needs.testflight.result != 'success' && github.event_name == 'pull_request'))
         uses: slackapi/slack-github-action@v2.0.0
         with:
           webhook-type: incoming-webhook


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Refines the GitHub Actions notification flow to always run the notify job while only sending Slack messages when the webhook secret is available. ✅

### 📊 Key Changes
- notify job now always runs (`if: always()`), regardless of Slack secret presence.
- Slack notification steps (Success/Failure) are gated with `secrets.SLACK_WEBHOOK_URL_HUBWEB != ''` to only send messages when configured.
- Preserves existing success/failure conditions for release and TestFlight events.

### 🎯 Purpose & Impact
- Improves reliability: the notify job executes consistently, ensuring metadata collection and status visibility even without Slack configured.
- Prevents failures/noise: avoids Slack step errors when the webhook secret is missing (e.g., in forks or external PRs).
- Maintains team visibility: Slack alerts still fire for maintainers when the secret is set, covering both releases and TestFlight builds. 📣
- Better contributor experience: external contributors won’t see skipped/failing notify jobs due to missing secrets. 🙌