### PR TITLE
Fix 2 for publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -165,7 +165,7 @@ jobs:
 
   notify:
     needs: [check, release, testflight]
-    if: always()
+    if: always() && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -188,7 +188,7 @@ jobs:
           echo "PR_NUMBER=${PR_NUMBER}" >> "${GITHUB_ENV}"
           echo "PR_TITLE=${PR_TITLE}" >> "${GITHUB_ENV}"
       - name: Notify Success
-        if: secrets.SLACK_WEBHOOK_URL_HUBWEB != '' && ((needs.release.result == 'success' && github.event_name == 'push') || (needs.testflight.result == 'success' && github.event_name == 'pull_request'))
+        if: (needs.release.result == 'success' && github.event_name == 'push') || (needs.testflight.result == 'success' && github.event_name == 'pull_request')
         uses: slackapi/slack-github-action@v2.0.0
         with:
           webhook-type: incoming-webhook
@@ -196,7 +196,7 @@ jobs:
           payload: |
             text: "<!channel> GitHub Actions success for ${{ github.workflow }} ✅\n\n\n*Repository:* https://github.com/${{ github.repository }}\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n*Event:* ${{ github.event_name == 'push' && format('NEW `YOLO iOS {0}` release published 🎉', needs.check.outputs.current_tag) || 'TestFlight build triggered for PR 🚀' }}\n*Job Status:* ${{ job.status }}\n*Pull Request:* <https://github.com/${{ github.repository }}/pull/${{ env.PR_NUMBER }}> ${{ env.PR_TITLE }}\n${{ github.event_name == 'push' && format('*Release Notes:* https://github.com/{0}/releases/tag/{1}', github.repository, needs.check.outputs.current_tag) || '' }}\n"
       - name: Notify Failure
-        if: secrets.SLACK_WEBHOOK_URL_HUBWEB != '' && ((needs.release.result != 'success' && github.event_name == 'push') || (needs.testflight.result != 'success' && github.event_name == 'pull_request'))
+        if: (needs.release.result != 'success' && github.event_name == 'push') || (needs.testflight.result != 'success' && github.event_name == 'pull_request')
         uses: slackapi/slack-github-action@v2.0.0
         with:
           webhook-type: incoming-webhook


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Streamlines GitHub Actions notifications by skipping Dependabot runs and simplifying Slack notification conditions, reducing noise and improving CI clarity. 🔔🤖

### 📊 Key Changes
- CI notify job now skips when the actor is Dependabot: `if: always() && github.actor != 'dependabot[bot]'` 🚫🤖
- Removed the explicit secret-present checks from Slack notify steps, simplifying conditions for success/failure notifications ✅❗

### 🎯 Purpose & Impact
- Reduces notification noise from automated Dependabot PRs, keeping alerts relevant to human contributors 📉📣
- Simplifies workflow logic, making CI behavior easier to understand and maintain 🧹
- Potential caveat: without the secret guard, Slack steps will run whenever conditions match; if `SLACK_WEBHOOK_URL_HUBWEB` isn’t configured (e.g., in forks), these steps may fail. Ensure the secret is available where the workflow runs 🔐⚠️