### PR TITLE
Custom annotation

### DIFF
--- a/Sources/YOLO/Plot.swift
+++ b/Sources/YOLO/Plot.swift
@@ -134,8 +134,8 @@ public func drawYOLODetections(on ciImage: CIImage, result: YOLOResult, config: 
   drawContext.restoreGState()
 
   // Calculate line width and font size based on configuration
-  let lineWidth = config.lineWidth ?? max(width, height) / 200
-  let fontSize = config.fontSize ?? max(width, height) / 50
+  let lineWidth = config.lineWidth ?? CGFloat(max(width, height)) / 200
+  let fontSize = config.fontSize ?? CGFloat(max(width, height)) / 50
 
   for box in result.boxes {
     let colorIndex = box.index % ultralyticsColors.count
@@ -398,8 +398,8 @@ public func drawYOLOClassifications(on ciImage: CIImage, result: YOLOResult, con
   }
 
   // Calculate line width and font size based on configuration
-  let lineWidth = config.lineWidth ?? max(width, height) / 200
-  let fontSize = config.fontSize ?? max(width, height) / 50
+  let lineWidth = config.lineWidth ?? CGFloat(max(width, height)) / 200
+  let fontSize = config.fontSize ?? CGFloat(max(width, height)) / 50
   let labelMargin = CGFloat(fontSize / 2)
 
   for (i, candidate) in top5.enumerated() {
@@ -799,8 +799,8 @@ func drawOBBsOnCIImage(
   }
 
   // Calculate line width and font size based on configuration
-  let lineWidth: CGFloat = config.lineWidth ?? max(extent.width, extent.height) / 200
-  let fontSize = config.fontSize ?? max(extent.width, extent.height) / 50
+  let lineWidth: CGFloat = config.lineWidth ?? CGFloat(max(extent.width, extent.height)) / 200
+  let fontSize = config.fontSize ?? CGFloat(max(extent.width, extent.height)) / 50
   let outputSize = targetSize ?? CGSize(width: extent.width, height: extent.height)
 
   UIGraphicsBeginImageContextWithOptions(outputSize, false, 1.0)
@@ -881,8 +881,8 @@ public func drawYOLOPoseWithBoxes(
 
   // 2. Calculate drawing sizes based on configuration
   let circleRadius = max(width, height) / 100
-  let lineWidth = config.lineWidth ?? max(width, height) / 200
-  let fontSize = config.fontSize ?? max(width, height) / 50
+  let lineWidth = config.lineWidth ?? CGFloat(max(width, height)) / 200
+  let fontSize = config.fontSize ?? CGFloat(max(width, height)) / 50
 
   // 3. Create a single rendering context
   UIGraphicsBeginImageContextWithOptions(renderedSize, false, 0.0)
@@ -999,8 +999,8 @@ public func drawYOLOSegmentationWithBoxes(
   let renderedSize = CGSize(width: width, height: height)
 
   // 2. Calculate drawing sizes based on configuration
-  let lineWidth = config.lineWidth ?? max(width, height) / 200
-  let fontSize = config.fontSize ?? max(width, height) / 50
+  let lineWidth = config.lineWidth ?? CGFloat(max(width, height)) / 200
+  let fontSize = config.fontSize ?? CGFloat(max(width, height)) / 50
 
   // 3. Create a single rendering context
   UIGraphicsBeginImageContextWithOptions(renderedSize, false, 0.0)

--- a/Sources/YOLO/Plot.swift
+++ b/Sources/YOLO/Plot.swift
@@ -50,18 +50,22 @@ public struct AnnotationConfig {
   public let lineWidth: CGFloat?
   /// Font weight for annotation labels
   public let fontWeight: UIFont.Weight
-  
-  public init(fontSize: CGFloat? = nil, lineWidth: CGFloat? = nil, fontWeight: UIFont.Weight = .semibold) {
+
+  public init(
+    fontSize: CGFloat? = nil, lineWidth: CGFloat? = nil, fontWeight: UIFont.Weight = .semibold
+  ) {
     self.fontSize = fontSize
     self.lineWidth = lineWidth
     self.fontWeight = fontWeight
   }
-  
+
   /// Default configuration with automatic scaling
   public static let `default` = AnnotationConfig()
-  
+
   /// Configuration with custom font size
-  public static func custom(fontSize: CGFloat, fontWeight: UIFont.Weight = .semibold) -> AnnotationConfig {
+  public static func custom(fontSize: CGFloat, fontWeight: UIFont.Weight = .semibold)
+    -> AnnotationConfig
+  {
     return AnnotationConfig(fontSize: fontSize, fontWeight: fontWeight)
   }
 }
@@ -114,7 +118,9 @@ let skeleton = [
   [5, 7],
 ]
 
-public func drawYOLODetections(on ciImage: CIImage, result: YOLOResult, config: AnnotationConfig = .default) -> UIImage {
+public func drawYOLODetections(
+  on ciImage: CIImage, result: YOLOResult, config: AnnotationConfig = .default
+) -> UIImage {
   let context = CIContext(options: nil)
   guard let cgImage = context.createCGImage(ciImage, from: ciImage.extent) else {
     return UIImage()
@@ -375,7 +381,9 @@ func composeImageWithMask(
   return UIImage(cgImage: composedImage)
 }
 
-public func drawYOLOClassifications(on ciImage: CIImage, result: YOLOResult, config: AnnotationConfig = .default) -> UIImage {
+public func drawYOLOClassifications(
+  on ciImage: CIImage, result: YOLOResult, config: AnnotationConfig = .default
+) -> UIImage {
   let context = CIContext(options: nil)
   guard let cgImage = context.createCGImage(ciImage, from: ciImage.extent) else {
     return UIImage()
@@ -1104,8 +1112,8 @@ public func drawYOLOSegmentationWithBoxes(
 
 /// Draw YOLO detections with custom font size
 public func drawYOLODetections(
-  on ciImage: CIImage, 
-  result: YOLOResult, 
+  on ciImage: CIImage,
+  result: YOLOResult,
   fontSize: CGFloat
 ) -> UIImage {
   let config = AnnotationConfig.custom(fontSize: fontSize)
@@ -1114,8 +1122,8 @@ public func drawYOLODetections(
 
 /// Draw YOLO classifications with custom font size
 public func drawYOLOClassifications(
-  on ciImage: CIImage, 
-  result: YOLOResult, 
+  on ciImage: CIImage,
+  result: YOLOResult,
   fontSize: CGFloat
 ) -> UIImage {
   let config = AnnotationConfig.custom(fontSize: fontSize)

--- a/Sources/YOLO/YOLOView.swift
+++ b/Sources/YOLO/YOLOView.swift
@@ -122,7 +122,7 @@ public class YOLOView: UIView, VideoCaptureDelegate {
   public var activityIndicator = UIActivityIndicatorView()
   public var playButton = UIButton()
   public var pauseButton = UIButton()
-  
+
   // Font size configuration
   public var annotationConfig: AnnotationConfig = .default
   public var switchCameraButton = UIButton()
@@ -402,15 +402,15 @@ public class YOLOView: UIView, VideoCaptureDelegate {
   /// Gets the current IoU threshold.
   /// - Returns: The current IoU threshold value.
   public func getIouThreshold() -> Double { Double(sliderIoU.value) }
-  
+
   /// Updates the annotation configuration for font size and line width
   public func setAnnotationConfig(_ config: AnnotationConfig) {
     annotationConfig = config
-    
+
     // Check if this is likely an external display
     let viewBounds = self.bounds
     let maxDimension = max(viewBounds.width, viewBounds.height)
-    
+
     // Update existing bounding box views with new font size
     for boxView in boundingBoxViews {
       if maxDimension > 1000 {
@@ -464,7 +464,7 @@ public class YOLOView: UIView, VideoCaptureDelegate {
         // Use annotation config for font size and line width on regular displays
         let fontSize = annotationConfig.fontSize ?? 14.0
         let lineWidth = annotationConfig.lineWidth ?? 4.0
-        
+
         boxView.setFontSize(fontSize)
         boxView.setLineWidth(lineWidth)
       }

--- a/YOLOiOSApp/YOLOiOSApp/ExternalDisplay/NotificationExtensions.swift
+++ b/YOLOiOSApp/YOLOiOSApp/ExternalDisplay/NotificationExtensions.swift
@@ -13,4 +13,5 @@ extension Notification.Name {
   static let thresholdDidChange = Notification.Name("ThresholdDidChange")
   static let taskDidChange = Notification.Name("TaskDidChange")
   static let detectionCountDidUpdate = Notification.Name("DetectionCountDidUpdate")
+  static let fontSizeDidChange = Notification.Name("FontSizeDidChange")
 }

--- a/YOLOiOSApp/YOLOiOSApp/Info.plist
+++ b/YOLOiOSApp/YOLOiOSApp/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>534</string>
+	<string>535</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/YOLOiOSApp/YOLOiOSApp/ViewController.swift
+++ b/YOLOiOSApp/YOLOiOSApp/ViewController.swift
@@ -60,7 +60,7 @@ class ViewController: UIViewController, YOLOViewDelegate {
   @IBOutlet weak var labelVersion: UILabel!
   @IBOutlet weak var activityIndicator: UIActivityIndicatorView!
   @IBOutlet weak var logoImage: UIImageView!
-  
+
   // Font size controls
   private var fontSizeSlider: UISlider!
   private var fontSizeLabel: UILabel!
@@ -78,7 +78,7 @@ class ViewController: UIViewController, YOLOViewDelegate {
   private let downloadProgressLabel = UILabel()
 
   private var loadingOverlayView: UIView?
-  
+
   // Font size configuration
   private var currentFontSize: CGFloat = 16.0
   private var annotationConfig: AnnotationConfig {
@@ -193,7 +193,7 @@ class ViewController: UIViewController, YOLOViewDelegate {
     yoloView.sliderIoU.addTarget(self, action: #selector(sliderValueChanged), for: .valueChanged)
     yoloView.sliderNumItems.addTarget(
       self, action: #selector(sliderValueChanged), for: .valueChanged)
-    
+
     // Setup font size controls
     setupFontSizeControls()
 
@@ -723,37 +723,37 @@ class ViewController: UIViewController, YOLOViewDelegate {
 
     print("📊 Threshold changed - Conf: \(conf), IoU: \(iou), Max items: \(maxItems)")
   }
-  
+
   @objc func fontSizeSliderChanged(_ sender: UISlider) {
     currentFontSize = CGFloat(sender.value)
     fontSizeValueLabel.text = String(format: "%.0f", currentFontSize)
-    
+
     // Update YOLOView with new annotation config
     yoloView.setAnnotationConfig(annotationConfig)
-    
+
     // Notify external display of font size change (Optional external display feature)
     NotificationCenter.default.post(
       name: .fontSizeDidChange,
       object: nil,
       userInfo: ["fontSize": currentFontSize]
     )
-    
+
     print("🔤 Font size changed to: \(currentFontSize)")
   }
-  
+
   /// Test method to demonstrate font size functionality
   private func testFontSizeFunctionality() {
     print("🧪 Testing font size functionality...")
-    
+
     // Test different font sizes
     let testSizes: [CGFloat] = [12, 16, 20, 24, 32]
-    
+
     for size in testSizes {
       let config = AnnotationConfig.custom(fontSize: size)
       yoloView.setAnnotationConfig(config)
       print("✅ Set font size to \(size)")
     }
-    
+
     // Reset to default
     yoloView.setAnnotationConfig(.default)
     print("✅ Reset to default font size")
@@ -770,40 +770,41 @@ class ViewController: UIViewController, YOLOViewDelegate {
     fontSizeSlider.maximumValue = 48.0
     fontSizeSlider.value = Float(currentFontSize)
     fontSizeSlider.addTarget(self, action: #selector(fontSizeSliderChanged), for: .valueChanged)
-    
+
     // Create labels
     fontSizeLabel = UILabel()
     fontSizeLabel.text = "Font Size"
     fontSizeLabel.textColor = .white
     fontSizeLabel.font = UIFont.systemFont(ofSize: 14)
-    
+
     fontSizeValueLabel = UILabel()
     fontSizeValueLabel.text = String(format: "%.0f", currentFontSize)
     fontSizeValueLabel.textColor = .white
     fontSizeValueLabel.font = UIFont.systemFont(ofSize: 12)
     fontSizeValueLabel.textAlignment = .center
-    
+
     // Add to view hierarchy
     [fontSizeSlider, fontSizeLabel, fontSizeValueLabel].forEach {
       $0?.translatesAutoresizingMaskIntoConstraints = false
       view.addSubview($0!)
     }
-    
+
     // Setup constraints
     NSLayoutConstraint.activate([
       // Font size label
       fontSizeLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
       fontSizeLabel.topAnchor.constraint(equalTo: modelSegmentedControl.bottomAnchor, constant: 20),
-      
+
       // Font size slider
       fontSizeSlider.leadingAnchor.constraint(equalTo: fontSizeLabel.trailingAnchor, constant: 10),
       fontSizeSlider.centerYAnchor.constraint(equalTo: fontSizeLabel.centerYAnchor),
       fontSizeSlider.widthAnchor.constraint(equalToConstant: 150),
-      
+
       // Font size value label
-      fontSizeValueLabel.leadingAnchor.constraint(equalTo: fontSizeSlider.trailingAnchor, constant: 10),
+      fontSizeValueLabel.leadingAnchor.constraint(
+        equalTo: fontSizeSlider.trailingAnchor, constant: 10),
       fontSizeValueLabel.centerYAnchor.constraint(equalTo: fontSizeLabel.centerYAnchor),
-      fontSizeValueLabel.widthAnchor.constraint(equalToConstant: 30)
+      fontSizeValueLabel.widthAnchor.constraint(equalToConstant: 30),
     ])
   }
 

--- a/YOLOiOSApp/YOLOiOSApp/ViewController.swift
+++ b/YOLOiOSApp/YOLOiOSApp/ViewController.swift
@@ -60,6 +60,11 @@ class ViewController: UIViewController, YOLOViewDelegate {
   @IBOutlet weak var labelVersion: UILabel!
   @IBOutlet weak var activityIndicator: UIActivityIndicatorView!
   @IBOutlet weak var logoImage: UIImageView!
+  
+  // Font size controls
+  private var fontSizeSlider: UISlider!
+  private var fontSizeLabel: UILabel!
+  private var fontSizeValueLabel: UILabel!
 
   let selection = UISelectionFeedbackGenerator()
 
@@ -73,6 +78,12 @@ class ViewController: UIViewController, YOLOViewDelegate {
   private let downloadProgressLabel = UILabel()
 
   private var loadingOverlayView: UIView?
+  
+  // Font size configuration
+  private var currentFontSize: CGFloat = 16.0
+  private var annotationConfig: AnnotationConfig {
+    return AnnotationConfig.custom(fontSize: currentFontSize)
+  }
 
   // MARK: - Constants
   private struct Constants {
@@ -182,6 +193,9 @@ class ViewController: UIViewController, YOLOViewDelegate {
     yoloView.sliderIoU.addTarget(self, action: #selector(sliderValueChanged), for: .valueChanged)
     yoloView.sliderNumItems.addTarget(
       self, action: #selector(sliderValueChanged), for: .valueChanged)
+    
+    // Setup font size controls
+    setupFontSizeControls()
 
     // Setup labels and version
     [labelName, labelFPS, labelVersion].forEach {
@@ -709,9 +723,88 @@ class ViewController: UIViewController, YOLOViewDelegate {
 
     print("📊 Threshold changed - Conf: \(conf), IoU: \(iou), Max items: \(maxItems)")
   }
+  
+  @objc func fontSizeSliderChanged(_ sender: UISlider) {
+    currentFontSize = CGFloat(sender.value)
+    fontSizeValueLabel.text = String(format: "%.0f", currentFontSize)
+    
+    // Update YOLOView with new annotation config
+    yoloView.setAnnotationConfig(annotationConfig)
+    
+    // Notify external display of font size change (Optional external display feature)
+    NotificationCenter.default.post(
+      name: .fontSizeDidChange,
+      object: nil,
+      userInfo: ["fontSize": currentFontSize]
+    )
+    
+    print("🔤 Font size changed to: \(currentFontSize)")
+  }
+  
+  /// Test method to demonstrate font size functionality
+  private func testFontSizeFunctionality() {
+    print("🧪 Testing font size functionality...")
+    
+    // Test different font sizes
+    let testSizes: [CGFloat] = [12, 16, 20, 24, 32]
+    
+    for size in testSizes {
+      let config = AnnotationConfig.custom(fontSize: size)
+      yoloView.setAnnotationConfig(config)
+      print("✅ Set font size to \(size)")
+    }
+    
+    // Reset to default
+    yoloView.setAnnotationConfig(.default)
+    print("✅ Reset to default font size")
+  }
 
   deinit {
     NotificationCenter.default.removeObserver(self)
+  }
+
+  private func setupFontSizeControls() {
+    // Create font size slider
+    fontSizeSlider = UISlider()
+    fontSizeSlider.minimumValue = 8.0
+    fontSizeSlider.maximumValue = 48.0
+    fontSizeSlider.value = Float(currentFontSize)
+    fontSizeSlider.addTarget(self, action: #selector(fontSizeSliderChanged), for: .valueChanged)
+    
+    // Create labels
+    fontSizeLabel = UILabel()
+    fontSizeLabel.text = "Font Size"
+    fontSizeLabel.textColor = .white
+    fontSizeLabel.font = UIFont.systemFont(ofSize: 14)
+    
+    fontSizeValueLabel = UILabel()
+    fontSizeValueLabel.text = String(format: "%.0f", currentFontSize)
+    fontSizeValueLabel.textColor = .white
+    fontSizeValueLabel.font = UIFont.systemFont(ofSize: 12)
+    fontSizeValueLabel.textAlignment = .center
+    
+    // Add to view hierarchy
+    [fontSizeSlider, fontSizeLabel, fontSizeValueLabel].forEach {
+      $0?.translatesAutoresizingMaskIntoConstraints = false
+      view.addSubview($0!)
+    }
+    
+    // Setup constraints
+    NSLayoutConstraint.activate([
+      // Font size label
+      fontSizeLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+      fontSizeLabel.topAnchor.constraint(equalTo: modelSegmentedControl.bottomAnchor, constant: 20),
+      
+      // Font size slider
+      fontSizeSlider.leadingAnchor.constraint(equalTo: fontSizeLabel.trailingAnchor, constant: 10),
+      fontSizeSlider.centerYAnchor.constraint(equalTo: fontSizeLabel.centerYAnchor),
+      fontSizeSlider.widthAnchor.constraint(equalToConstant: 150),
+      
+      // Font size value label
+      fontSizeValueLabel.leadingAnchor.constraint(equalTo: fontSizeSlider.trailingAnchor, constant: 10),
+      fontSizeValueLabel.centerYAnchor.constraint(equalTo: fontSizeLabel.centerYAnchor),
+      fontSizeValueLabel.widthAnchor.constraint(equalToConstant: 30)
+    ])
   }
 
   private func debugCheckModelFolders() {


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds a centralized `AnnotationConfig` and UI controls to customize annotation font size/line width across the YOLO iOS app for clearer, more adaptable overlays 🔤📦

### 📊 Key Changes
- Introduced `AnnotationConfig` (font size, line width, font weight) to control how labels/boxes are rendered 🎛️
- Updated all major rendering paths in `Plot.swift` to accept `config: AnnotationConfig = .default`:
  - detections, classifications, pose, segmentation, and OBB rendering 🖼️
- Added convenience overloads to draw with just `fontSize` (wrapping into `AnnotationConfig`) for simpler call sites 🧩
- Enhanced `YOLOView` with:
  - `annotationConfig` property
  - `setAnnotationConfig(_:)` to update existing bounding boxes and handle “external display” scaling automatically 🖥️
- Added a new notification `fontSizeDidChange` for optional external display syncing 📢
- Added a font size slider + labels in `ViewController` to let users adjust annotation text size at runtime 🎚️
  - Updates `YOLOView` live and broadcasts the change via `NotificationCenter`

### 🎯 Purpose & Impact
- Improves readability of labels and overlays, especially on large screens/external displays 🖥️👀
- Gives developers and users consistent, app-wide control over annotation styling instead of fixed auto-scaling 🎨
- Reduces duplication and makes future styling tweaks easier by routing sizing/weight decisions through one config object 🧱
- Potential impact: minor API surface change (new optional `config` parameters) but remains backward-friendly due to defaults (`.default`) ✅