### PR TITLE
fix: publish on main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,17 +13,12 @@ on:
   workflow_dispatch:
     inputs:
       source_branch:
-        description: "Branch to publish"
+        description: "Branch to build from (releases only created from main)"
         required: true
         default: "main"
         type: string
-      release:
-        description: "Create new tag and release"
-        required: true
-        type: boolean
-        default: false
       testflight:
-        description: "Publish to TestFlight"
+        description: "Build and push to TestFlight"
         required: true
         type: boolean
         default: true
@@ -83,7 +78,7 @@ jobs:
 
   release:
     needs: check
-    if: needs.check.outputs.new_version == 'true' && (github.event_name == 'push' || inputs.release == true)
+    if: needs.check.outputs.new_version == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -116,7 +111,7 @@ jobs:
 
   testflight:
     needs: check
-    if: github.event_name == 'pull_request' || inputs.testflight == true
+    if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.testflight == true)
     runs-on: macos-26
     permissions:
       contents: write


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Tightens the iOS app’s release workflow: releases now only cut from main on version bumps, while TestFlight builds are clearer and safer to trigger. 🚀

### 📊 Key Changes
- Removes the manual `release` input; releases can’t be toggled via workflow_dispatch anymore.
- Clarifies the `source_branch` input: used only to build; releases are created from main.
- Updates descriptions for clearer intent (e.g., “Build and push to TestFlight”).
- Release job condition tightened: runs only on push events to `main` and when a new version is detected.
- TestFlight job condition refined: runs on pull requests, or on manual runs only if `testflight` is true.

### 🎯 Purpose & Impact
- Prevents accidental releases from non-main branches or manual triggers ✅
- Enforces a clean, predictable release policy tied to version bumps on `main` 🔒
- Gives contributors a safe path to TestFlight builds via PRs or explicit manual opt-in 🧪
- Reduces confusion in CI by removing ambiguous inputs and clarifying workflow behavior 🧭
- Improves reliability and consistency of App Store/TestFlight delivery for users 📦