### PR TITLE
Fix typo in print message in getModelInputSize

### DIFF
--- a/Sources/YOLO/BasePredictor.swift
+++ b/Sources/YOLO/BasePredictor.swift
@@ -331,7 +331,7 @@ public class BasePredictor: Predictor, @unchecked Sendable {
       return (width: width, height: height)
     }
 
-    print("cannot find input size")
+    print("Cannot find input size")
     return (0, 0)
   }
 }


### PR DESCRIPTION
I got this message with the default model and example [HERE](https://github.com/ultralytics/yolo-ios-app/blob/f43e8edf97b5c8d665b3872af66de050c8a8f905/ExampleApps/YOLOSingleImageSwiftUI/YOLOSingleImageSwiftUI/ContentView.swift#L24). Seems to work fine even though the message says model input size can't be determined. Weird.

Anyways, this PR just fixed the typo.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Fixes a typo in a log message within BasePredictor.getModelInputSize to improve clarity 🧹📝

### 📊 Key Changes
- Corrected print message from "an not find input size" to "can not find input size" in Sources/YOLO/BasePredictor.swift

### 🎯 Purpose & Impact
- Improves developer experience by providing clearer logging output
- No functional or behavioral changes to the app
- Aids debugging by making log intent unambiguous