### PR TITLE
Expose YOLO load readiness and preserve UIImage orientation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: false
       - run: uv pip install --system --no-cache ultralytics-actions
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: false
       - run: uv pip install --system --no-cache ultralytics-actions

--- a/Sources/YOLO/UIImage+Orientation.swift
+++ b/Sources/YOLO/UIImage+Orientation.swift
@@ -1,0 +1,47 @@
+// Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+//  This file is part of the Ultralytics YOLO Package, providing image-orientation utilities.
+//  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
+//  Access the source code: https://github.com/ultralytics/yolo-ios-app
+
+import CoreImage
+import ImageIO
+import UIKit
+
+extension CGImagePropertyOrientation {
+  /// Maps a `UIImage.Orientation` to its equivalent `CGImagePropertyOrientation`.
+  ///
+  /// The two enums use different raw values and need an explicit mapping.
+  public init(_ uiOrientation: UIImage.Orientation) {
+    switch uiOrientation {
+    case .up: self = .up
+    case .down: self = .down
+    case .left: self = .left
+    case .right: self = .right
+    case .upMirrored: self = .upMirrored
+    case .downMirrored: self = .downMirrored
+    case .leftMirrored: self = .leftMirrored
+    case .rightMirrored: self = .rightMirrored
+    @unknown default: self = .up
+    }
+  }
+}
+
+extension UIImage {
+  /// Returns an upright copy of this image with `imageOrientation == .up`.
+  ///
+  /// Photos from the camera roll and camera API often carry a non-`.up` `imageOrientation`
+  /// (for example `.right` for a portrait photo from the rear camera). `CIImage(image:)` and
+  /// many Core Graphics APIs ignore that metadata, so inference would run against the raw,
+  /// rotated pixels. Call this to normalize the image before handing it off to CV pipelines.
+  ///
+  /// - Returns: A new `UIImage` whose pixels are visually upright, or `self` when already upright.
+  public func uprightForYOLO() -> UIImage {
+    guard imageOrientation != .up else { return self }
+    let format = UIGraphicsImageRendererFormat.default()
+    format.scale = scale
+    return UIGraphicsImageRenderer(size: size, format: format).image { _ in
+      draw(at: .zero)
+    }
+  }
+}

--- a/Sources/YOLO/YOLO.swift
+++ b/Sources/YOLO/YOLO.swift
@@ -16,6 +16,10 @@ import SwiftUI
 import UIKit
 
 /// The primary interface for working with YOLO models, supporting multiple input types and inference methods.
+///
+/// Model loading is asynchronous. Calling a `callAsFunction` overload before the init completion
+/// handler has fired returns an empty `YOLOResult`. Use `isLoaded` to check readiness, or perform
+/// inference from inside the completion handler.
 public final class YOLO: @unchecked Sendable {
   var predictor: Predictor?
   private var modelDownloader: YOLOModelDownloader?
@@ -23,6 +27,14 @@ public final class YOLO: @unchecked Sendable {
   private var pendingNumItems: Int?
   private var pendingConfidence: Double?
   private var pendingIou: Double?
+
+  /// Whether the model has finished loading and is ready to run inference.
+  ///
+  /// `false` while the model is still compiling/loading (or if loading failed).
+  /// `true` once the completion handler passed to `init` has fired with `.success`.
+  public var isLoaded: Bool {
+    (predictor as? BasePredictor)?.isModelLoaded ?? false
+  }
 
   /// Initialize YOLO with remote URL for automatic download and caching
   public init(url: URL, task: YOLOTask, completion: @escaping (Result<YOLO, Error>) -> Void) {
@@ -177,10 +189,24 @@ public final class YOLO: @unchecked Sendable {
   }
 
   public func callAsFunction(_ uiImage: UIImage) -> YOLOResult {
-    guard let ciImage = CIImage(image: uiImage) else {
+    // CIImage(image:) drops UIImage.imageOrientation, so non-`.up` photos (e.g. portrait
+    // shots with orientation = .right) would otherwise be inferred against raw, rotated
+    // pixels. Build the CIImage from the backing CGImage and re-apply the orientation.
+    guard let cgImage = uiImage.cgImage else {
+      let uprightImage = uiImage.uprightForYOLO()
+      if let cgImage = uprightImage.cgImage {
+        return run(CIImage(cgImage: cgImage))
+      }
+      if let ciImage = uprightImage.ciImage {
+        return run(ciImage)
+      }
+      if let ciImage = CIImage(image: uprightImage) {
+        return run(ciImage)
+      }
       return YOLOResult(orig_shape: .zero, boxes: [], speed: 0, names: [])
     }
-    return run(ciImage)
+    let orientation = CGImagePropertyOrientation(uiImage.imageOrientation)
+    return run(CIImage(cgImage: cgImage).oriented(orientation))
   }
 
   public func callAsFunction(_ ciImage: CIImage) -> YOLOResult {

--- a/Sources/YOLO/YOLOModelDownloader.swift
+++ b/Sources/YOLO/YOLOModelDownloader.swift
@@ -194,7 +194,10 @@ public final class YOLOModelDownloader: NSObject {
 
   /// Extract ZIP file while skipping macOS metadata
   private func unzipSkippingMacOSX(at sourceURL: URL, to destinationURL: URL) throws {
-    guard let archive = try? Archive(url: sourceURL, accessMode: .read) else {
+    let archive: Archive
+    do {
+      archive = try Archive(url: sourceURL, accessMode: .read)
+    } catch {
       throw DownloadError.invalidZipFile
     }
 

--- a/Tests/YOLOTests/UIImageOrientationTests.swift
+++ b/Tests/YOLOTests/UIImageOrientationTests.swift
@@ -1,0 +1,26 @@
+// Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+import CoreImage
+import UIKit
+import XCTest
+
+@testable import YOLO
+
+final class UIImageOrientationTests: XCTestCase {
+
+  func testUprightForYOLONormalizesCIImageBackedOrientation() {
+    let source = UIImage(
+      ciImage: CIImage(color: .red).cropped(to: CGRect(x: 0, y: 0, width: 40, height: 20)),
+      scale: 1,
+      orientation: .right
+    )
+
+    XCTAssertNil(source.cgImage)
+    XCTAssertEqual(source.imageOrientation, .right)
+
+    let normalized = source.uprightForYOLO()
+
+    XCTAssertEqual(normalized.imageOrientation, .up)
+    XCTAssertNotNil(normalized.cgImage)
+  }
+}


### PR DESCRIPTION
## Summary
- add public `YOLO.isLoaded` and class-level docs so callers can gate inference until async model loading completes (#202, #214, #137, #163)
- preserve `UIImage.imageOrientation` in `YOLO.callAsFunction(_:)` and add `UIImage.uprightForYOLO()` for callers that want to normalize images at other boundaries (#203)
- replace the deprecated ZIPFoundation archive initializer in `YOLOModelDownloader`
- add a focused test for CIImage-backed `UIImage` normalization

## Review Follow-up
- tightened the `cgImage == nil` fallback during review so CIImage-backed `UIImage` instances are normalized before inference instead of falling back to the orientation-dropping `CIImage(image:)` path

## Validation
- reviewed the staged diff for API and behavior regressions
- attempted local Xcode/SwiftPM validation; `xcodebuild` could not target iOS from this machine because the iOS 26.4 platform component is not installed, and `swift build/test` is currently blocked by duplicate resource basenames already present under `Tests/YOLOTests/Resources`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR improves image orientation handling in the iOS YOLO app, adds a model readiness check, strengthens ZIP error handling, and makes a small GitHub Actions compatibility update.

### 📊 Key Changes
- 📸 Added `UIImage` orientation utilities in `UIImage+Orientation.swift` to normalize images before inference.
- 🔄 Updated `YOLO.callAsFunction(_ uiImage: UIImage)` so predictions use correctly oriented image data instead of potentially rotated raw pixels.
- ✅ Added a new public `isLoaded` property to `YOLO` so apps can check whether the model is ready before running inference.
- 📝 Expanded `YOLO` documentation to clarify that model loading is asynchronous and that early inference calls return an empty result.
- 🧪 Added `UIImageOrientationTests.swift` to verify that orientation normalization works correctly, especially for `CIImage`-backed `UIImage` inputs.
- 🧱 Improved ZIP extraction error handling in `YOLOModelDownloader` by making invalid archive failures more explicit.
- ⚙️ Changed the GitHub Actions workflow from `astral-sh/setup-uv@v8` to `@v7` in the publish pipeline.

### 🎯 Purpose & Impact
- 🎯 Fixes a real-world inference issue where photos taken in portrait or with stored orientation metadata could be analyzed incorrectly.
- 📱 Makes iOS predictions more reliable for camera roll and camera-captured images, improving detection accuracy and user trust.
- 🚦 Gives developers a clearer way to avoid calling inference before the model has finished loading.
- 🛡️ Improves robustness around downloaded model ZIP handling, reducing unclear failures during model setup.
- 🔁 The workflow change likely helps maintain CI/CD stability or compatibility during publishing.