### PR TITLE
Fix redirected URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Welcome to the [Ultralytics YOLO](https://github.com/ultralytics/ultralytics) iO
   <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
   <a href="https://twitter.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-twitter.png" width="3%" alt="Ultralytics Twitter"></a>
   <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
-  <a href="https://youtube.com/ultralytics?sub_confirmation=1"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-youtube.png" width="3%" alt="Ultralytics YouTube"></a>
+  <a href="https://www.youtube.com/ultralytics?sub_confirmation=1"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-youtube.png" width="3%" alt="Ultralytics YouTube"></a>
   <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
   <a href="https://www.tiktok.com/@ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-tiktok.png" width="3%" alt="Ultralytics TikTok"></a>
   <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
@@ -141,7 +141,7 @@ We warmly welcome contributions to our open-source projects! Your support helps 
 
 Ultralytics provides two licensing options to accommodate diverse use cases:
 
-- **AGPL-3.0 License**: An [OSI-approved](https://opensource.org/license/agpl-v3) open-source license ideal for academic research, personal projects, and experimentation. It promotes open collaboration and knowledge sharing. See the [LICENSE](https://github.com/ultralytics/yolo-ios-app/blob/main/LICENSE) file and the full [AGPL-3.0 license text](https://www.gnu.org/licenses/agpl-3.0.en.html) for details.
+- **AGPL-3.0 License**: An [OSI-approved](https://opensource.org/license/agpl-3.0) open-source license ideal for academic research, personal projects, and experimentation. It promotes open collaboration and knowledge sharing. See the [LICENSE](https://github.com/ultralytics/yolo-ios-app/blob/main/LICENSE) file and the full [AGPL-3.0 license text](https://www.gnu.org/licenses/agpl-3.0.en.html) for details.
 - **Enterprise License**: Tailored for commercial applications, this license allows the integration of Ultralytics software and AI models into commercial products and services without the open-source requirements of AGPL-3.0. If your scenario involves commercial use, please contact us via [Ultralytics Licensing](https://www.ultralytics.com/license).
 
 ## 🤝 Contact
@@ -157,7 +157,7 @@ Ultralytics provides two licensing options to accommodate diverse use cases:
   <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
   <a href="https://twitter.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-twitter.png" width="3%" alt="Ultralytics Twitter"></a>
   <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
-  <a href="https://youtube.com/ultralytics?sub_confirmation=1"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-youtube.png" width="3%" alt="Ultralytics YouTube"></a>
+  <a href="https://www.youtube.com/ultralytics?sub_confirmation=1"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-youtube.png" width="3%" alt="Ultralytics YouTube"></a>
   <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
   <a href="https://www.tiktok.com/@ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-tiktok.png" width="3%" alt="Ultralytics TikTok"></a>
   <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -25,7 +25,7 @@
   <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
   <a href="https://twitter.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-twitter.png" width="3%" alt="Ultralytics Twitter"></a>
   <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
-  <a href="https://youtube.com/ultralytics?sub_confirmation=1"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-youtube.png" width="3%" alt="Ultralytics YouTube"></a>
+  <a href="https://www.youtube.com/ultralytics?sub_confirmation=1"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-youtube.png" width="3%" alt="Ultralytics YouTube"></a>
   <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
   <a href="https://www.tiktok.com/@ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-tiktok.png" width="3%" alt="Ultralytics TikTok"></a>
   <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
@@ -141,7 +141,7 @@ var body: some View {
 
 Ultralytics 提供两种许可证选项，以适配不同的使用场景：
 
-- **AGPL-3.0 License**：这是一个经 [OSI 批准](https://opensource.org/license/agpl-v3)的开源许可证，适用于学术研究、个人项目和实验用途。它鼓励开放协作与知识共享。详情请参阅 [LICENSE](https://github.com/ultralytics/yolo-ios-app/blob/main/LICENSE) 文件以及完整的 [AGPL-3.0 许可证文本](https://www.gnu.org/licenses/agpl-3.0.en.html)。
+- **AGPL-3.0 License**：这是一个经 [OSI 批准](https://opensource.org/license/agpl-3.0)的开源许可证，适用于学术研究、个人项目和实验用途。它鼓励开放协作与知识共享。详情请参阅 [LICENSE](https://github.com/ultralytics/yolo-ios-app/blob/main/LICENSE) 文件以及完整的 [AGPL-3.0 许可证文本](https://www.gnu.org/licenses/agpl-3.0.en.html)。
 - **Enterprise License**：面向商业应用场景，允许将 Ultralytics 软件和 AI 模型集成到商业产品与服务中，而无需遵循 AGPL-3.0 的开源要求。如果你的场景涉及商业用途，请通过 [Ultralytics Licensing](https://www.ultralytics.com/license) 与我们联系。
 
 ## 🤝 联系我们
@@ -157,7 +157,7 @@ Ultralytics 提供两种许可证选项，以适配不同的使用场景：
   <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
   <a href="https://twitter.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-twitter.png" width="3%" alt="Ultralytics Twitter"></a>
   <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
-  <a href="https://youtube.com/ultralytics?sub_confirmation=1"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-youtube.png" width="3%" alt="Ultralytics YouTube"></a>
+  <a href="https://www.youtube.com/ultralytics?sub_confirmation=1"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-youtube.png" width="3%" alt="Ultralytics YouTube"></a>
   <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
   <a href="https://www.tiktok.com/@ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-tiktok.png" width="3%" alt="Ultralytics TikTok"></a>
   <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">

--- a/Sources/YOLO/README.md
+++ b/Sources/YOLO/README.md
@@ -294,4 +294,4 @@ Contributions are welcome! Whether it's bug reports, feature requests, or code c
 
 ## 📜 License
 
-This project is licensed under the [AGPL-3.0 License](https://opensource.org/license/agpl-v3). See the [LICENSE](https://github.com/ultralytics/yolo-ios-app/blob/main/LICENSE) file for details. For alternative licensing options, please visit [Ultralytics Licensing](https://www.ultralytics.com/license).
+This project is licensed under the [AGPL-3.0 License](https://opensource.org/license/agpl-3.0). See the [LICENSE](https://github.com/ultralytics/yolo-ios-app/blob/main/LICENSE) file for details. For alternative licensing options, please visit [Ultralytics Licensing](https://www.ultralytics.com/license).

--- a/Tests/YOLOTests/README.md
+++ b/Tests/YOLOTests/README.md
@@ -120,7 +120,7 @@ If you receive an error message indicating that a model file could not be found:
 If tests fail or you encounter other problems:
 
 1.  **Xcode Version:** Ensure your installed Xcode version supports Swift 5.10 and an iOS 16 simulator runtime.
-2.  **iOS Target:** The package requires [iOS](https://www.apple.com/ios/ios-18/) 16.0 or later. Make sure your testing environment (simulator or device) meets this requirement.
+2.  **iOS Target:** The package requires [iOS](https://www.apple.com/os/ios/) 16.0 or later. Make sure your testing environment (simulator or device) meets this requirement.
 3.  **Framework Availability:** Confirm that the [Core ML](https://developer.apple.com/documentation/coreml) and [Vision frameworks](https://developer.apple.com/documentation/vision) are available and correctly linked in your build settings.
 4.  **Consult Logs:** Examine the detailed test logs in Xcode or the terminal output for specific error messages that can help pinpoint the issue.
 5.  **Check Ultralytics Docs:** Refer to the [Ultralytics documentation](https://docs.ultralytics.com/) or the [FAQ section](https://docs.ultralytics.com/help/FAQ/) for potential solutions and common issues. You might also find relevant discussions on the [Ultralytics Community Forums](https://community.ultralytics.com/).

--- a/YOLOiOSApp/README.md
+++ b/YOLOiOSApp/README.md
@@ -20,7 +20,7 @@ The Ultralytics YOLO iOS App makes it easy to experience the power of [Ultralyti
   <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
   <a href="https://twitter.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-twitter.png" width="3%" alt="Ultralytics Twitter"></a>
   <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
-  <a href="https://youtube.com/ultralytics?sub_confirmation=1"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-youtube.png" width="3%" alt="Ultralytics YouTube"></a>
+  <a href="https://www.youtube.com/ultralytics?sub_confirmation=1"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-youtube.png" width="3%" alt="Ultralytics YouTube"></a>
   <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
   <a href="https://www.tiktok.com/@ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-tiktok.png" width="3%" alt="Ultralytics TikTok"></a>
   <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
@@ -42,7 +42,7 @@ Getting started with the Ultralytics YOLO iOS App is straightforward. Follow the
 Ensure you have the following before you begin:
 
 - **Xcode:** The app requires [Xcode](https://developer.apple.com/xcode/) installed on your macOS machine. You can download it from the [Mac App Store](https://apps.apple.com/us/app/xcode/id497799835).
-- **iOS Device:** An iPhone or iPad running [iOS 16.0](https://support.apple.com/guide/iphone/iphone-models-compatible-with-ios-18-iphe3fa5df43/ios) or later is needed for testing.
+- **iOS Device:** An iPhone or iPad running [iOS 16.0](https://support.apple.com/guide/iphone/iphone-models-compatible-with-ios-26-iphe3fa5df43/ios) or later is needed for testing.
 - **Apple Developer Account:** A free [Apple Developer account](https://developer.apple.com/programs/enroll/) is sufficient for testing on your device.
 
 ### Installation
@@ -178,7 +178,7 @@ Contributions power the open-source community! We welcome your involvement in im
 
 Ultralytics provides two licensing options to accommodate different use cases:
 
-- **AGPL-3.0 License:** Ideal for students, researchers, and enthusiasts who want to experiment, learn, and share their work openly. This [OSI-approved](https://opensource.org/license/agpl-v3) license promotes collaboration and knowledge sharing within the open-source community. See the [LICENSE](https://github.com/ultralytics/yolo-ios-app/blob/main/LICENSE) file for the full terms and conditions.
+- **AGPL-3.0 License:** Ideal for students, researchers, and enthusiasts who want to experiment, learn, and share their work openly. This [OSI-approved](https://opensource.org/license/agpl-3.0) license promotes collaboration and knowledge sharing within the open-source community. See the [LICENSE](https://github.com/ultralytics/yolo-ios-app/blob/main/LICENSE) file for the full terms and conditions.
 - **Enterprise License:** Designed for commercial applications where integrating Ultralytics software into proprietary products or services is necessary. This license allows for commercial use without the open-source requirements of AGPL-3.0. If your project requires an Enterprise License, please contact us through the [Ultralytics Licensing](https://www.ultralytics.com/license) page.
 
 ## 🤝 Contact
@@ -199,7 +199,7 @@ For general questions, support, and discussions about Ultralytics YOLO models, s
   <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
   <a href="https://twitter.com/ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-twitter.png" width="3%" alt="Ultralytics Twitter"></a>
   <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
-  <a href="https://youtube.com/ultralytics?sub_confirmation=1"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-youtube.png" width="3%" alt="Ultralytics YouTube"></a>
+  <a href="https://www.youtube.com/ultralytics?sub_confirmation=1"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-youtube.png" width="3%" alt="Ultralytics YouTube"></a>
   <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">
   <a href="https://www.tiktok.com/@ultralytics"><img src="https://github.com/ultralytics/assets/raw/main/social/logo-social-tiktok.png" width="3%" alt="Ultralytics TikTok"></a>
   <img src="https://github.com/ultralytics/assets/raw/main/social/logo-transparent.png" width="3%" alt="space">

--- a/YOLOiOSApp/README.md
+++ b/YOLOiOSApp/README.md
@@ -42,7 +42,7 @@ Getting started with the Ultralytics YOLO iOS App is straightforward. Follow the
 Ensure you have the following before you begin:
 
 - **Xcode:** The app requires [Xcode](https://developer.apple.com/xcode/) installed on your macOS machine. You can download it from the [Mac App Store](https://apps.apple.com/us/app/xcode/id497799835).
-- **iOS Device:** An iPhone or iPad running [iOS 16.0](https://support.apple.com/guide/iphone/iphone-models-compatible-with-ios-26-iphe3fa5df43/ios) or later is needed for testing.
+- **iOS Device:** An iPhone or iPad running [iOS 16.0](https://www.apple.com/os/ios/) or later is needed for testing.
 - **Apple Developer Account:** A free [Apple Developer account](https://developer.apple.com/programs/enroll/) is sufficient for testing on your device.
 
 ### Installation


### PR DESCRIPTION
## Summary
- update redirected external URLs to their final destinations
- apply the redirect cleanup across tracked documentation and related text files

## Testing
- no tests run (link-only changes)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR makes small but important documentation fixes across the `ultralytics/yolo-ios-app` repo by updating outdated links for YouTube, AGPL-3.0 licensing, and iOS documentation.

### 📊 Key Changes
- 🔗 Updated Ultralytics YouTube links from `youtube.com` to `www.youtube.com` in multiple README files.
- 📜 Corrected AGPL-3.0 license links from the older `agpl-v3` URL to the current `agpl-3.0` URL.
- 🍎 Fixed Apple iOS documentation links, replacing more version-specific or outdated URLs with the general official iOS page.
- 🌍 Applied these documentation fixes consistently across:
  - main `README.md`
  - `README.zh-CN.md`
  - `Sources/YOLO/README.md`
  - `Tests/YOLOTests/README.md`
  - `YOLOiOSApp/README.md`

### 🎯 Purpose & Impact
- ✅ Improves documentation accuracy so users land on the correct official pages.
- 📚 Reduces confusion around licensing by pointing to the proper AGPL-3.0 reference.
- 🚀 Makes onboarding smoother for iOS developers by linking to more reliable Apple docs.
- 🛠️ No app code or runtime behavior changes are included, so impact is low-risk and limited to better documentation quality.