### PR TITLE
Bump slackapi/slack-github-action from v3.0.1 to v3.0.2 in /.github/workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -178,7 +178,7 @@ jobs:
           echo "PR_TITLE=${PR_TITLE}" >> "${GITHUB_ENV}"
       - name: Notify Success
         if: needs.release.result == 'success' && github.event_name == 'push'
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@v3.0.2
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_HUBWEB }}
@@ -186,7 +186,7 @@ jobs:
             text: "<!channel> GitHub Actions success for ${{ github.workflow }} ✅\n\n\n*Repository:* https://github.com/${{ github.repository }}\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n*Event:* NEW `YOLO iOS ${{ needs.check.outputs.current_tag }}` release published 🎉\n*Job Status:* ${{ job.status }}\n*Pull Request:* <https://github.com/${{ github.repository }}/pull/${{ env.PR_NUMBER }}> ${{ env.PR_TITLE }}\n*Release Notes:* https://github.com/${{ github.repository }}/releases/tag/${{ needs.check.outputs.current_tag }}\n"
       - name: Notify Failure
         if: needs.release.result != 'success'
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@v3.0.2
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_HUBWEB }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <a href="https://www.ultralytics.com/"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
 
+
+
 [English](README.md) | [简体中文](README.zh-CN.md)
 
 # 🚀 Ultralytics YOLO for iOS: App and Swift Package

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 <a href="https://www.ultralytics.com/"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
 
-
-
 [English](README.md) | [简体中文](README.zh-CN.md)
 
 # 🚀 Ultralytics YOLO for iOS: App and Swift Package


### PR DESCRIPTION
Bump slackapi/slack-github-action from v3.0.1 to v3.0.2 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR makes a small maintenance update by upgrading the GitHub Action used for Slack release notifications in the iOS app publish workflow.

### 📊 Key Changes
- ⬆️ Updated `slackapi/slack-github-action` in `.github/workflows/publish.yml`
  - Changed from `v3.0.1` to `v3.0.2`
- 📣 Applied the update to both notification steps:
  - `Notify Success`
  - `Notify Failure`
- ⚙️ No app code, model behavior, or release logic was changed

### 🎯 Purpose & Impact
- 🛠️ Keeps CI/CD dependencies current with the latest patch release
- 🔔 Helps maintain reliable Slack notifications for publish success and failure events
- ✅ Low-risk change since it only updates a patch version of a GitHub Action
- 👀 Mostly impacts repository automation and team visibility, with no direct effect on end users of the iOS app