### PR TITLE
Add iOS-style camera lens selector

### DIFF
--- a/ExampleApps/YOLORealTimeUIKit/YOLORealTimeUIKitTests/YOLORealTimeUIKitTests.swift
+++ b/ExampleApps/YOLORealTimeUIKit/YOLORealTimeUIKitTests/YOLORealTimeUIKitTests.swift
@@ -83,9 +83,9 @@ struct YOLORealTimeUIKitTests {
     await #expect(yoloView.sliderIoU.maximumValue == 1)
     await #expect(yoloView.sliderIoU.value == 0.7)  // Default IoU threshold
 
-    await #expect(yoloView.sliderNumItems.minimumValue == 0)
+    await #expect(yoloView.sliderNumItems.minimumValue == 1)
     await #expect(yoloView.sliderNumItems.maximumValue == 100)
-    await #expect(yoloView.sliderNumItems.value == 30)  // Default number of items
+    await #expect(yoloView.sliderNumItems.value == 100)  // Default number of items
 
     // Test buttons
     await #expect(yoloView.playButton != nil)

--- a/Sources/YOLO/VideoCapture.swift
+++ b/Sources/YOLO/VideoCapture.swift
@@ -65,11 +65,7 @@ func captureDevices(position: AVCaptureDevice.Position) -> [AVCaptureDevice] {
 }
 
 func bestCaptureDevice(position: AVCaptureDevice.Position) -> AVCaptureDevice? {
-  if UserDefaults.standard.bool(forKey: "use_telephoto"),
-    let device = AVCaptureDevice.default(.builtInTelephotoCamera, for: .video, position: position)
-  {
-    return device
-  } else if let device = AVCaptureDevice.default(
+  if let device = AVCaptureDevice.default(
     .builtInDualCamera, for: .video, position: position)
   {
     return device

--- a/Sources/YOLO/VideoCapture.swift
+++ b/Sources/YOLO/VideoCapture.swift
@@ -74,8 +74,8 @@ func bestCaptureDevice(position: AVCaptureDevice.Position) -> AVCaptureDevice? {
   }
 }
 
-private extension AVCaptureDevice.DeviceType {
-  var lensSortOrder: Int {
+extension AVCaptureDevice.DeviceType {
+  fileprivate var lensSortOrder: Int {
     switch self {
     case .builtInUltraWideCamera: return 0
     case .builtInWideAngleCamera: return 1

--- a/Sources/YOLO/VideoCapture.swift
+++ b/Sources/YOLO/VideoCapture.swift
@@ -52,8 +52,16 @@ func captureDevices(position: AVCaptureDevice.Position) -> [AVCaptureDevice] {
     .filter { seenDeviceIDs.insert($0.uniqueID).inserted }
     .sorted { $0.deviceType.lensSortOrder < $1.deviceType.lensSortOrder }
   let physicalDevices = devices.filter { physicalLensTypes.contains($0.deviceType) }
+  var selectableDevices = physicalDevices.isEmpty ? devices : physicalDevices
 
-  return physicalDevices.count > 1 ? physicalDevices : devices
+  if let defaultDevice = bestCaptureDevice(position: position),
+    defaultDevice.position == position,
+    !selectableDevices.contains(where: { $0.uniqueID == defaultDevice.uniqueID })
+  {
+    selectableDevices.append(defaultDevice)
+  }
+
+  return selectableDevices.sorted { $0.deviceType.lensSortOrder < $1.deviceType.lensSortOrder }
 }
 
 func bestCaptureDevice(position: AVCaptureDevice.Position) -> AVCaptureDevice? {
@@ -74,15 +82,15 @@ func bestCaptureDevice(position: AVCaptureDevice.Position) -> AVCaptureDevice? {
   }
 }
 
-extension AVCaptureDevice.DeviceType {
-  fileprivate var lensSortOrder: Int {
+private extension AVCaptureDevice.DeviceType {
+  var lensSortOrder: Int {
     switch self {
     case .builtInUltraWideCamera: return 0
     case .builtInWideAngleCamera: return 1
-    case .builtInDualWideCamera: return 2
-    case .builtInDualCamera: return 3
-    case .builtInTripleCamera: return 4
-    case .builtInTelephotoCamera: return 5
+    case .builtInTelephotoCamera: return 2
+    case .builtInDualWideCamera: return 3
+    case .builtInDualCamera: return 4
+    case .builtInTripleCamera: return 5
     case .builtInTrueDepthCamera: return 6
     default: return 7
     }
@@ -179,6 +187,7 @@ public final class VideoCapture: NSObject, @unchecked Sendable {
     let previewLayer = AVCaptureVideoPreviewLayer(session: captureSession)
     previewLayer.videoGravity = AVLayerVideoGravity.resizeAspectFill
     previewLayer.connection?.videoOrientation = videoOrientation
+    configureVideoMirroring(previewLayer.connection, isMirrored: position == .front)
     self.previewLayer = previewLayer
 
     let settings: [String: Any] = [
@@ -200,9 +209,7 @@ public final class VideoCapture: NSObject, @unchecked Sendable {
     // rotated by 90 degrees. Need to set this _after_ addOutput()!
     let connection = videoOutput.connection(with: AVMediaType.video)
     connection?.videoOrientation = videoOrientation
-    if position == .front {
-      connection?.isVideoMirrored = true
-    }
+    configureVideoMirroring(connection, isMirrored: position == .front)
 
     guard configureCameraDevice(device) else {
       return false
@@ -247,9 +254,9 @@ public final class VideoCapture: NSObject, @unchecked Sendable {
       ?? .portrait
     let videoConnection = videoOutput.connection(with: .video)
     videoConnection?.videoOrientation = videoOrientation
-    videoConnection?.isVideoMirrored = device.position == .front
+    configureVideoMirroring(videoConnection, isMirrored: device.position == .front)
     previewLayer?.connection?.videoOrientation = videoOrientation
-    previewLayer?.connection?.isVideoMirrored = device.position == .front
+    configureVideoMirroring(previewLayer?.connection, isMirrored: device.position == .front)
 
     guard configureCameraDevice(device) else {
       captureSession.commitConfiguration()
@@ -300,13 +307,15 @@ public final class VideoCapture: NSObject, @unchecked Sendable {
 
     connection.videoOrientation = orientation
     let currentInput = self.captureSession.inputs.first as? AVCaptureDeviceInput
-    if currentInput?.device.position == .front {
-      connection.isVideoMirrored = true
-    } else {
-      connection.isVideoMirrored = false
-    }
+    configureVideoMirroring(connection, isMirrored: currentInput?.device.position == .front)
     self.previewLayer?.connection?.videoOrientation = connection.videoOrientation
-    self.previewLayer?.connection?.isVideoMirrored = connection.isVideoMirrored
+    configureVideoMirroring(self.previewLayer?.connection, isMirrored: connection.isVideoMirrored)
+  }
+
+  private func configureVideoMirroring(_ connection: AVCaptureConnection?, isMirrored: Bool) {
+    guard let connection else { return }
+    connection.automaticallyAdjustsVideoMirroring = false
+    connection.isVideoMirrored = isMirrored
   }
 
   private func configurePhotoOutput(for device: AVCaptureDevice) {

--- a/Sources/YOLO/VideoCapture.swift
+++ b/Sources/YOLO/VideoCapture.swift
@@ -16,11 +16,44 @@ import CoreVideo
 import UIKit
 import Vision
 
+private let selectableCameraTypes: [AVCaptureDevice.DeviceType] = [
+  .builtInUltraWideCamera,
+  .builtInWideAngleCamera,
+  .builtInTelephotoCamera,
+  .builtInDualWideCamera,
+  .builtInDualCamera,
+  .builtInTripleCamera,
+  .builtInTrueDepthCamera,
+]
+
+private let physicalLensTypes: [AVCaptureDevice.DeviceType] = [
+  .builtInUltraWideCamera,
+  .builtInWideAngleCamera,
+  .builtInTelephotoCamera,
+  .builtInTrueDepthCamera,
+]
+
 /// Protocol for receiving video capture frame processing results.
 @MainActor
 public protocol VideoCaptureDelegate: AnyObject {
   func onPredict(result: YOLOResult)
   func onInferenceTime(speed: Double, fps: Double)
+}
+
+func captureDevices(position: AVCaptureDevice.Position) -> [AVCaptureDevice] {
+  var seenDeviceIDs = Set<String>()
+  let discoverySession = AVCaptureDevice.DiscoverySession(
+    deviceTypes: selectableCameraTypes,
+    mediaType: .video,
+    position: position
+  )
+
+  let devices = discoverySession.devices
+    .filter { seenDeviceIDs.insert($0.uniqueID).inserted }
+    .sorted { $0.deviceType.lensSortOrder < $1.deviceType.lensSortOrder }
+  let physicalDevices = devices.filter { physicalLensTypes.contains($0.deviceType) }
+
+  return physicalDevices.count > 1 ? physicalDevices : devices
 }
 
 func bestCaptureDevice(position: AVCaptureDevice.Position) -> AVCaptureDevice? {
@@ -38,6 +71,21 @@ func bestCaptureDevice(position: AVCaptureDevice.Position) -> AVCaptureDevice? {
     return device
   } else {
     return AVCaptureDevice.default(for: .video)
+  }
+}
+
+private extension AVCaptureDevice.DeviceType {
+  var lensSortOrder: Int {
+    switch self {
+    case .builtInUltraWideCamera: return 0
+    case .builtInWideAngleCamera: return 1
+    case .builtInDualWideCamera: return 2
+    case .builtInDualCamera: return 3
+    case .builtInTripleCamera: return 4
+    case .builtInTelephotoCamera: return 5
+    case .builtInTrueDepthCamera: return 6
+    default: return 7
+    }
   }
 }
 
@@ -104,6 +152,9 @@ public final class VideoCapture: NSObject, @unchecked Sendable {
     orientation: UIDeviceOrientation
   ) -> Bool {
     captureSession.beginConfiguration()
+    defer {
+      captureSession.commitConfiguration()
+    }
     captureSession.sessionPreset = sessionPreset
 
     guard let device = bestCaptureDevice(position: position) else {
@@ -142,17 +193,7 @@ public final class VideoCapture: NSObject, @unchecked Sendable {
     }
     if captureSession.canAddOutput(photoOutput) {
       captureSession.addOutput(photoOutput)
-      if #available(iOS 16.0, *) {
-        // Use maxPhotoDimensions instead of deprecated isHighResolutionCaptureEnabled
-        if let device = captureDevice,
-          let maxDimensions = device.activeFormat.supportedMaxPhotoDimensions.last
-        {
-          photoOutput.maxPhotoDimensions = maxDimensions
-        }
-      } else {
-        // Fallback for iOS versions before 16.0
-        photoOutput.isHighResolutionCaptureEnabled = true
-      }
+      configurePhotoOutput(for: device)
     }
 
     // We want the buffers to be in portrait orientation otherwise they are
@@ -163,18 +204,55 @@ public final class VideoCapture: NSObject, @unchecked Sendable {
       connection?.isVideoMirrored = true
     }
 
-    guard let device = captureDevice else { return false }
+    guard configureCameraDevice(device) else {
+      return false
+    }
+
+    return true
+  }
+
+  func selectCaptureDevice(_ device: AVCaptureDevice, orientation: UIDeviceOrientation) -> Bool {
+    guard captureDevice?.uniqueID != device.uniqueID else { return true }
+
+    let newInput: AVCaptureDeviceInput
     do {
-      try device.lockForConfiguration()
-      if device.isFocusModeSupported(.continuousAutoFocus),
-        device.isFocusPointOfInterestSupported
-      {
-        device.focusMode = .continuousAutoFocus
-        device.focusPointOfInterest = CGPoint(x: 0.5, y: 0.5)
-      }
-      device.exposureMode = .continuousAutoExposure
-      device.unlockForConfiguration()
+      newInput = try AVCaptureDeviceInput(device: device)
     } catch {
+      YOLOLog.error("Failed to create video input: \(error)")
+      return false
+    }
+
+    captureSession.beginConfiguration()
+    let currentInput = videoInput ?? captureSession.inputs.first as? AVCaptureDeviceInput
+    if let currentInput {
+      captureSession.removeInput(currentInput)
+    }
+
+    guard captureSession.canAddInput(newInput) else {
+      if let currentInput, captureSession.canAddInput(currentInput) {
+        captureSession.addInput(currentInput)
+      }
+      captureSession.commitConfiguration()
+      return false
+    }
+
+    captureSession.addInput(newInput)
+    videoInput = newInput
+    captureDevice = device
+    configurePhotoOutput(for: device)
+
+    let videoOrientation =
+      AVCaptureVideoOrientation(orientation)
+      ?? videoOutput.connection(with: .video)?.videoOrientation
+      ?? .portrait
+    let videoConnection = videoOutput.connection(with: .video)
+    videoConnection?.videoOrientation = videoOrientation
+    videoConnection?.isVideoMirrored = device.position == .front
+    previewLayer?.connection?.videoOrientation = videoOrientation
+    previewLayer?.connection?.isVideoMirrored = device.position == .front
+
+    guard configureCameraDevice(device) else {
+      captureSession.commitConfiguration()
       return false
     }
 
@@ -228,6 +306,37 @@ public final class VideoCapture: NSObject, @unchecked Sendable {
       connection.isVideoMirrored = false
     }
     self.previewLayer?.connection?.videoOrientation = connection.videoOrientation
+    self.previewLayer?.connection?.isVideoMirrored = connection.isVideoMirrored
+  }
+
+  private func configurePhotoOutput(for device: AVCaptureDevice) {
+    if #available(iOS 16.0, *) {
+      if let maxDimensions = device.activeFormat.supportedMaxPhotoDimensions.last {
+        photoOutput.maxPhotoDimensions = maxDimensions
+      }
+    } else {
+      photoOutput.isHighResolutionCaptureEnabled = true
+    }
+  }
+
+  private func configureCameraDevice(_ device: AVCaptureDevice) -> Bool {
+    do {
+      try device.lockForConfiguration()
+      if device.isFocusModeSupported(.continuousAutoFocus),
+        device.isFocusPointOfInterestSupported
+      {
+        device.focusMode = .continuousAutoFocus
+        device.focusPointOfInterest = CGPoint(x: 0.5, y: 0.5)
+      }
+      if device.isExposureModeSupported(.continuousAutoExposure) {
+        device.exposureMode = .continuousAutoExposure
+      }
+      device.unlockForConfiguration()
+      return true
+    } catch {
+      YOLOLog.error("Camera configuration failed: \(error.localizedDescription)")
+      return false
+    }
   }
 }
 

--- a/Sources/YOLO/VideoCapture.swift
+++ b/Sources/YOLO/VideoCapture.swift
@@ -53,17 +53,7 @@ func captureDevices(position: AVCaptureDevice.Position) -> [AVCaptureDevice] {
   let devices = discoverySession.devices
     .filter { seenDeviceIDs.insert($0.uniqueID).inserted }
     .sorted { $0.deviceType.lensSortOrder < $1.deviceType.lensSortOrder }
-  let physicalDevices = devices.filter { physicalLensTypes.contains($0.deviceType) }
-  var selectableDevices = physicalDevices.isEmpty ? devices : physicalDevices
-
-  if let defaultDevice = bestCaptureDevice(position: position),
-    defaultDevice.position == position,
-    !selectableDevices.contains(where: { $0.uniqueID == defaultDevice.uniqueID })
-  {
-    selectableDevices.append(defaultDevice)
-  }
-
-  return selectableDevices.sorted { $0.deviceType.lensSortOrder < $1.deviceType.lensSortOrder }
+  return devices.filter { physicalLensTypes.contains($0.deviceType) }
 }
 
 func bestCaptureDevice(position: AVCaptureDevice.Position) -> AVCaptureDevice? {

--- a/Sources/YOLO/VideoCapture.swift
+++ b/Sources/YOLO/VideoCapture.swift
@@ -23,14 +23,12 @@ private let selectableCameraTypes: [AVCaptureDevice.DeviceType] = [
   .builtInDualWideCamera,
   .builtInDualCamera,
   .builtInTripleCamera,
-  .builtInTrueDepthCamera,
 ]
 
 private let physicalLensTypes: [AVCaptureDevice.DeviceType] = [
   .builtInUltraWideCamera,
   .builtInWideAngleCamera,
   .builtInTelephotoCamera,
-  .builtInTrueDepthCamera,
 ]
 
 /// Protocol for receiving video capture frame processing results.
@@ -87,8 +85,7 @@ extension AVCaptureDevice.DeviceType {
     case .builtInDualWideCamera: return 3
     case .builtInDualCamera: return 4
     case .builtInTripleCamera: return 5
-    case .builtInTrueDepthCamera: return 6
-    default: return 7
+    default: return 6
     }
   }
 }

--- a/Sources/YOLO/VideoCapture.swift
+++ b/Sources/YOLO/VideoCapture.swift
@@ -109,7 +109,9 @@ func displayZoomFactor(_ zoomFactor: CGFloat, for device: AVCaptureDevice) -> CG
 func displayZoomFactor(
   for lensDevice: AVCaptureDevice, activeDevice: AVCaptureDevice?
 ) -> CGFloat? {
-  let candidates = [activeDevice, bestCaptureDevice(position: lensDevice.position)].compactMap { $0 }
+  let candidates = [activeDevice, bestCaptureDevice(position: lensDevice.position)].compactMap {
+    $0
+  }
   for candidate in candidates {
     if let zoomFactor = zoomFactor(for: lensDevice, on: candidate) {
       return displayZoomFactor(zoomFactor, for: candidate)

--- a/Sources/YOLO/VideoCapture.swift
+++ b/Sources/YOLO/VideoCapture.swift
@@ -82,8 +82,8 @@ func bestCaptureDevice(position: AVCaptureDevice.Position) -> AVCaptureDevice? {
   }
 }
 
-private extension AVCaptureDevice.DeviceType {
-  var lensSortOrder: Int {
+extension AVCaptureDevice.DeviceType {
+  fileprivate var lensSortOrder: Int {
     switch self {
     case .builtInUltraWideCamera: return 0
     case .builtInWideAngleCamera: return 1

--- a/Sources/YOLO/VideoCapture.swift
+++ b/Sources/YOLO/VideoCapture.swift
@@ -39,6 +39,10 @@ public protocol VideoCaptureDelegate: AnyObject {
 }
 
 func captureDevices(position: AVCaptureDevice.Position) -> [AVCaptureDevice] {
+  if position == .front {
+    return bestCaptureDevice(position: position).map { [$0] } ?? []
+  }
+
   var seenDeviceIDs = Set<String>()
   let discoverySession = AVCaptureDevice.DiscoverySession(
     deviceTypes: selectableCameraTypes,

--- a/Sources/YOLO/VideoCapture.swift
+++ b/Sources/YOLO/VideoCapture.swift
@@ -16,7 +16,7 @@ import CoreVideo
 import UIKit
 import Vision
 
-private let physicalLensTypes: [AVCaptureDevice.DeviceType] = [
+let physicalLensTypes: [AVCaptureDevice.DeviceType] = [
   .builtInUltraWideCamera,
   .builtInWideAngleCamera,
   .builtInTelephotoCamera,
@@ -34,17 +34,14 @@ func captureDevices(position: AVCaptureDevice.Position) -> [AVCaptureDevice] {
     return bestCaptureDevice(position: position).map { [$0] } ?? []
   }
 
-  var seenDeviceIDs = Set<String>()
   let discoverySession = AVCaptureDevice.DiscoverySession(
     deviceTypes: physicalLensTypes,
     mediaType: .video,
     position: position
   )
 
-  let devices = discoverySession.devices
-    .filter { seenDeviceIDs.insert($0.uniqueID).inserted }
+  return discoverySession.devices
     .sorted { $0.deviceType.lensSortOrder < $1.deviceType.lensSortOrder }
-  return devices.filter { physicalLensTypes.contains($0.deviceType) }
 }
 
 func bestCaptureDevice(position: AVCaptureDevice.Position) -> AVCaptureDevice? {
@@ -111,10 +108,7 @@ extension AVCaptureDevice.DeviceType {
     case .builtInUltraWideCamera: return 0
     case .builtInWideAngleCamera: return 1
     case .builtInTelephotoCamera: return 2
-    case .builtInDualWideCamera: return 3
-    case .builtInDualCamera: return 4
-    case .builtInTripleCamera: return 5
-    default: return 6
+    default: return 3
     }
   }
 }

--- a/Sources/YOLO/VideoCapture.swift
+++ b/Sources/YOLO/VideoCapture.swift
@@ -16,15 +16,6 @@ import CoreVideo
 import UIKit
 import Vision
 
-private let selectableCameraTypes: [AVCaptureDevice.DeviceType] = [
-  .builtInUltraWideCamera,
-  .builtInWideAngleCamera,
-  .builtInTelephotoCamera,
-  .builtInDualWideCamera,
-  .builtInDualCamera,
-  .builtInTripleCamera,
-]
-
 private let physicalLensTypes: [AVCaptureDevice.DeviceType] = [
   .builtInUltraWideCamera,
   .builtInWideAngleCamera,
@@ -45,7 +36,7 @@ func captureDevices(position: AVCaptureDevice.Position) -> [AVCaptureDevice] {
 
   var seenDeviceIDs = Set<String>()
   let discoverySession = AVCaptureDevice.DiscoverySession(
-    deviceTypes: selectableCameraTypes,
+    deviceTypes: physicalLensTypes,
     mediaType: .video,
     position: position
   )
@@ -409,6 +400,7 @@ public final class VideoCapture: NSObject, @unchecked Sendable {
 
   private func configureVideoMirroring(_ connection: AVCaptureConnection?, isMirrored: Bool) {
     guard let connection else { return }
+    guard connection.isVideoMirroringSupported else { return }
     connection.automaticallyAdjustsVideoMirroring = false
     connection.isVideoMirrored = isMirrored
   }

--- a/Sources/YOLO/VideoCapture.swift
+++ b/Sources/YOLO/VideoCapture.swift
@@ -303,6 +303,10 @@ public final class VideoCapture: NSObject, @unchecked Sendable {
       return false
     }
 
+    guard configureCameraDevice(device) else {
+      return false
+    }
+
     captureSession.beginConfiguration()
     defer {
       captureSession.commitConfiguration()
@@ -331,7 +335,7 @@ public final class VideoCapture: NSObject, @unchecked Sendable {
     previewLayer?.connection?.videoOrientation = videoOrientation
     configureVideoMirroring(previewLayer?.connection, isMirrored: device.position == .front)
 
-    return configureCameraDevice(device)
+    return true
   }
 
   private func rampZoom(to zoomFactor: CGFloat, on device: AVCaptureDevice) -> Bool {

--- a/Sources/YOLO/VideoCapture.swift
+++ b/Sources/YOLO/VideoCapture.swift
@@ -63,17 +63,59 @@ func captureDevices(position: AVCaptureDevice.Position) -> [AVCaptureDevice] {
 }
 
 func bestCaptureDevice(position: AVCaptureDevice.Position) -> AVCaptureDevice? {
-  if let device = AVCaptureDevice.default(
-    .builtInDualCamera, for: .video, position: position)
-  {
-    return device
-  } else if let device = AVCaptureDevice.default(
-    .builtInWideAngleCamera, for: .video, position: position)
-  {
-    return device
-  } else {
-    return AVCaptureDevice.default(for: .video)
+  let preferredTypes: [AVCaptureDevice.DeviceType] =
+    position == .back
+    ? [.builtInTripleCamera, .builtInDualWideCamera, .builtInDualCamera, .builtInWideAngleCamera]
+    : [.builtInTrueDepthCamera, .builtInWideAngleCamera]
+
+  for deviceType in preferredTypes {
+    if let device = AVCaptureDevice.default(deviceType, for: .video, position: position) {
+      return device
+    }
   }
+
+  return nil
+}
+
+func zoomFactor(for lensDevice: AVCaptureDevice, on virtualDevice: AVCaptureDevice) -> CGFloat? {
+  guard lensDevice.position == virtualDevice.position else { return nil }
+  let constituentDevices = virtualDevice.constituentDevices
+  guard constituentDevices.count > 1 else { return nil }
+
+  let lensIndex =
+    constituentDevices.firstIndex { $0.uniqueID == lensDevice.uniqueID }
+    ?? constituentDevices.firstIndex { $0.deviceType == lensDevice.deviceType }
+  guard let lensIndex else { return nil }
+
+  let switchOverZoomFactors = virtualDevice.virtualDeviceSwitchOverVideoZoomFactors.map {
+    CGFloat(truncating: $0)
+  }
+  let zoomFactors = [virtualDevice.minAvailableVideoZoomFactor] + switchOverZoomFactors
+  guard lensIndex < zoomFactors.count else { return nil }
+
+  return min(
+    max(zoomFactors[lensIndex], virtualDevice.minAvailableVideoZoomFactor),
+    virtualDevice.maxAvailableVideoZoomFactor
+  )
+}
+
+func displayZoomFactor(_ zoomFactor: CGFloat, for device: AVCaptureDevice) -> CGFloat {
+  if #available(iOS 18.0, *) {
+    return zoomFactor * device.displayVideoZoomFactorMultiplier
+  }
+  return zoomFactor
+}
+
+func displayZoomFactor(
+  for lensDevice: AVCaptureDevice, activeDevice: AVCaptureDevice?
+) -> CGFloat? {
+  let candidates = [activeDevice, bestCaptureDevice(position: lensDevice.position)].compactMap { $0 }
+  for candidate in candidates {
+    if let zoomFactor = zoomFactor(for: lensDevice, on: candidate) {
+      return displayZoomFactor(zoomFactor, for: candidate)
+    }
+  }
+  return nil
 }
 
 extension AVCaptureDevice.DeviceType {
@@ -211,9 +253,55 @@ public final class VideoCapture: NSObject, @unchecked Sendable {
     return true
   }
 
-  func selectCaptureDevice(_ device: AVCaptureDevice, orientation: UIDeviceOrientation) -> Bool {
+  func selectCaptureDevice(
+    _ device: AVCaptureDevice,
+    orientation: UIDeviceOrientation,
+    completion: @escaping (Bool) -> Void
+  ) {
+    cameraQueue.async { [weak self] in
+      guard let self else {
+        DispatchQueue.main.async { completion(false) }
+        return
+      }
+
+      let success = self.selectCaptureDeviceSync(device, orientation: orientation)
+      DispatchQueue.main.async {
+        completion(success)
+      }
+    }
+  }
+
+  private func selectCaptureDeviceSync(
+    _ device: AVCaptureDevice, orientation: UIDeviceOrientation
+  ) -> Bool {
+    if device.position == .back, selectVirtualRearLens(device, orientation: orientation) {
+      return true
+    }
+
     guard captureDevice?.uniqueID != device.uniqueID else { return true }
 
+    return switchCaptureInput(to: device, orientation: orientation)
+  }
+
+  private func selectVirtualRearLens(
+    _ lensDevice: AVCaptureDevice, orientation: UIDeviceOrientation
+  ) -> Bool {
+    let candidates = [captureDevice, bestCaptureDevice(position: .back)].compactMap { $0 }
+    for virtualDevice in candidates {
+      guard let zoomFactor = zoomFactor(for: lensDevice, on: virtualDevice) else { continue }
+      if captureDevice?.uniqueID != virtualDevice.uniqueID,
+        !switchCaptureInput(to: virtualDevice, orientation: orientation)
+      {
+        return false
+      }
+      return rampZoom(to: zoomFactor, on: virtualDevice)
+    }
+    return false
+  }
+
+  private func switchCaptureInput(
+    to device: AVCaptureDevice, orientation: UIDeviceOrientation
+  ) -> Bool {
     let newInput: AVCaptureDeviceInput
     do {
       newInput = try AVCaptureDeviceInput(device: device)
@@ -223,6 +311,10 @@ public final class VideoCapture: NSObject, @unchecked Sendable {
     }
 
     captureSession.beginConfiguration()
+    defer {
+      captureSession.commitConfiguration()
+    }
+
     let currentInput = videoInput ?? captureSession.inputs.first as? AVCaptureDeviceInput
     if let currentInput {
       captureSession.removeInput(currentInput)
@@ -232,7 +324,6 @@ public final class VideoCapture: NSObject, @unchecked Sendable {
       if let currentInput, captureSession.canAddInput(currentInput) {
         captureSession.addInput(currentInput)
       }
-      captureSession.commitConfiguration()
       return false
     }
 
@@ -251,28 +342,40 @@ public final class VideoCapture: NSObject, @unchecked Sendable {
     previewLayer?.connection?.videoOrientation = videoOrientation
     configureVideoMirroring(previewLayer?.connection, isMirrored: device.position == .front)
 
-    guard configureCameraDevice(device) else {
-      captureSession.commitConfiguration()
+    return configureCameraDevice(device)
+  }
+
+  private func rampZoom(to zoomFactor: CGFloat, on device: AVCaptureDevice) -> Bool {
+    do {
+      try device.lockForConfiguration()
+      defer { device.unlockForConfiguration() }
+
+      let clampedZoomFactor = min(
+        max(zoomFactor, device.minAvailableVideoZoomFactor),
+        device.maxAvailableVideoZoomFactor
+      )
+      if device.isRampingVideoZoom {
+        device.cancelVideoZoomRamp()
+      }
+      device.ramp(toVideoZoomFactor: clampedZoomFactor, withRate: 20)
+      return true
+    } catch {
+      YOLOLog.error("Zoom configuration failed: \(error.localizedDescription)")
       return false
     }
-
-    captureSession.commitConfiguration()
-    return true
   }
 
   func start() {
-    if !captureSession.isRunning {
-      DispatchQueue.global().async { [weak self] in
-        self?.captureSession.startRunning()
-      }
+    cameraQueue.async { [weak self] in
+      guard let self, !self.captureSession.isRunning else { return }
+      self.captureSession.startRunning()
     }
   }
 
   func stop() {
-    if captureSession.isRunning {
-      DispatchQueue.global().async { [weak self] in
-        self?.captureSession.stopRunning()
-      }
+    cameraQueue.async { [weak self] in
+      guard let self, self.captureSession.isRunning else { return }
+      self.captureSession.stopRunning()
     }
   }
 
@@ -296,13 +399,16 @@ public final class VideoCapture: NSObject, @unchecked Sendable {
   }
 
   func updateVideoOrientation(orientation: AVCaptureVideoOrientation) {
-    guard let connection = videoOutput.connection(with: .video) else { return }
+    cameraQueue.async { [weak self] in
+      guard let self, let connection = self.videoOutput.connection(with: .video) else { return }
 
-    connection.videoOrientation = orientation
-    let currentInput = self.captureSession.inputs.first as? AVCaptureDeviceInput
-    configureVideoMirroring(connection, isMirrored: currentInput?.device.position == .front)
-    self.previewLayer?.connection?.videoOrientation = connection.videoOrientation
-    configureVideoMirroring(self.previewLayer?.connection, isMirrored: connection.isVideoMirrored)
+      connection.videoOrientation = orientation
+      let currentInput = self.captureSession.inputs.first as? AVCaptureDeviceInput
+      self.configureVideoMirroring(connection, isMirrored: currentInput?.device.position == .front)
+      self.previewLayer?.connection?.videoOrientation = connection.videoOrientation
+      self.configureVideoMirroring(
+        self.previewLayer?.connection, isMirrored: connection.isVideoMirrored)
+    }
   }
 
   private func configureVideoMirroring(_ connection: AVCaptureConnection?, isMirrored: Bool) {

--- a/Sources/YOLO/VideoCapture.swift
+++ b/Sources/YOLO/VideoCapture.swift
@@ -421,6 +421,12 @@ public final class VideoCapture: NSObject, @unchecked Sendable {
       if device.isExposureModeSupported(.continuousAutoExposure) {
         device.exposureMode = .continuousAutoExposure
       }
+      if #available(iOS 18.0, *), device.position == .back {
+        device.videoZoomFactor = min(
+          max(1 / device.displayVideoZoomFactorMultiplier, device.minAvailableVideoZoomFactor),
+          device.maxAvailableVideoZoomFactor
+        )
+      }
       device.unlockForConfiguration()
       return true
     } catch {

--- a/Sources/YOLO/VideoCapture.swift
+++ b/Sources/YOLO/VideoCapture.swift
@@ -114,6 +114,16 @@ extension AVCaptureDevice.DeviceType {
 }
 
 extension AVCaptureVideoOrientation {
+  init?(_ interfaceOrientation: UIInterfaceOrientation) {
+    switch interfaceOrientation {
+    case .portrait: self = .portrait
+    case .portraitUpsideDown: self = .portraitUpsideDown
+    case .landscapeLeft: self = .landscapeLeft
+    case .landscapeRight: self = .landscapeRight
+    default: return nil
+    }
+  }
+
   /// Maps a `UIDeviceOrientation` to the matching video orientation. Unknown device
   /// orientations (face-up/down) return `nil` so callers can preserve the existing setting.
   init?(_ deviceOrientation: UIDeviceOrientation) {
@@ -236,7 +246,7 @@ public final class VideoCapture: NSObject, @unchecked Sendable {
 
   func selectCaptureDevice(
     _ device: AVCaptureDevice,
-    orientation: UIDeviceOrientation,
+    videoOrientation: AVCaptureVideoOrientation,
     completion: @escaping (Bool) -> Void
   ) {
     cameraQueue.async { [weak self] in
@@ -245,7 +255,7 @@ public final class VideoCapture: NSObject, @unchecked Sendable {
         return
       }
 
-      let success = self.selectCaptureDeviceSync(device, orientation: orientation)
+      let success = self.selectCaptureDeviceSync(device, videoOrientation: videoOrientation)
       DispatchQueue.main.async {
         completion(success)
       }
@@ -253,25 +263,27 @@ public final class VideoCapture: NSObject, @unchecked Sendable {
   }
 
   private func selectCaptureDeviceSync(
-    _ device: AVCaptureDevice, orientation: UIDeviceOrientation
+    _ device: AVCaptureDevice, videoOrientation: AVCaptureVideoOrientation
   ) -> Bool {
-    if device.position == .back, selectVirtualRearLens(device, orientation: orientation) {
+    if device.position == .back,
+      selectVirtualRearLens(device, videoOrientation: videoOrientation)
+    {
       return true
     }
 
     guard captureDevice?.uniqueID != device.uniqueID else { return true }
 
-    return switchCaptureInput(to: device, orientation: orientation)
+    return switchCaptureInput(to: device, videoOrientation: videoOrientation)
   }
 
   private func selectVirtualRearLens(
-    _ lensDevice: AVCaptureDevice, orientation: UIDeviceOrientation
+    _ lensDevice: AVCaptureDevice, videoOrientation: AVCaptureVideoOrientation
   ) -> Bool {
     let candidates = [captureDevice, bestCaptureDevice(position: .back)].compactMap { $0 }
     for virtualDevice in candidates {
       guard let zoomFactor = zoomFactor(for: lensDevice, on: virtualDevice) else { continue }
       if captureDevice?.uniqueID != virtualDevice.uniqueID,
-        !switchCaptureInput(to: virtualDevice, orientation: orientation)
+        !switchCaptureInput(to: virtualDevice, videoOrientation: videoOrientation)
       {
         return false
       }
@@ -281,7 +293,7 @@ public final class VideoCapture: NSObject, @unchecked Sendable {
   }
 
   private func switchCaptureInput(
-    to device: AVCaptureDevice, orientation: UIDeviceOrientation
+    to device: AVCaptureDevice, videoOrientation: AVCaptureVideoOrientation
   ) -> Bool {
     let newInput: AVCaptureDeviceInput
     do {
@@ -313,10 +325,6 @@ public final class VideoCapture: NSObject, @unchecked Sendable {
     captureDevice = device
     configurePhotoOutput(for: device)
 
-    let videoOrientation =
-      AVCaptureVideoOrientation(orientation)
-      ?? videoOutput.connection(with: .video)?.videoOrientation
-      ?? .portrait
     let videoConnection = videoOutput.connection(with: .video)
     videoConnection?.videoOrientation = videoOrientation
     configureVideoMirroring(videoConnection, isMirrored: device.position == .front)

--- a/Sources/YOLO/YOLOView.swift
+++ b/Sources/YOLO/YOLOView.swift
@@ -107,6 +107,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   public var toolbar = UIView()
   let selection = UISelectionFeedbackGenerator()
   private let lensControl = UISegmentedControl()
+  private let lensCaptionLabel = UILabel()
   private var lensDevices = [AVCaptureDevice]()
   private var overlayLayer = CALayer()
   private var maskLayer: CALayer?
@@ -692,6 +693,12 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
       ], for: .selected)
     lensControl.addTarget(self, action: #selector(lensChanged(_:)), for: .valueChanged)
     self.addSubview(lensControl)
+
+    lensCaptionLabel.isHidden = true
+    lensCaptionLabel.textAlignment = .center
+    lensCaptionLabel.textColor = UIColor.white.withAlphaComponent(0.78)
+    lensCaptionLabel.font = UIFont.systemFont(ofSize: 11, weight: .medium)
+    self.addSubview(lensCaptionLabel)
   }
 
   public override func layoutSubviews() {
@@ -740,7 +747,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     let sliderWidth: CGFloat = width * 0.2
     let sliderHeight: CGFloat = height * 0.06
 
-    let bottomMargin: CGFloat = 80
+    let bottomMargin: CGFloat = lensControl.isHidden ? 80 : 144
     let totalSliderHeight = (sliderHeight + 3) * 6
     let startY = height - bottomMargin - totalSliderHeight
 
@@ -795,7 +802,9 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     let sliderHeight: CGFloat = height * 0.02
     let leftPadding: CGFloat = 20
 
-    let thresholdStartY = center.y + height * 0.16 + sliderHeight * 2 + 20
+    let cameraControlsOffset: CGFloat = lensControl.isHidden ? 0 : 64
+    let thresholdStartY =
+      center.y + height * 0.16 + sliderHeight * 2 + 20 - cameraControlsOffset
 
     labelSliderConf.frame = CGRect(
       x: leftPadding, y: thresholdStartY,
@@ -849,12 +858,26 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     guard !lensControl.isHidden else { return }
     let toolBarHeight: CGFloat = 66
     let controlHeight: CGFloat = 34
+    let captionHeight: CGFloat = 14
+    let zoomHeight: CGFloat = max(height * 0.035, 28)
     let controlWidth = min(max(CGFloat(lensDevices.count) * 52, 104), width - 40)
     lensControl.frame = CGRect(
       x: (width - controlWidth) / 2,
-      y: height - toolBarHeight - controlHeight - 16,
+      y: height - toolBarHeight - controlHeight - 14,
       width: controlWidth,
       height: controlHeight
+    )
+    lensCaptionLabel.frame = CGRect(
+      x: 20,
+      y: lensControl.frame.minY - captionHeight - 4,
+      width: width - 40,
+      height: captionHeight
+    )
+    labelZoom.frame = CGRect(
+      x: center.x - 50,
+      y: lensCaptionLabel.frame.minY - zoomHeight - 8,
+      width: 100,
+      height: zoomHeight
     )
   }
 
@@ -991,6 +1014,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     lensControl.removeAllSegments()
 
     guard lensDevices.count > 1 else {
+      lensCaptionLabel.text = currentDevice.map { lensCaption(for: $0) }
       updateLensControlVisibility()
       setNeedsLayout()
       return
@@ -1003,12 +1027,14 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     lensControl.selectedSegmentIndex =
       lensDevices.firstIndex { $0.uniqueID == currentDevice?.uniqueID }
       ?? UISegmentedControl.noSegment
+    lensCaptionLabel.text = currentDevice.map { lensCaption(for: $0) }
     updateLensControlVisibility()
     setNeedsLayout()
   }
 
   private func updateLensControlVisibility() {
     lensControl.isHidden = switchCameraButton.isHidden || lensDevices.count <= 1
+    lensCaptionLabel.isHidden = lensControl.isHidden
   }
 
   private func lensTitle(for device: AVCaptureDevice) -> String {
@@ -1018,6 +1044,17 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     case .builtInTelephotoCamera: return "2"
     case .builtInTrueDepthCamera: return "Front"
     case .builtInDualWideCamera, .builtInDualCamera, .builtInTripleCamera: return "Auto"
+    default: return device.localizedName
+    }
+  }
+
+  private func lensCaption(for device: AVCaptureDevice) -> String {
+    switch device.deviceType {
+    case .builtInUltraWideCamera: return "Ultra wide camera"
+    case .builtInWideAngleCamera: return "Wide camera"
+    case .builtInTelephotoCamera: return "Telephoto camera"
+    case .builtInTrueDepthCamera: return "Front camera"
+    case .builtInDualWideCamera, .builtInDualCamera, .builtInTripleCamera: return "Auto camera"
     default: return device.localizedName
     }
   }

--- a/Sources/YOLO/YOLOView.swift
+++ b/Sources/YOLO/YOLOView.swift
@@ -1044,8 +1044,9 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
       self.selectedLensDeviceID = nil
     }
     if position == .back, let currentDevice, selectedLensDeviceID == nil {
-      selectedLensDeviceID = lensDevice(
-        rawZoomFactor: currentDevice.videoZoomFactor, device: currentDevice)?.uniqueID
+      selectedLensDeviceID =
+        lensDevice(
+          rawZoomFactor: currentDevice.videoZoomFactor, device: currentDevice)?.uniqueID
     }
     lensControl.removeAllSegments()
 

--- a/Sources/YOLO/YOLOView.swift
+++ b/Sources/YOLO/YOLOView.swift
@@ -1129,7 +1129,8 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
 
   private func lensDevice(rawZoomFactor: CGFloat, device: AVCaptureDevice) -> AVCaptureDevice? {
     let lensZooms = lensDevices.compactMap { lens -> (device: AVCaptureDevice, zoom: CGFloat)? in
-      guard isPhysicalRearLens(lens), let zoom = zoomFactor(for: lens, on: device)
+      guard lens.position == .back, physicalLensTypes.contains(lens.deviceType),
+        let zoom = zoomFactor(for: lens, on: device)
       else {
         return nil
       }
@@ -1138,15 +1139,6 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
 
     return lensZooms.last(where: { rawZoomFactor >= $0.zoom - 0.01 })?.device
       ?? lensZooms.first?.device
-  }
-
-  private func isPhysicalRearLens(_ device: AVCaptureDevice) -> Bool {
-    switch device.deviceType {
-    case .builtInUltraWideCamera, .builtInWideAngleCamera, .builtInTelephotoCamera:
-      return device.position == .back
-    default:
-      return false
-    }
   }
 
   private func lensCaption(for device: AVCaptureDevice) -> String {

--- a/Sources/YOLO/YOLOView.swift
+++ b/Sources/YOLO/YOLOView.swift
@@ -869,7 +869,8 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
       x: switchCameraButton.frame.maxX, y: buttonY, width: buttonHeight, height: buttonHeight
     )
     infoButton.frame = CGRect(
-      x: width - horizontalInset - buttonHeight, y: buttonY, width: buttonHeight, height: buttonHeight
+      x: width - horizontalInset - buttonHeight, y: buttonY, width: buttonHeight,
+      height: buttonHeight
     )
   }
 

--- a/Sources/YOLO/YOLOView.swift
+++ b/Sources/YOLO/YOLOView.swift
@@ -860,7 +860,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     let controlHeight: CGFloat = 34
     let captionHeight: CGFloat = 14
     let zoomHeight: CGFloat = max(height * 0.035, 28)
-    let controlWidth = min(max(CGFloat(lensDevices.count) * 52, 104), width - 40)
+    let controlWidth = min(max(CGFloat(lensDevices.count) * 60, 104), width - 40)
     lensControl.frame = CGRect(
       x: (width - controlWidth) / 2,
       y: height - toolBarHeight - controlHeight - 14,
@@ -1043,8 +1043,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     case .builtInUltraWideCamera: return "0.5"
     case .builtInWideAngleCamera: return "1"
     case .builtInTelephotoCamera: return "2"
-    case .builtInTrueDepthCamera: return "Front"
-    case .builtInDualWideCamera, .builtInDualCamera, .builtInTripleCamera: return "Auto"
+    case .builtInDualWideCamera, .builtInDualCamera, .builtInTripleCamera: return "Default"
     default: return device.localizedName
     }
   }
@@ -1054,8 +1053,8 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     case .builtInUltraWideCamera: return "Ultra wide camera"
     case .builtInWideAngleCamera: return "Wide camera"
     case .builtInTelephotoCamera: return "Telephoto camera"
-    case .builtInTrueDepthCamera: return "Front camera"
-    case .builtInDualWideCamera, .builtInDualCamera, .builtInTripleCamera: return "Auto camera"
+    case .builtInDualWideCamera, .builtInDualCamera, .builtInTripleCamera:
+      return "Default back camera"
     default: return device.localizedName
     }
   }

--- a/Sources/YOLO/YOLOView.swift
+++ b/Sources/YOLO/YOLOView.swift
@@ -108,8 +108,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   let selection = UISelectionFeedbackGenerator()
   private let lensControl = UISegmentedControl()
   private let lensCaptionLabel = UILabel()
-  private let cameraTransitionBlurView = UIVisualEffectView(
-    effect: UIBlurEffect(style: .systemUltraThinMaterialDark))
+  private var cameraTransitionView: UIView?
   private var lensDevices = [AVCaptureDevice]()
   private var selectedLensDeviceID: String?
   private var cameraSwitchInProgress = false
@@ -599,10 +598,6 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   }
 
   private func setupUI() {
-    cameraTransitionBlurView.alpha = 0
-    cameraTransitionBlurView.isUserInteractionEnabled = false
-    self.addSubview(cameraTransitionBlurView)
-
     labelName.text = processString(modelName)
     labelName.textAlignment = .center
     labelName.font = UIFont.systemFont(ofSize: 24, weight: .medium)
@@ -730,7 +725,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     }
 
     self.videoCapture.previewLayer?.frame = self.bounds
-    cameraTransitionBlurView.frame = self.bounds
+    cameraTransitionView?.frame = self.bounds
   }
 
   /// Apply consistent toolbar and button styling
@@ -1058,18 +1053,37 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   }
 
   private func showCameraTransitionBlur() {
-    cameraTransitionBlurView.frame = bounds
-    cameraTransitionBlurView.isHidden = false
-    cameraTransitionBlurView.alpha = 1
+    cameraTransitionView?.removeFromSuperview()
+
+    let transitionView = UIView(frame: bounds)
+    transitionView.isUserInteractionEnabled = false
+    transitionView.backgroundColor = .black
+
+    if let snapshot = snapshotView(afterScreenUpdates: false) {
+      snapshot.frame = transitionView.bounds
+      transitionView.addSubview(snapshot)
+    }
+
+    let blurView = UIVisualEffectView(effect: UIBlurEffect(style: .systemUltraThinMaterialDark))
+    blurView.frame = transitionView.bounds
+    blurView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+    transitionView.addSubview(blurView)
+
+    insertSubview(transitionView, belowSubview: labelName)
+    cameraTransitionView = transitionView
   }
 
   private func hideCameraTransitionBlur() {
+    guard let transitionView = cameraTransitionView else { return }
+    cameraTransitionView = nil
     UIView.animate(
       withDuration: 0.18,
       delay: 0.06,
       options: [.beginFromCurrentState, .curveEaseOut]
     ) {
-      self.cameraTransitionBlurView.alpha = 0
+      transitionView.alpha = 0
+    } completion: { _ in
+      transitionView.removeFromSuperview()
     }
   }
 

--- a/Sources/YOLO/YOLOView.swift
+++ b/Sources/YOLO/YOLOView.swift
@@ -108,6 +108,8 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   let selection = UISelectionFeedbackGenerator()
   private let lensControl = UISegmentedControl()
   private let lensCaptionLabel = UILabel()
+  private let cameraTransitionBlurView = UIVisualEffectView(
+    effect: UIBlurEffect(style: .systemUltraThinMaterialDark))
   private var lensDevices = [AVCaptureDevice]()
   private var selectedLensDeviceID: String?
   private var cameraSwitchInProgress = false
@@ -597,6 +599,10 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   }
 
   private func setupUI() {
+    cameraTransitionBlurView.alpha = 0
+    cameraTransitionBlurView.isUserInteractionEnabled = false
+    self.addSubview(cameraTransitionBlurView)
+
     labelName.text = processString(modelName)
     labelName.textAlignment = .center
     labelName.font = UIFont.systemFont(ofSize: 24, weight: .medium)
@@ -724,6 +730,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     }
 
     self.videoCapture.previewLayer?.frame = self.bounds
+    cameraTransitionBlurView.frame = self.bounds
   }
 
   /// Apply consistent toolbar and button styling
@@ -1016,8 +1023,12 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
 
   private func switchToCamera(_ device: AVCaptureDevice) {
     guard !cameraSwitchInProgress else { return }
+    let changesPosition = videoCapture.captureDevice?.position != device.position
     cameraSwitchInProgress = true
     setCameraControlsEnabled(false)
+    if changesPosition {
+      showCameraTransitionBlur()
+    }
 
     videoCapture.selectCaptureDevice(device, videoOrientation: currentVideoOrientation()) {
       [weak self] success in
@@ -1025,6 +1036,10 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
 
       self.cameraSwitchInProgress = false
       self.setCameraControlsEnabled(true)
+      if changesPosition {
+        self.applyPreviewConnection(for: self.videoCapture.captureDevice ?? device)
+        self.hideCameraTransitionBlur()
+      }
 
       guard success else {
         self.updateLensControl()
@@ -1040,6 +1055,32 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
       self.labelZoom.text = self.zoomLabelText(rawZoomFactor: rawZoomFactor, device: activeDevice)
       self.updateLensControl()
     }
+  }
+
+  private func showCameraTransitionBlur() {
+    cameraTransitionBlurView.frame = bounds
+    cameraTransitionBlurView.isHidden = false
+    cameraTransitionBlurView.alpha = 1
+  }
+
+  private func hideCameraTransitionBlur() {
+    UIView.animate(
+      withDuration: 0.18,
+      delay: 0.06,
+      options: [.beginFromCurrentState, .curveEaseOut]
+    ) {
+      self.cameraTransitionBlurView.alpha = 0
+    }
+  }
+
+  private func applyPreviewConnection(for device: AVCaptureDevice) {
+    guard let connection = videoCapture.previewLayer?.connection else { return }
+    if connection.isVideoOrientationSupported {
+      connection.videoOrientation = currentVideoOrientation()
+    }
+    guard connection.isVideoMirroringSupported else { return }
+    connection.automaticallyAdjustsVideoMirroring = false
+    connection.isVideoMirrored = device.position == .front
   }
 
   private func setCameraControlsEnabled(_ isEnabled: Bool) {

--- a/Sources/YOLO/YOLOView.swift
+++ b/Sources/YOLO/YOLOView.swift
@@ -104,6 +104,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   public var pauseButton = UIButton()
   public var switchCameraButton = UIButton()
   public var shareButton = UIButton()
+  public var infoButton = UIButton()
   public var toolbar = UIView()
   let selection = UISelectionFeedbackGenerator()
   private let lensControl = UISegmentedControl()
@@ -651,12 +652,15 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
       UIImage(systemName: "camera.rotate", withConfiguration: config), for: .normal)
     shareButton.setImage(
       UIImage(systemName: "square.and.arrow.up", withConfiguration: config), for: .normal)
+    infoButton.setImage(UIImage(systemName: "info.circle", withConfiguration: config), for: .normal)
+    infoButton.accessibilityLabel = "Ultralytics"
 
     playButton.isEnabled = false
     pauseButton.isEnabled = true
     playButton.addTarget(self, action: #selector(playTapped), for: .touchUpInside)
     pauseButton.addTarget(self, action: #selector(pauseTapped), for: .touchUpInside)
     switchCameraButton.addTarget(self, action: #selector(switchCameraTapped), for: .touchUpInside)
+    infoButton.addTarget(self, action: #selector(infoTapped), for: .touchUpInside)
 
     setupToolbar()
     setupLensControl()
@@ -677,7 +681,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   /// Setup toolbar with consistent styling
   private func setupToolbar() {
     toolbar.backgroundColor = .black.withAlphaComponent(0.7)
-    [playButton, pauseButton, switchCameraButton, shareButton].forEach { button in
+    [playButton, pauseButton, switchCameraButton, shareButton, infoButton].forEach { button in
       button.tintColor = .white
       toolbar.addSubview(button)
     }
@@ -732,7 +736,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   private func applyToolbarStyling(isLandscape: Bool) {
     toolbar.backgroundColor = .black.withAlphaComponent(0.7)
     let buttonColor: UIColor = isLandscape ? .white : .white
-    [playButton, pauseButton, switchCameraButton, shareButton].forEach { button in
+    [playButton, pauseButton, switchCameraButton, shareButton, infoButton].forEach { button in
       button.tintColor = buttonColor
     }
   }
@@ -860,6 +864,9 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     shareButton.frame = CGRect(
       x: switchCameraButton.frame.maxX, y: 0, width: buttonHeight, height: buttonHeight
     )
+    infoButton.frame = CGRect(
+      x: width - buttonHeight, y: 0, width: buttonHeight, height: buttonHeight
+    )
   }
 
   private func layoutLensControl(width: CGFloat, height: CGFloat) {
@@ -868,7 +875,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     let controlHeight: CGFloat = 34
     let captionHeight: CGFloat = 14
     let zoomHeight: CGFloat = 18
-    let controlWidth = min(max(CGFloat(lensDevices.count) * 60, 104), width - 40)
+    let controlWidth = min(CGFloat(lensDevices.count) * 60, width - 40)
     lensControl.frame = CGRect(
       x: (width - controlWidth) / 2,
       y: height - toolBarHeight - controlHeight - 14,
@@ -1014,6 +1021,13 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
       return
     }
     switchToCamera(lensDevices[sender.selectedSegmentIndex])
+  }
+
+  @objc private func infoTapped() {
+    selection.selectionChanged()
+    if let url = URL(string: "https://www.ultralytics.com") {
+      UIApplication.shared.open(url)
+    }
   }
 
   private func switchToCamera(_ device: AVCaptureDevice) {

--- a/Sources/YOLO/YOLOView.swift
+++ b/Sources/YOLO/YOLOView.swift
@@ -864,7 +864,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
       x: switchCameraButton.frame.maxX, y: 0, width: buttonHeight, height: buttonHeight
     )
     infoButton.frame = CGRect(
-      x: shareButton.frame.maxX, y: 0, width: buttonHeight, height: buttonHeight
+      x: width - buttonHeight, y: 0, width: buttonHeight, height: buttonHeight
     )
   }
 

--- a/Sources/YOLO/YOLOView.swift
+++ b/Sources/YOLO/YOLOView.swift
@@ -109,6 +109,8 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   private let lensControl = UISegmentedControl()
   private let lensCaptionLabel = UILabel()
   private var lensDevices = [AVCaptureDevice]()
+  private var selectedLensDeviceID: String?
+  private var cameraSwitchInProgress = false
   private var overlayLayer = CALayer()
   private var maskLayer: CALayer?
   private var poseLayer: CALayer?
@@ -950,7 +952,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     switch pinch.state {
     case .began, .changed:
       update(scale: newScaleFactor)
-      self.labelZoom.text = String(format: "%.2fx", newScaleFactor)
+      self.labelZoom.text = zoomLabelText(rawZoomFactor: newScaleFactor, device: device)
       self.labelZoom.font = UIFont.preferredFont(forTextStyle: .title2)
     case .ended:
       lastZoomFactor = minMaxZoom(newScaleFactor)
@@ -994,14 +996,40 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   }
 
   private func switchToCamera(_ device: AVCaptureDevice) {
-    guard videoCapture.selectCaptureDevice(device, orientation: UIDevice.current.orientation) else {
-      updateLensControl()
-      return
-    }
+    guard !cameraSwitchInProgress else { return }
+    cameraSwitchInProgress = true
+    setCameraControlsEnabled(false)
 
-    lastZoomFactor = min(max(device.videoZoomFactor, minimumZoom), maximumZoom)
-    labelZoom.text = String(format: "%.2fx", lastZoomFactor)
-    updateLensControl()
+    videoCapture.selectCaptureDevice(device, orientation: UIDevice.current.orientation) {
+      [weak self] success in
+      guard let self else { return }
+
+      self.cameraSwitchInProgress = false
+      self.setCameraControlsEnabled(true)
+
+      guard success else {
+        self.updateLensControl()
+        return
+      }
+
+      self.selectedLensDeviceID = device.position == .back ? device.uniqueID : nil
+      let activeDevice = self.videoCapture.captureDevice ?? device
+      let rawZoomFactor =
+        zoomFactor(for: device, on: activeDevice)
+        ?? min(max(activeDevice.videoZoomFactor, self.minimumZoom), self.maximumZoom)
+      self.lastZoomFactor = rawZoomFactor
+      self.labelZoom.text = self.zoomLabelText(rawZoomFactor: rawZoomFactor, device: activeDevice)
+      self.updateLensControl()
+    }
+  }
+
+  private func setCameraControlsEnabled(_ isEnabled: Bool) {
+    switchCameraButton.isEnabled = isEnabled
+    lensControl.isEnabled = isEnabled
+    UIView.animate(withDuration: 0.12) {
+      self.switchCameraButton.alpha = isEnabled ? 1 : 0.45
+      self.lensControl.alpha = isEnabled ? 1 : 0.55
+    }
   }
 
   private func updateLensControl() {
@@ -1011,10 +1039,16 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     if let currentDevice, !lensDevices.contains(where: { $0.uniqueID == currentDevice.uniqueID }) {
       lensDevices.append(currentDevice)
     }
+    if let selectedLensDeviceID,
+      !lensDevices.contains(where: { $0.uniqueID == selectedLensDeviceID })
+    {
+      self.selectedLensDeviceID = nil
+    }
     lensControl.removeAllSegments()
 
     guard lensDevices.count > 1 else {
-      lensCaptionLabel.text = currentDevice.map { lensCaption(for: $0) }
+      let selectedDevice = selectedLensDevice() ?? currentDevice
+      lensCaptionLabel.text = selectedDevice.map { lensCaption(for: $0) }
       updateLensControlVisibility()
       setNeedsLayout()
       return
@@ -1024,10 +1058,11 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
       lensControl.insertSegment(withTitle: lensTitle(for: device), at: index, animated: false)
     }
 
+    let selectedDeviceID = selectedLensDeviceID ?? currentDevice?.uniqueID
     lensControl.selectedSegmentIndex =
-      lensDevices.firstIndex { $0.uniqueID == currentDevice?.uniqueID }
+      lensDevices.firstIndex { $0.uniqueID == selectedDeviceID }
       ?? UISegmentedControl.noSegment
-    lensCaptionLabel.text = currentDevice.map { lensCaption(for: $0) }
+    lensCaptionLabel.text = selectedLensDevice().map { lensCaption(for: $0) }
     updateLensControlVisibility()
     setNeedsLayout()
   }
@@ -1040,12 +1075,41 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
 
   private func lensTitle(for device: AVCaptureDevice) -> String {
     switch device.deviceType {
-    case .builtInUltraWideCamera: return "0.5"
-    case .builtInWideAngleCamera: return "1"
-    case .builtInTelephotoCamera: return "2"
+    case .builtInUltraWideCamera, .builtInWideAngleCamera, .builtInTelephotoCamera:
+      if let displayZoomFactor = displayZoomFactor(
+        for: device, activeDevice: videoCapture.captureDevice)
+      {
+        return zoomTitle(displayZoomFactor)
+      }
+      return fallbackLensTitle(for: device)
     case .builtInDualWideCamera, .builtInDualCamera, .builtInTripleCamera: return "Default"
     default: return device.localizedName
     }
+  }
+
+  private func fallbackLensTitle(for device: AVCaptureDevice) -> String {
+    switch device.deviceType {
+    case .builtInUltraWideCamera: return "0.5"
+    case .builtInWideAngleCamera: return "1"
+    case .builtInTelephotoCamera: return "2"
+    default: return device.localizedName
+    }
+  }
+
+  private func zoomTitle(_ zoomFactor: CGFloat) -> String {
+    let roundedZoom = (zoomFactor * 10).rounded() / 10
+    return roundedZoom.truncatingRemainder(dividingBy: 1) == 0
+      ? String(format: "%.0f", roundedZoom)
+      : String(format: "%.1f", roundedZoom)
+  }
+
+  private func zoomLabelText(rawZoomFactor: CGFloat, device: AVCaptureDevice) -> String {
+    String(format: "%.2fx", displayZoomFactor(rawZoomFactor, for: device))
+  }
+
+  private func selectedLensDevice() -> AVCaptureDevice? {
+    guard let selectedLensDeviceID else { return videoCapture.captureDevice }
+    return lensDevices.first { $0.uniqueID == selectedLensDeviceID } ?? videoCapture.captureDevice
   }
 
   private func lensCaption(for device: AVCaptureDevice) -> String {

--- a/Sources/YOLO/YOLOView.swift
+++ b/Sources/YOLO/YOLOView.swift
@@ -894,9 +894,22 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   }
 
   @objc func orientationDidChange() {
-    guard let orientation = AVCaptureVideoOrientation(UIDevice.current.orientation) else { return }
-    videoCapture.updateVideoOrientation(orientation: orientation)
+    videoCapture.updateVideoOrientation(orientation: currentVideoOrientation())
     videoCapture.frameSizeCaptured = false
+  }
+
+  private func currentVideoOrientation() -> AVCaptureVideoOrientation {
+    if let interfaceOrientation = window?.windowScene?.interfaceOrientation,
+      let videoOrientation = AVCaptureVideoOrientation(interfaceOrientation)
+    {
+      return videoOrientation
+    }
+
+    if let videoOrientation = AVCaptureVideoOrientation(UIDevice.current.orientation) {
+      return videoOrientation
+    }
+
+    return videoCapture.previewLayer?.connection?.videoOrientation ?? .portrait
   }
 
   @objc public func sliderChanged(_ sender: Any) {
@@ -1006,7 +1019,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     cameraSwitchInProgress = true
     setCameraControlsEnabled(false)
 
-    videoCapture.selectCaptureDevice(device, orientation: UIDevice.current.orientation) {
+    videoCapture.selectCaptureDevice(device, videoOrientation: currentVideoOrientation()) {
       [weak self] success in
       guard let self else { return }
 

--- a/Sources/YOLO/YOLOView.swift
+++ b/Sources/YOLO/YOLOView.swift
@@ -1033,7 +1033,8 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   }
 
   private func updateLensControlVisibility() {
-    lensControl.isHidden = switchCameraButton.isHidden || lensDevices.count <= 1
+    let isFrontCamera = videoCapture.captureDevice?.position == .front
+    lensControl.isHidden = switchCameraButton.isHidden || isFrontCamera || lensDevices.count <= 1
     lensCaptionLabel.isHidden = lensControl.isHidden
   }
 

--- a/Sources/YOLO/YOLOView.swift
+++ b/Sources/YOLO/YOLOView.swift
@@ -752,7 +752,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     let totalSliderHeight = (sliderHeight + 3) * 6
     let startY = height - bottomMargin - totalSliderHeight
 
-    let thresholdStartY = startY + (sliderHeight + 3) * 2
+    let thresholdStartY = startY + (sliderHeight + 3) * 2 + 10
 
     labelSliderConf.frame = CGRect(
       x: width * 0.1, y: thresholdStartY,
@@ -805,7 +805,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
 
     let cameraControlsOffset: CGFloat = lensControl.isHidden ? 0 : 64
     let thresholdStartY =
-      center.y + height * 0.16 + sliderHeight * 2 + 20 - cameraControlsOffset
+      center.y + height * 0.16 + sliderHeight * 2 + 40 - cameraControlsOffset
 
     labelSliderConf.frame = CGRect(
       x: leftPadding, y: thresholdStartY,
@@ -1038,15 +1038,14 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     let position = currentDevice?.position ?? .back
     lensDevices =
       position == .front ? currentDevice.map { [$0] } ?? [] : captureDevices(position: position)
-    if position == .back, let currentDevice,
-      !lensDevices.contains(where: { $0.uniqueID == currentDevice.uniqueID })
-    {
-      lensDevices.append(currentDevice)
-    }
     if let selectedLensDeviceID,
       !lensDevices.contains(where: { $0.uniqueID == selectedLensDeviceID })
     {
       self.selectedLensDeviceID = nil
+    }
+    if position == .back, let currentDevice, selectedLensDeviceID == nil {
+      selectedLensDeviceID = lensDevice(
+        rawZoomFactor: currentDevice.videoZoomFactor, device: currentDevice)?.uniqueID
     }
     lensControl.removeAllSegments()
 
@@ -1081,7 +1080,6 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
         return zoomTitle(displayZoomFactor)
       }
       return fallbackLensTitle(for: device)
-    case .builtInDualWideCamera, .builtInDualCamera, .builtInTripleCamera: return "Default"
     default: return device.localizedName
     }
   }
@@ -1117,19 +1115,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
       return
     }
 
-    let lensZooms = lensDevices.compactMap { lens -> (device: AVCaptureDevice, zoom: CGFloat)? in
-      guard isPhysicalRearLens(lens), let zoom = zoomFactor(for: lens, on: device)
-      else {
-        return nil
-      }
-      return (lens, zoom)
-    }.sorted { $0.zoom < $1.zoom }
-
-    guard
-      let selectedLens =
-        lensZooms.last(where: { rawZoomFactor >= $0.zoom - 0.01 })?.device
-        ?? lensZooms.first?.device
-    else {
+    guard let selectedLens = lensDevice(rawZoomFactor: rawZoomFactor, device: device) else {
       return
     }
 
@@ -1138,6 +1124,19 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
       lensDevices.firstIndex { $0.uniqueID == selectedLens.uniqueID }
       ?? UISegmentedControl.noSegment
     lensCaptionLabel.text = lensCaption(for: selectedLens)
+  }
+
+  private func lensDevice(rawZoomFactor: CGFloat, device: AVCaptureDevice) -> AVCaptureDevice? {
+    let lensZooms = lensDevices.compactMap { lens -> (device: AVCaptureDevice, zoom: CGFloat)? in
+      guard isPhysicalRearLens(lens), let zoom = zoomFactor(for: lens, on: device)
+      else {
+        return nil
+      }
+      return (lens, zoom)
+    }.sorted { $0.zoom < $1.zoom }
+
+    return lensZooms.last(where: { rawZoomFactor >= $0.zoom - 0.01 })?.device
+      ?? lensZooms.first?.device
   }
 
   private func isPhysicalRearLens(_ device: AVCaptureDevice) -> Bool {
@@ -1158,8 +1157,6 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     case .builtInUltraWideCamera: return "Ultra wide camera"
     case .builtInWideAngleCamera: return "Wide camera"
     case .builtInTelephotoCamera: return "Telephoto camera"
-    case .builtInDualWideCamera, .builtInDualCamera, .builtInTripleCamera:
-      return "Default back camera"
     default: return device.localizedName
     }
   }

--- a/Sources/YOLO/YOLOView.swift
+++ b/Sources/YOLO/YOLOView.swift
@@ -852,20 +852,24 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   private func layoutToolbarButtons(width: CGFloat, height: CGFloat) {
     let toolBarHeight: CGFloat = 66
     let buttonHeight: CGFloat = toolBarHeight * 0.75
+    let buttonY = (toolBarHeight - buttonHeight) / 2
+    let horizontalInset: CGFloat = 8
 
     toolbar.frame = CGRect(x: 0, y: height - toolBarHeight, width: width, height: toolBarHeight)
-    playButton.frame = CGRect(x: 0, y: 0, width: buttonHeight, height: buttonHeight)
+    playButton.frame = CGRect(
+      x: horizontalInset, y: buttonY, width: buttonHeight, height: buttonHeight
+    )
     pauseButton.frame = CGRect(
-      x: playButton.frame.maxX, y: 0, width: buttonHeight, height: buttonHeight
+      x: playButton.frame.maxX, y: buttonY, width: buttonHeight, height: buttonHeight
     )
     switchCameraButton.frame = CGRect(
-      x: pauseButton.frame.maxX, y: 0, width: buttonHeight, height: buttonHeight
+      x: pauseButton.frame.maxX, y: buttonY, width: buttonHeight, height: buttonHeight
     )
     shareButton.frame = CGRect(
-      x: switchCameraButton.frame.maxX, y: 0, width: buttonHeight, height: buttonHeight
+      x: switchCameraButton.frame.maxX, y: buttonY, width: buttonHeight, height: buttonHeight
     )
     infoButton.frame = CGRect(
-      x: width - buttonHeight, y: 0, width: buttonHeight, height: buttonHeight
+      x: width - horizontalInset - buttonHeight, y: buttonY, width: buttonHeight, height: buttonHeight
     )
   }
 

--- a/Sources/YOLO/YOLOView.swift
+++ b/Sources/YOLO/YOLOView.swift
@@ -253,6 +253,11 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
               self.pendingCameraPosition = nil
               self.switchCameraTapped()
             }
+            if let device = self.videoCapture.captureDevice {
+              self.lastZoomFactor = device.videoZoomFactor
+              self.labelZoom.text = self.zoomLabelText(
+                rawZoomFactor: self.lastZoomFactor, device: device)
+            }
             self.updateLensControl()
 
             self.busy = false

--- a/Sources/YOLO/YOLOView.swift
+++ b/Sources/YOLO/YOLOView.swift
@@ -25,6 +25,8 @@ public protocol YOLOViewDelegate: AnyObject {
 
 }
 
+private let defaultMaxDetectionItems = 100
+
 /// A UIView component that provides real-time object detection, segmentation, and pose estimation capabilities.
 @MainActor
 public final class YOLOView: UIView, VideoCaptureDelegate {
@@ -104,6 +106,8 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   public var shareButton = UIButton()
   public var toolbar = UIView()
   let selection = UISelectionFeedbackGenerator()
+  private let lensControl = UISegmentedControl()
+  private var lensDevices = [AVCaptureDevice]()
   private var overlayLayer = CALayer()
   private var maskLayer: CALayer?
   private var poseLayer: CALayer?
@@ -208,6 +212,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
         switch result {
         case .success(let predictor):
           self.videoCapture.predictor = predictor
+          predictor.setNumItemsThreshold(numItems: self.getNumItemsThreshold())
           self.labelName.text = processString(self.modelName)
           if task == .obb { self.obbLayer?.isHidden = false }
           completion?(.success(()))
@@ -245,6 +250,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
               self.pendingCameraPosition = nil
               self.switchCameraTapped()
             }
+            self.updateLensControl()
 
             self.busy = false
           }
@@ -264,7 +270,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   // MARK: - Threshold Configuration Methods
 
   /// Sets the maximum number of detection items to include in results.
-  /// - Parameter numItems: The maximum number of items to include (default is 30).
+  /// - Parameter numItems: The maximum number of items to include (default is 100).
   public func setNumItemsThreshold(_ numItems: Int) {
     sliderNumItems.value = Float(numItems)
     (videoCapture.predictor as? BasePredictor)?.setNumItemsThreshold(numItems: numItems)
@@ -432,11 +438,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   func showBoxes(predictions: YOLOResult) {
     let width = self.bounds.width
     let height = self.bounds.height
-    let resultCount = predictions.boxes.count
-    let maxVisible = min(resultCount, 50, boundingBoxViews.count)
-
-    self.labelSliderNumItems.text =
-      "\(resultCount) items (max \(Int(sliderNumItems.value)))"
+    let maxVisible = min(predictions.boxes.count, 50, boundingBoxViews.count)
 
     if UIDevice.current.orientation.isLandscape {
       let frameAspect = videoCapture.longSide / videoCapture.shortSide
@@ -600,14 +602,9 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     labelFPS.font = UIFont.preferredFont(forTextStyle: .body)
     self.addSubview(labelFPS)
 
-    labelSliderNumItems.text = "0 items (max 30)"
-    labelSliderNumItems.textAlignment = .left
-    labelSliderNumItems.textColor = .white
-    labelSliderNumItems.font = UIFont.preferredFont(forTextStyle: .subheadline)
-    self.addSubview(labelSliderNumItems)
-
-    configureSlider(sliderNumItems, min: 1, max: 100, value: 30)
-    self.addSubview(sliderNumItems)
+    labelSliderNumItems.isHidden = true
+    configureSlider(sliderNumItems, min: 1, max: 100, value: Float(defaultMaxDetectionItems))
+    sliderNumItems.isHidden = true
 
     labelSliderConf.text = "0.25 Confidence Threshold"
     labelSliderConf.textAlignment = .left
@@ -627,7 +624,6 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     configureSlider(sliderIoU, min: 0, max: 1, value: 0.7)
     self.addSubview(sliderIoU)
 
-    self.labelSliderNumItems.text = "0 items (max " + String(Int(sliderNumItems.value)) + ")"
     self.labelSliderConf.text = "0.25 Confidence Threshold"
     self.labelSliderIoU.text = "0.70 IoU Threshold"
 
@@ -655,6 +651,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     switchCameraButton.addTarget(self, action: #selector(switchCameraTapped), for: .touchUpInside)
 
     setupToolbar()
+    setupLensControl()
 
     self.addGestureRecognizer(UIPinchGestureRecognizer(target: self, action: #selector(pinch)))
   }
@@ -679,6 +676,24 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     self.addSubview(toolbar)
   }
 
+  private func setupLensControl() {
+    lensControl.isHidden = true
+    lensControl.backgroundColor = UIColor.black.withAlphaComponent(0.38)
+    lensControl.selectedSegmentTintColor = UIColor.white.withAlphaComponent(0.18)
+    lensControl.setTitleTextAttributes(
+      [
+        .foregroundColor: UIColor.white,
+        .font: UIFont.systemFont(ofSize: 13, weight: .semibold),
+      ], for: .normal)
+    lensControl.setTitleTextAttributes(
+      [
+        .foregroundColor: UIColor.systemYellow,
+        .font: UIFont.systemFont(ofSize: 13, weight: .bold),
+      ], for: .selected)
+    lensControl.addTarget(self, action: #selector(lensChanged(_:)), for: .valueChanged)
+    self.addSubview(lensControl)
+  }
+
   public override func layoutSubviews() {
     super.layoutSubviews()
     setupOverlayLayer()
@@ -687,6 +702,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
 
     // Apply consistent toolbar styling
     applyToolbarStyling(isLandscape: isLandscape)
+    updateLensControlVisibility()
 
     if isLandscape {
       layoutLandscape()
@@ -728,18 +744,10 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     let totalSliderHeight = (sliderHeight + 3) * 6
     let startY = height - bottomMargin - totalSliderHeight
 
-    labelSliderNumItems.frame = CGRect(
-      x: width * 0.1, y: startY,
-      width: sliderWidth, height: sliderHeight
-    )
-
-    sliderNumItems.frame = CGRect(
-      x: width * 0.1, y: labelSliderNumItems.frame.maxY + 3,
-      width: sliderWidth, height: sliderHeight
-    )
+    let thresholdStartY = startY + (sliderHeight + 3) * 2
 
     labelSliderConf.frame = CGRect(
-      x: width * 0.1, y: sliderNumItems.frame.maxY + 3,
+      x: width * 0.1, y: thresholdStartY,
       width: sliderWidth * 1.5, height: sliderHeight
     )
 
@@ -765,6 +773,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     )
 
     layoutToolbarButtons(width: width, height: height)
+    layoutLensControl(width: width, height: height)
   }
 
   /// Layout views for portrait orientation
@@ -786,18 +795,10 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     let sliderHeight: CGFloat = height * 0.02
     let leftPadding: CGFloat = 20
 
-    labelSliderNumItems.frame = CGRect(
-      x: leftPadding, y: center.y + height * 0.16,
-      width: sliderWidth, height: sliderHeight
-    )
-
-    sliderNumItems.frame = CGRect(
-      x: leftPadding, y: labelSliderNumItems.frame.maxY + 10,
-      width: sliderWidth, height: sliderHeight
-    )
+    let thresholdStartY = center.y + height * 0.16 + sliderHeight * 2 + 20
 
     labelSliderConf.frame = CGRect(
-      x: leftPadding, y: sliderNumItems.frame.maxY + 10,
+      x: leftPadding, y: thresholdStartY,
       width: sliderWidth * 1.5, height: sliderHeight
     )
 
@@ -823,6 +824,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     )
 
     layoutToolbarButtons(width: width, height: height)
+    layoutLensControl(width: width, height: height)
   }
 
   /// Layout toolbar buttons (shared between orientations)
@@ -840,6 +842,19 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     )
     shareButton.frame = CGRect(
       x: switchCameraButton.frame.maxX, y: 0, width: buttonHeight, height: buttonHeight
+    )
+  }
+
+  private func layoutLensControl(width: CGFloat, height: CGFloat) {
+    guard !lensControl.isHidden else { return }
+    let toolBarHeight: CGFloat = 66
+    let controlHeight: CGFloat = 34
+    let controlWidth = min(max(CGFloat(lensDevices.count) * 52, 104), width - 40)
+    lensControl.frame = CGRect(
+      x: (width - controlWidth) / 2,
+      y: height - toolBarHeight - controlHeight - 16,
+      width: controlWidth,
+      height: controlHeight
     )
   }
 
@@ -862,7 +877,6 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     if slider === sliderNumItems {
       let numItems = Int(sliderNumItems.value)
       predictor?.setNumItemsThreshold(numItems: numItems)
-      updateNumItemsLabel(max: numItems)
     } else if slider === sliderConf {
       let conf = Double(round(100 * sliderConf.value)) / 100
       self.labelSliderConf.text = String(format: "%.2f Confidence Threshold", conf)
@@ -874,13 +888,6 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     }
   }
 
-  /// Rewrites the numItems label, keeping any existing "current count" prefix intact.
-  private func updateNumItemsLabel(max numItems: Int) {
-    let current = self.labelSliderNumItems.text ?? ""
-    let countPrefix = current.range(of: " items").map { String(current[..<$0.lowerBound]) } ?? "0"
-    self.labelSliderNumItems.text = "\(countPrefix) items (max \(numItems))"
-  }
-
   /// Update thresholds programmatically (for external display sync).
   public func updateThresholds(conf: Double, iou: Double, numItems: Int) {
     sliderConf.value = Float(conf)
@@ -888,7 +895,6 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     sliderNumItems.value = Float(numItems)
     self.labelSliderConf.text = String(format: "%.2f Confidence Threshold", conf)
     self.labelSliderIoU.text = String(format: "%.2f IoU Threshold", iou)
-    updateNumItemsLabel(max: numItems)
 
     if let predictor = videoCapture.predictor as? BasePredictor {
       predictor.setConfidenceThreshold(confidence: conf)
@@ -948,35 +954,72 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   @objc func switchCameraTapped() {
     selection.selectionChanged()
 
-    self.videoCapture.captureSession.beginConfiguration()
-    guard let currentInput = self.videoCapture.captureSession.inputs.first as? AVCaptureDeviceInput
-    else {
-      self.videoCapture.captureSession.commitConfiguration()
-      return
-    }
-    self.videoCapture.captureSession.removeInput(currentInput)
-    let currentPosition = currentInput.device.position
-
+    let currentPosition = videoCapture.captureDevice?.position ?? .back
     let nextCameraPosition: AVCaptureDevice.Position = currentPosition == .back ? .front : .back
+    guard let newCameraDevice = bestCaptureDevice(position: nextCameraPosition) else { return }
+    switchToCamera(newCameraDevice)
+  }
 
-    guard let newCameraDevice = bestCaptureDevice(position: nextCameraPosition) else {
-      self.videoCapture.captureSession.commitConfiguration()
+  @objc private func lensChanged(_ sender: UISegmentedControl) {
+    selection.selectionChanged()
+    guard sender.selectedSegmentIndex >= 0,
+      sender.selectedSegmentIndex < lensDevices.count
+    else {
+      return
+    }
+    switchToCamera(lensDevices[sender.selectedSegmentIndex])
+  }
+
+  private func switchToCamera(_ device: AVCaptureDevice) {
+    guard videoCapture.selectCaptureDevice(device, orientation: UIDevice.current.orientation) else {
+      updateLensControl()
       return
     }
 
-    guard let videoInput1 = try? AVCaptureDeviceInput(device: newCameraDevice) else {
-      self.videoCapture.captureSession.commitConfiguration()
+    lastZoomFactor = min(max(device.videoZoomFactor, minimumZoom), maximumZoom)
+    labelZoom.text = String(format: "%.2fx", lastZoomFactor)
+    updateLensControl()
+  }
+
+  private func updateLensControl() {
+    let currentDevice = videoCapture.captureDevice
+    let position = currentDevice?.position ?? .back
+    lensDevices = captureDevices(position: position)
+    if let currentDevice, !lensDevices.contains(where: { $0.uniqueID == currentDevice.uniqueID }) {
+      lensDevices.append(currentDevice)
+    }
+    lensControl.removeAllSegments()
+
+    guard lensDevices.count > 1 else {
+      updateLensControlVisibility()
+      setNeedsLayout()
       return
     }
 
-    self.videoCapture.captureSession.addInput(videoInput1)
-    guard let orientation = AVCaptureVideoOrientation(UIDevice.current.orientation) else {
-      self.videoCapture.captureSession.commitConfiguration()
-      return
+    for (index, device) in lensDevices.enumerated() {
+      lensControl.insertSegment(withTitle: lensTitle(for: device), at: index, animated: false)
     }
-    self.videoCapture.updateVideoOrientation(orientation: orientation)
 
-    self.videoCapture.captureSession.commitConfiguration()
+    lensControl.selectedSegmentIndex =
+      lensDevices.firstIndex { $0.uniqueID == currentDevice?.uniqueID }
+      ?? UISegmentedControl.noSegment
+    updateLensControlVisibility()
+    setNeedsLayout()
+  }
+
+  private func updateLensControlVisibility() {
+    lensControl.isHidden = switchCameraButton.isHidden || lensDevices.count <= 1
+  }
+
+  private func lensTitle(for device: AVCaptureDevice) -> String {
+    switch device.deviceType {
+    case .builtInUltraWideCamera: return "0.5"
+    case .builtInWideAngleCamera: return "1"
+    case .builtInTelephotoCamera: return "2"
+    case .builtInTrueDepthCamera: return "Front"
+    case .builtInDualWideCamera, .builtInDualCamera, .builtInTripleCamera: return "Auto"
+    default: return device.localizedName
+    }
   }
 
   public func capturePhoto(completion: @escaping (UIImage?) -> Void) {

--- a/Sources/YOLO/YOLOView.swift
+++ b/Sources/YOLO/YOLOView.swift
@@ -1128,9 +1128,10 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
       return (lens, zoom)
     }.sorted { $0.zoom < $1.zoom }
 
-    guard let selectedLens =
-      lensZooms.last(where: { rawZoomFactor >= $0.zoom - 0.01 })?.device
-      ?? lensZooms.first?.device
+    guard
+      let selectedLens =
+        lensZooms.last(where: { rawZoomFactor >= $0.zoom - 0.01 })?.device
+        ?? lensZooms.first?.device
     else {
       return
     }

--- a/Sources/YOLO/YOLOView.swift
+++ b/Sources/YOLO/YOLOView.swift
@@ -632,9 +632,8 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
 
     labelZoom.text = "1.00x"
     labelZoom.textColor = .white
-    labelZoom.font = UIFont.systemFont(ofSize: 14)
+    labelZoom.font = UIFont.systemFont(ofSize: 12, weight: .semibold)
     labelZoom.textAlignment = .center
-    labelZoom.font = UIFont.preferredFont(forTextStyle: .body)
     self.addSubview(labelZoom)
 
     let config = UIImage.SymbolConfiguration(pointSize: 20, weight: .regular, scale: .default)
@@ -861,7 +860,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     let toolBarHeight: CGFloat = 66
     let controlHeight: CGFloat = 34
     let captionHeight: CGFloat = 14
-    let zoomHeight: CGFloat = max(height * 0.035, 28)
+    let zoomHeight: CGFloat = 18
     let controlWidth = min(max(CGFloat(lensDevices.count) * 60, 104), width - 40)
     lensControl.frame = CGRect(
       x: (width - controlWidth) / 2,
@@ -877,7 +876,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     )
     labelZoom.frame = CGRect(
       x: center.x - 50,
-      y: lensCaptionLabel.frame.minY - zoomHeight - 8,
+      y: lensCaptionLabel.frame.minY - zoomHeight - 2,
       width: 100,
       height: zoomHeight
     )
@@ -954,12 +953,12 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
       update(scale: newScaleFactor)
       self.labelZoom.text = zoomLabelText(rawZoomFactor: newScaleFactor, device: device)
       updateSelectedLens(rawZoomFactor: newScaleFactor, device: device)
-      self.labelZoom.font = UIFont.preferredFont(forTextStyle: .title2)
+      self.labelZoom.font = UIFont.systemFont(ofSize: 12, weight: .semibold)
     case .ended:
       lastZoomFactor = minMaxZoom(newScaleFactor)
       update(scale: lastZoomFactor)
       updateSelectedLens(rawZoomFactor: lastZoomFactor, device: device)
-      self.labelZoom.font = UIFont.preferredFont(forTextStyle: .body)
+      self.labelZoom.font = UIFont.systemFont(ofSize: 12, weight: .semibold)
     default: break
     }
   }
@@ -1037,8 +1036,10 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   private func updateLensControl() {
     let currentDevice = videoCapture.captureDevice
     let position = currentDevice?.position ?? .back
-    lensDevices = captureDevices(position: position)
-    if let currentDevice, !lensDevices.contains(where: { $0.uniqueID == currentDevice.uniqueID }) {
+    lensDevices = position == .front ? currentDevice.map { [$0] } ?? [] : captureDevices(position: position)
+    if position == .back, let currentDevice,
+      !lensDevices.contains(where: { $0.uniqueID == currentDevice.uniqueID })
+    {
       lensDevices.append(currentDevice)
     }
     if let selectedLensDeviceID,
@@ -1047,14 +1048,6 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
       self.selectedLensDeviceID = nil
     }
     lensControl.removeAllSegments()
-
-    guard lensDevices.count > 1 else {
-      let selectedDevice = selectedLensDevice() ?? currentDevice
-      lensCaptionLabel.text = selectedDevice.map { lensCaption(for: $0) }
-      updateLensControlVisibility()
-      setNeedsLayout()
-      return
-    }
 
     for (index, device) in lensDevices.enumerated() {
       lensControl.insertSegment(withTitle: lensTitle(for: device), at: index, animated: false)
@@ -1070,12 +1063,15 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   }
 
   private func updateLensControlVisibility() {
-    let isFrontCamera = videoCapture.captureDevice?.position == .front
-    lensControl.isHidden = switchCameraButton.isHidden || isFrontCamera || lensDevices.count <= 1
+    lensControl.isHidden = switchCameraButton.isHidden || lensDevices.isEmpty
     lensCaptionLabel.isHidden = lensControl.isHidden
   }
 
   private func lensTitle(for device: AVCaptureDevice) -> String {
+    if device.position == .front {
+      return "1"
+    }
+
     switch device.deviceType {
     case .builtInUltraWideCamera, .builtInWideAngleCamera, .builtInTelephotoCamera:
       if let displayZoomFactor = displayZoomFactor(
@@ -1153,6 +1149,10 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   }
 
   private func lensCaption(for device: AVCaptureDevice) -> String {
+    if device.position == .front {
+      return "Front camera"
+    }
+
     switch device.deviceType {
     case .builtInUltraWideCamera: return "Ultra wide camera"
     case .builtInWideAngleCamera: return "Wide camera"

--- a/Sources/YOLO/YOLOView.swift
+++ b/Sources/YOLO/YOLOView.swift
@@ -654,7 +654,6 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
       UIImage(systemName: "square.and.arrow.up", withConfiguration: config), for: .normal)
     infoButton.setImage(UIImage(systemName: "info.circle", withConfiguration: config), for: .normal)
     infoButton.accessibilityLabel = "Ultralytics"
-
     playButton.isEnabled = false
     pauseButton.isEnabled = true
     playButton.addTarget(self, action: #selector(playTapped), for: .touchUpInside)
@@ -852,25 +851,20 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   private func layoutToolbarButtons(width: CGFloat, height: CGFloat) {
     let toolBarHeight: CGFloat = 66
     let buttonHeight: CGFloat = toolBarHeight * 0.75
-    let buttonY = (toolBarHeight - buttonHeight) / 2
-    let horizontalInset: CGFloat = 8
 
     toolbar.frame = CGRect(x: 0, y: height - toolBarHeight, width: width, height: toolBarHeight)
-    playButton.frame = CGRect(
-      x: horizontalInset, y: buttonY, width: buttonHeight, height: buttonHeight
-    )
+    playButton.frame = CGRect(x: 0, y: 0, width: buttonHeight, height: buttonHeight)
     pauseButton.frame = CGRect(
-      x: playButton.frame.maxX, y: buttonY, width: buttonHeight, height: buttonHeight
+      x: playButton.frame.maxX, y: 0, width: buttonHeight, height: buttonHeight
     )
     switchCameraButton.frame = CGRect(
-      x: pauseButton.frame.maxX, y: buttonY, width: buttonHeight, height: buttonHeight
+      x: pauseButton.frame.maxX, y: 0, width: buttonHeight, height: buttonHeight
     )
     shareButton.frame = CGRect(
-      x: switchCameraButton.frame.maxX, y: buttonY, width: buttonHeight, height: buttonHeight
+      x: switchCameraButton.frame.maxX, y: 0, width: buttonHeight, height: buttonHeight
     )
     infoButton.frame = CGRect(
-      x: width - horizontalInset - buttonHeight, y: buttonY, width: buttonHeight,
-      height: buttonHeight
+      x: shareButton.frame.maxX, y: 0, width: buttonHeight, height: buttonHeight
     )
   }
 

--- a/Sources/YOLO/YOLOView.swift
+++ b/Sources/YOLO/YOLOView.swift
@@ -953,10 +953,12 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     case .began, .changed:
       update(scale: newScaleFactor)
       self.labelZoom.text = zoomLabelText(rawZoomFactor: newScaleFactor, device: device)
+      updateSelectedLens(rawZoomFactor: newScaleFactor, device: device)
       self.labelZoom.font = UIFont.preferredFont(forTextStyle: .title2)
     case .ended:
       lastZoomFactor = minMaxZoom(newScaleFactor)
       update(scale: lastZoomFactor)
+      updateSelectedLens(rawZoomFactor: lastZoomFactor, device: device)
       self.labelZoom.font = UIFont.preferredFont(forTextStyle: .body)
     default: break
     }
@@ -1110,6 +1112,43 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   private func selectedLensDevice() -> AVCaptureDevice? {
     guard let selectedLensDeviceID else { return videoCapture.captureDevice }
     return lensDevices.first { $0.uniqueID == selectedLensDeviceID } ?? videoCapture.captureDevice
+  }
+
+  private func updateSelectedLens(rawZoomFactor: CGFloat, device: AVCaptureDevice) {
+    guard device.position == .back else {
+      selectedLensDeviceID = nil
+      return
+    }
+
+    let lensZooms = lensDevices.compactMap { lens -> (device: AVCaptureDevice, zoom: CGFloat)? in
+      guard isPhysicalRearLens(lens), let zoom = zoomFactor(for: lens, on: device)
+      else {
+        return nil
+      }
+      return (lens, zoom)
+    }.sorted { $0.zoom < $1.zoom }
+
+    guard let selectedLens =
+      lensZooms.last(where: { rawZoomFactor >= $0.zoom - 0.01 })?.device
+      ?? lensZooms.first?.device
+    else {
+      return
+    }
+
+    selectedLensDeviceID = selectedLens.uniqueID
+    lensControl.selectedSegmentIndex =
+      lensDevices.firstIndex { $0.uniqueID == selectedLens.uniqueID }
+      ?? UISegmentedControl.noSegment
+    lensCaptionLabel.text = lensCaption(for: selectedLens)
+  }
+
+  private func isPhysicalRearLens(_ device: AVCaptureDevice) -> Bool {
+    switch device.deviceType {
+    case .builtInUltraWideCamera, .builtInWideAngleCamera, .builtInTelephotoCamera:
+      return device.position == .back
+    default:
+      return false
+    }
   }
 
   private func lensCaption(for device: AVCaptureDevice) -> String {

--- a/Sources/YOLO/YOLOView.swift
+++ b/Sources/YOLO/YOLOView.swift
@@ -1036,7 +1036,8 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   private func updateLensControl() {
     let currentDevice = videoCapture.captureDevice
     let position = currentDevice?.position ?? .back
-    lensDevices = position == .front ? currentDevice.map { [$0] } ?? [] : captureDevices(position: position)
+    lensDevices =
+      position == .front ? currentDevice.map { [$0] } ?? [] : captureDevices(position: position)
     if position == .back, let currentDevice,
       !lensDevices.contains(where: { $0.uniqueID == currentDevice.uniqueID })
     {

--- a/Sources/YOLO/YOLOView.swift
+++ b/Sources/YOLO/YOLOView.swift
@@ -1022,7 +1022,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     cameraSwitchInProgress = true
     setCameraControlsEnabled(false)
     if changesPosition {
-      showCameraTransitionBlur()
+      showCameraTransition()
     }
 
     videoCapture.selectCaptureDevice(device, videoOrientation: currentVideoOrientation()) {
@@ -1032,8 +1032,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
       self.cameraSwitchInProgress = false
       self.setCameraControlsEnabled(true)
       if changesPosition {
-        self.applyPreviewConnection(for: self.videoCapture.captureDevice ?? device)
-        self.hideCameraTransitionBlur()
+        self.hideCameraTransition()
       }
 
       guard success else {
@@ -1052,7 +1051,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     }
   }
 
-  private func showCameraTransitionBlur() {
+  private func showCameraTransition() {
     cameraTransitionView?.removeFromSuperview()
 
     let transitionView = UIView(frame: bounds)
@@ -1073,7 +1072,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     cameraTransitionView = transitionView
   }
 
-  private func hideCameraTransitionBlur() {
+  private func hideCameraTransition() {
     guard let transitionView = cameraTransitionView else { return }
     cameraTransitionView = nil
     UIView.animate(
@@ -1085,16 +1084,6 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     } completion: { _ in
       transitionView.removeFromSuperview()
     }
-  }
-
-  private func applyPreviewConnection(for device: AVCaptureDevice) {
-    guard let connection = videoCapture.previewLayer?.connection else { return }
-    if connection.isVideoOrientationSupported {
-      connection.videoOrientation = currentVideoOrientation()
-    }
-    guard connection.isVideoMirroringSupported else { return }
-    connection.automaticallyAdjustsVideoMirroring = false
-    connection.isVideoMirrored = device.position == .front
   }
 
   private func setCameraControlsEnabled(_ isEnabled: Bool) {

--- a/YOLOiOSApp/YOLOiOSApp.xcodeproj/project.pbxproj
+++ b/YOLOiOSApp/YOLOiOSApp.xcodeproj/project.pbxproj
@@ -141,7 +141,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1010;
-				LastUpgradeCheck = 1640;
+				LastUpgradeCheck = 2640;
 				ORGANIZATIONNAME = Ultralytics;
 				TargetAttributes = {
 					7BCB411621C3096100BFC4D0 = {
@@ -289,6 +289,7 @@
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
@@ -345,6 +346,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				VALIDATE_PRODUCT = YES;

--- a/YOLOiOSApp/YOLOiOSApp.xcodeproj/project.pbxproj
+++ b/YOLOiOSApp/YOLOiOSApp.xcodeproj/project.pbxproj
@@ -367,7 +367,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.8.2;
+				MARKETING_VERSION = 8.8.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ultralytics.iDetection;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -395,7 +395,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.8.2;
+				MARKETING_VERSION = 8.8.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ultralytics.iDetection;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/YOLOiOSApp/YOLOiOSApp.xcodeproj/xcshareddata/xcschemes/YOLOiOSApp.xcscheme
+++ b/YOLOiOSApp/YOLOiOSApp.xcodeproj/xcshareddata/xcschemes/YOLOiOSApp.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1640"
+   LastUpgradeVersion = "2640"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/YOLOiOSApp/YOLOiOSApp/ExternalDisplay/ExternalViewController.swift
+++ b/YOLOiOSApp/YOLOiOSApp/ExternalDisplay/ExternalViewController.swift
@@ -177,7 +177,7 @@ class ExternalViewController: UIViewController, YOLOViewDelegate {
     [
       yoloView.labelZoom, yoloView.activityIndicator,
       yoloView.playButton, yoloView.pauseButton,
-      yoloView.switchCameraButton,
+      yoloView.switchCameraButton, yoloView.infoButton,
     ].forEach { $0.isHidden = true }
   }
 

--- a/YOLOiOSApp/YOLOiOSApp/ExternalDisplay/ExternalViewController.swift
+++ b/YOLOiOSApp/YOLOiOSApp/ExternalDisplay/ExternalViewController.swift
@@ -163,7 +163,6 @@ class ExternalViewController: UIViewController, YOLOViewDelegate {
     guard let yoloView = yoloView else { return }
 
     let controlsToRemove = [
-      yoloView.sliderNumItems, yoloView.labelSliderNumItems,
       yoloView.sliderConf, yoloView.labelSliderConf,
       yoloView.sliderIoU, yoloView.labelSliderIoU,
       yoloView.labelName, yoloView.labelFPS,
@@ -384,24 +383,6 @@ extension ExternalViewController {
   }
 
   func yoloView(_ view: YOLOView, didReceiveResult result: YOLOResult) {
-    let detectionCount: Int
-
-    switch currentTask {
-    case .pose:
-      detectionCount = result.keypointsList.count
-    case .obb:
-      detectionCount = result.obb.count
-    case .classify:
-      detectionCount = result.probs != nil ? 1 : 0
-    default:
-      detectionCount = result.boxes.count
-    }
-
-    NotificationCenter.default.post(
-      name: .detectionCountDidUpdate,
-      object: nil,
-      userInfo: ["count": detectionCount]
-    )
   }
 
 }

--- a/YOLOiOSApp/YOLOiOSApp/ExternalDisplay/NotificationExtensions.swift
+++ b/YOLOiOSApp/YOLOiOSApp/ExternalDisplay/NotificationExtensions.swift
@@ -12,5 +12,4 @@ extension Notification.Name {
   static let yoloResultsAvailable = Notification.Name("YOLOResultsAvailable")
   static let thresholdDidChange = Notification.Name("ThresholdDidChange")
   static let taskDidChange = Notification.Name("TaskDidChange")
-  static let detectionCountDidUpdate = Notification.Name("DetectionCountDidUpdate")
 }

--- a/YOLOiOSApp/YOLOiOSApp/ExternalDisplay/ViewController+ExternalDisplay.swift
+++ b/YOLOiOSApp/YOLOiOSApp/ExternalDisplay/ViewController+ExternalDisplay.swift
@@ -110,6 +110,7 @@ extension ViewController {
         [
           self.yoloView.switchCameraButton,
           self.yoloView.shareButton,
+          self.yoloView.infoButton,
         ].forEach { $0.isHidden = true }
         self.modelSegmentedControl.setNeedsLayout()
         self.modelSegmentedControl.layoutIfNeeded()
@@ -167,6 +168,7 @@ extension ViewController {
       [
         self.yoloView.switchCameraButton,
         self.yoloView.shareButton,
+        self.yoloView.infoButton,
       ].forEach { $0.isHidden = false }
 
       self.yoloView.resume()

--- a/YOLOiOSApp/YOLOiOSApp/ExternalDisplay/ViewController+ExternalDisplay.swift
+++ b/YOLOiOSApp/YOLOiOSApp/ExternalDisplay/ViewController+ExternalDisplay.swift
@@ -84,13 +84,6 @@ extension ViewController {
       object: nil
     )
 
-    // Listen for detection count updates from external display
-    NotificationCenter.default.addObserver(
-      self,
-      selector: #selector(handleDetectionCountUpdate(_:)),
-      name: .detectionCountDidUpdate,
-      object: nil
-    )
   }
 
   @objc func handleExternalDisplayConnected(_ notification: Notification) {
@@ -110,25 +103,14 @@ extension ViewController {
         [
           self.yoloView.sliderConf, self.yoloView.labelSliderConf,
           self.yoloView.sliderIoU, self.yoloView.labelSliderIoU,
-          self.yoloView.sliderNumItems, self.yoloView.labelSliderNumItems,
           self.yoloView.playButton, self.yoloView.pauseButton,
           self.modelSegmentedControl,
         ].forEach { $0?.isHidden = false }
-
-        self.customModelButton?.isHidden = self.currentModels.isEmpty
 
         [
           self.yoloView.switchCameraButton,
           self.yoloView.shareButton,
         ].forEach { $0.isHidden = true }
-        self.yoloView.labelSliderNumItems.text =
-          "0 items (max \(Int(self.yoloView.sliderNumItems.value)))"
-
-        self.yoloView.sliderNumItems.addTarget(
-          self,
-          action: #selector(self.updateNumItemsLabelForExternalDisplay),
-          for: .valueChanged
-        )
         self.modelSegmentedControl.setNeedsLayout()
         self.modelSegmentedControl.layoutIfNeeded()
       }
@@ -155,27 +137,6 @@ extension ViewController {
         .iOS(interfaceOrientations: [.landscapeLeft, .landscapeRight]))
     } else {
       UIViewController.attemptRotationToDeviceOrientation()
-    }
-  }
-
-  @objc private func updateNumItemsLabelForExternalDisplay() {
-    if isExternalDisplayConnected {
-      let maxValue = Int(yoloView.sliderNumItems.value)
-      let currentText = yoloView.labelSliderNumItems.text ?? ""
-      let currentCount = Int(currentText.split(separator: " ").first ?? "0") ?? 0
-      yoloView.labelSliderNumItems.text = "\(currentCount) items (max \(maxValue))"
-    }
-  }
-
-  @objc private func handleDetectionCountUpdate(_ notification: Notification) {
-    guard isExternalDisplayConnected,
-      let count = notification.userInfo?["count"] as? Int
-    else { return }
-
-    DispatchQueue.main.async { [weak self] in
-      guard let self = self else { return }
-      let maxValue = Int(self.yoloView.sliderNumItems.value)
-      self.yoloView.labelSliderNumItems.text = "\(count) items (max \(maxValue))"
     }
   }
 
@@ -207,13 +168,6 @@ extension ViewController {
         self.yoloView.switchCameraButton,
         self.yoloView.shareButton,
       ].forEach { $0.isHidden = false }
-
-      self.yoloView.sliderNumItems.removeTarget(
-        self,
-        action: #selector(self.updateNumItemsLabelForExternalDisplay),
-        for: .valueChanged
-      )
-      self.yoloView.sliderChanged(self.yoloView.sliderNumItems)
 
       self.yoloView.resume()
       self.yoloView.setInferenceFlag(ok: true)
@@ -256,7 +210,6 @@ extension ViewController {
     guard hasExternalDisplay else { return }
 
     // Layout adjustments for external display mode if needed
-    // The segmented control and custom button are already properly positioned
   }
 
   @objc func handleExternalDisplayReady(_ notification: Notification) {

--- a/YOLOiOSApp/YOLOiOSApp/Info.plist
+++ b/YOLOiOSApp/YOLOiOSApp/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>567</string>
+	<string>568</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/YOLOiOSApp/YOLOiOSApp/Settings.bundle/Root.plist
+++ b/YOLOiOSApp/YOLOiOSApp/Settings.bundle/Root.plist
@@ -30,16 +30,6 @@
                 <key>Type</key>
                 <string>PSToggleSwitchSpecifier</string>
                 <key>Title</key>
-                <string>Use Telephoto</string>
-                <key>Key</key>
-                <string>use_telephoto</string>
-                <key>DefaultValue</key>
-                <false/>
-            </dict>
-            <dict>
-                <key>Type</key>
-                <string>PSToggleSwitchSpecifier</string>
-                <key>Title</key>
                 <string>Developer Mode</string>
                 <key>Key</key>
                 <string>developer_mode</string>

--- a/YOLOiOSApp/YOLOiOSApp/ViewController.swift
+++ b/YOLOiOSApp/YOLOiOSApp/ViewController.swift
@@ -665,7 +665,7 @@ class ViewController: UIViewController, YOLOViewDelegate {
     let sliderMidY = (yoloView.sliderConf.frame.midY + yoloView.sliderIoU.frame.midY) / 2
     guard sliderMidY.isFinite, sliderMidY > 0 else { return }
 
-    logoImage.center = CGPoint(x: logoImage.center.x, y: sliderMidY)
+    logoImage.center = CGPoint(x: logoImage.center.x, y: sliderMidY + 6)
   }
 
   @objc func shareButtonTapped() {

--- a/YOLOiOSApp/YOLOiOSApp/ViewController.swift
+++ b/YOLOiOSApp/YOLOiOSApp/ViewController.swift
@@ -66,9 +66,6 @@ class ViewController: UIViewController, YOLOViewDelegate {
   // Store current loading entry for external display notification (Optional feature)
   var currentLoadingEntry: ModelEntry?
 
-  // Custom model selection button (created programmatically)
-  var customModelButton: UIButton!
-
   private let downloadProgressView = UIProgressView(progressViewStyle: .default)
   private let downloadProgressLabel = UILabel()
 
@@ -139,9 +136,6 @@ class ViewController: UIViewController, YOLOViewDelegate {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    // Debug: Check model folders
-    debugCheckModelFolders()
-
     // MARK: External Display Setup (Optional)
     // NOTE: The following external display setup is OPTIONAL and not required for core app functionality.
     // This code enhances the app for external monitor/TV connections and remains dormant when not in use.
@@ -167,7 +161,6 @@ class ViewController: UIViewController, YOLOViewDelegate {
     }
 
     setupModelSegmentedControl()
-    setupCustomModelButton()
 
     if tasks.indices.contains(Constants.defaultTaskIndex) {
       segmentedControl.selectedSegmentIndex = Constants.defaultTaskIndex
@@ -193,8 +186,6 @@ class ViewController: UIViewController, YOLOViewDelegate {
     // Add target to sliders to monitor changes
     yoloView.sliderConf.addTarget(self, action: #selector(sliderValueChanged), for: .valueChanged)
     yoloView.sliderIoU.addTarget(self, action: #selector(sliderValueChanged), for: .valueChanged)
-    yoloView.sliderNumItems.addTarget(
-      self, action: #selector(sliderValueChanged), for: .valueChanged)
 
     // Setup labels and version
     [labelName, labelFPS, labelVersion].forEach {
@@ -634,35 +625,6 @@ class ViewController: UIViewController, YOLOViewDelegate {
     ])
   }
 
-  private func setupCustomModelButton() {
-    customModelButton = UIButton(type: .system)
-    customModelButton.setTitle("Custom", for: .normal)
-    customModelButton.titleLabel?.font = UIFont.systemFont(ofSize: 13)
-    customModelButton.setTitleColor(.white, for: .normal)
-    customModelButton.setTitleColor(.systemBlue, for: .selected)
-    customModelButton.backgroundColor = .systemBackground.withAlphaComponent(0.1)
-    customModelButton.layer.cornerRadius = 8
-    customModelButton.layer.borderWidth = 1
-    customModelButton.layer.borderColor = UIColor.systemGray.cgColor
-    customModelButton.addTarget(
-      self, action: #selector(customModelButtonTapped), for: .touchUpInside)
-    customModelButton.translatesAutoresizingMaskIntoConstraints = false
-
-    View0.addSubview(customModelButton)
-
-    modelSegmentedControl.translatesAutoresizingMaskIntoConstraints = false
-    NSLayoutConstraint.activate([
-      modelSegmentedControl.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
-      modelSegmentedControl.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
-    ])
-  }
-
-  // MARK: - Actions
-  @objc func customModelButtonTapped() {
-    selection.selectionChanged()
-    // Placeholder action for custom model selection; integrate picker if needed
-  }
-
   func updateModelSegmentedControlAppearance() {
     guard modelSegmentedControl != nil else { return }
 
@@ -731,33 +693,6 @@ class ViewController: UIViewController, YOLOViewDelegate {
 
   deinit {
     NotificationCenter.default.removeObserver(self)
-  }
-
-  private func debugCheckModelFolders() {
-    print("\n🔍 DEBUG: Checking model folders...")
-    let folders = [
-      "Models/Detect", "Models/Segment", "Models/Classify", "Models/Pose", "Models/OBB",
-    ]
-
-    for folder in folders {
-      if let folderURL = Bundle.main.url(forResource: folder, withExtension: nil) {
-        print("✅ \(folder) found at: \(folderURL.path)")
-
-        do {
-          let files = try FileManager.default.contentsOfDirectory(
-            at: folderURL, includingPropertiesForKeys: nil)
-          let models = files.filter {
-            $0.pathExtension == "mlmodel" || $0.pathExtension == "mlpackage"
-          }
-          print("   📦 Models: \(models.map { $0.lastPathComponent })")
-        } catch {
-          print("   ❌ Error reading folder: \(error)")
-        }
-      } else {
-        print("❌ \(folder) NOT FOUND in bundle")
-      }
-    }
-    print("\n")
   }
 
 }

--- a/YOLOiOSApp/YOLOiOSApp/ViewController.swift
+++ b/YOLOiOSApp/YOLOiOSApp/ViewController.swift
@@ -657,6 +657,15 @@ class ViewController: UIViewController, YOLOViewDelegate {
   override func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()
     adjustLayoutForExternalDisplayIfNeeded()
+    alignLogoWithThresholdSliders()
+  }
+
+  private func alignLogoWithThresholdSliders() {
+    guard logoImage != nil, yoloView != nil else { return }
+    let sliderMidY = (yoloView.sliderConf.frame.midY + yoloView.sliderIoU.frame.midY) / 2
+    guard sliderMidY.isFinite, sliderMidY > 0 else { return }
+
+    logoImage.center = CGPoint(x: logoImage.center.x, y: sliderMidY)
   }
 
   @objc func shareButtonTapped() {


### PR DESCRIPTION
## Summary
- add an iOS Camera-style selector above the toolbar that exposes only the available physical camera devices
- keep the default virtual rear camera path internal for fast rear-lens switching without showing a confusing Default option
- show the same selector/caption/zoom UI in front and back camera modes, including a single value when only one camera is available
- keep the selected lens segment and caption synced when the user pinch-zooms across lens ranges
- keep the reverse camera icon as a front/back toggle only
- tighten the lower controls: smaller zoom readout near the selector, physical-camera caption, lowered confidence/IoU sliders, and logo aligned to the two-slider stack
- run capture session start/stop/orientation/switching work on the camera queue to avoid blocking gestures and racing session configuration
- disable automatic video mirroring before manually mirroring front-camera capture/preview connections
- remove the visible max-items slider, default max detections to 100, and remove the obsolete Use Telephoto setting
- remove the stale Custom button and related dead external-display detection-count/debug code

Closes #234

## Testing
- git diff --check
- xcodebuild -project YOLOiOSApp/YOLOiOSApp.xcodeproj -scheme YOLOiOSApp -destination "platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4" build
- swift test (fails on macOS host because this package imports UIKit and must build for iOS)
- xcodebuild test for YOLO and YOLOiOSApp schemes (schemes are not configured for the test action)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📱 This PR upgrades the iOS app camera experience with multi-lens selection, smoother camera switching, cleaner controls, and a few UI/maintenance updates for a more polished release.

### 📊 Key Changes
- 🎥 **Added multi-lens camera support** for supported rear cameras, including ultra-wide, wide, and telephoto options.
- 🔄 **Reworked camera switching logic** to safely switch devices on a dedicated camera queue, with better handling for orientation, mirroring, zoom, and photo output.
- 🔍 **Improved zoom behavior** by mapping lens selections to zoom levels, updating zoom labels more accurately, and supporting iOS 18 display zoom multipliers.
- 🧭 **Added a lens selector UI** in `YOLOView` using a segmented control, plus captions like “Ultra wide camera” and “Telephoto camera.”
- ✨ **Introduced a smoother camera transition effect** when switching between front and back cameras, and temporarily disables controls during the switch to avoid glitches.
- ℹ️ **Added an info button** that opens the Ultralytics website from the app toolbar.
- 🧹 **Simplified detection item controls**:
  - default max detections changed from **30 to 100**
  - minimum value changed from **0 to 1**
  - the num-items slider and label are now hidden from the main UI
  - related tests were updated accordingly
- 🖥️ **Cleaned up external display logic** by removing detection count notifications and num-items UI syncing that are no longer needed.
- 🗑️ **Removed older/unused options and debug code**, including:
  - the `Use Telephoto` settings toggle
  - placeholder custom model button code
  - model folder debug logging
- 🛠️ **Project metadata updated** with a version bump to **8.8.3** and newer Xcode upgrade settings.

### 🎯 Purpose & Impact
- 👍 **Makes the camera experience more intuitive** by letting users directly choose available lenses instead of relying on a basic telephoto toggle.
- 📸 **Improves reliability and polish** during camera changes, reducing the chance of broken orientation, mirroring, or configuration issues.
- 🚀 **Better supports modern iPhones** with multi-camera systems, giving users more control over framing and zoom in real-time YOLO demos.
- 🧼 **Reduces UI clutter** by hiding less important controls while keeping the detection pipeline configured with a higher default limit.
- 🖥️ **Simplifies external display behavior**, which should make the code easier to maintain and reduce unnecessary synchronization logic.
- 🔧 **Cleans up technical debt** by removing outdated settings, debug helpers, and placeholder UI, making future app updates easier.
- 📦 **Prepares a new app release** with updated build/version settings and improved overall user experience.