### PR TITLE
Fix paused share capture

### DIFF
--- a/Sources/YOLO/VideoCapture.swift
+++ b/Sources/YOLO/VideoCapture.swift
@@ -62,6 +62,8 @@ func bestCaptureDevice(position: AVCaptureDevice.Position) -> AVCaptureDevice? {
 func zoomFactor(for lensDevice: AVCaptureDevice, on virtualDevice: AVCaptureDevice) -> CGFloat? {
   guard lensDevice.position == virtualDevice.position else { return nil }
   let constituentDevices = virtualDevice.constituentDevices
+    .filter { physicalLensTypes.contains($0.deviceType) }
+    .sorted { $0.deviceType.lensSortOrder < $1.deviceType.lensSortOrder }
   guard constituentDevices.count > 1 else { return nil }
 
   let lensIndex =
@@ -146,7 +148,6 @@ public final class VideoCapture: NSObject, @unchecked Sendable {
   let captureSession = AVCaptureSession()
   var videoInput: AVCaptureDeviceInput? = nil
   let videoOutput = AVCaptureVideoDataOutput()
-  var photoOutput = AVCapturePhotoOutput()
   let cameraQueue = DispatchQueue(label: "camera-queue")
   var inferenceOK = true
   var longSide: CGFloat = 3
@@ -154,6 +155,8 @@ public final class VideoCapture: NSObject, @unchecked Sendable {
   var frameSizeCaptured = false
 
   private var currentBuffer: CVPixelBuffer?
+  private lazy var imageContext = CIContext()
+  private var frameCaptureCompletion: ((UIImage?) -> Void)?
 
   deinit {
     captureSession.stopRunning()
@@ -226,11 +229,6 @@ public final class VideoCapture: NSObject, @unchecked Sendable {
     if captureSession.canAddOutput(videoOutput) {
       captureSession.addOutput(videoOutput)
     }
-    if captureSession.canAddOutput(photoOutput) {
-      captureSession.addOutput(photoOutput)
-      configurePhotoOutput(for: device)
-    }
-
     // We want the buffers to be in portrait orientation otherwise they are
     // rotated by 90 degrees. Need to set this _after_ addOutput()!
     let connection = videoOutput.connection(with: AVMediaType.video)
@@ -327,7 +325,6 @@ public final class VideoCapture: NSObject, @unchecked Sendable {
     captureSession.addInput(newInput)
     videoInput = newInput
     captureDevice = device
-    configurePhotoOutput(for: device)
 
     let videoConnection = videoOutput.connection(with: .video)
     videoConnection?.videoOrientation = videoOrientation
@@ -372,6 +369,20 @@ public final class VideoCapture: NSObject, @unchecked Sendable {
     }
   }
 
+  func captureNextFrame(completion: @escaping (UIImage?) -> Void) {
+    cameraQueue.async { [weak self] in
+      guard let self, self.captureSession.isRunning else {
+        DispatchQueue.main.async { completion(nil) }
+        return
+      }
+      guard self.frameCaptureCompletion == nil else {
+        DispatchQueue.main.async { completion(nil) }
+        return
+      }
+      self.frameCaptureCompletion = completion
+    }
+  }
+
   private func predictOnFrame(sampleBuffer: CMSampleBuffer) {
     guard let predictor = predictor else {
       return
@@ -411,16 +422,6 @@ public final class VideoCapture: NSObject, @unchecked Sendable {
     connection.isVideoMirrored = isMirrored
   }
 
-  private func configurePhotoOutput(for device: AVCaptureDevice) {
-    if #available(iOS 16.0, *) {
-      if let maxDimensions = device.activeFormat.supportedMaxPhotoDimensions.last {
-        photoOutput.maxPhotoDimensions = maxDimensions
-      }
-    } else {
-      photoOutput.isHighResolutionCaptureEnabled = true
-    }
-  }
-
   private func configureCameraDevice(_ device: AVCaptureDevice) -> Bool {
     do {
       try device.lockForConfiguration()
@@ -453,6 +454,23 @@ extension VideoCapture: AVCaptureVideoDataOutputSampleBufferDelegate {
     _ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer,
     from connection: AVCaptureConnection
   ) {
+    let requestedFrameCompletion = frameCaptureCompletion
+    if requestedFrameCompletion != nil {
+      frameCaptureCompletion = nil
+    }
+    defer {
+      if let requestedFrameCompletion {
+        let capturedImage = CMSampleBufferGetImageBuffer(sampleBuffer).flatMap { pixelBuffer in
+          let image = CIImage(cvPixelBuffer: pixelBuffer)
+          return imageContext.createCGImage(image, from: image.extent).map {
+            UIImage(cgImage: $0)
+          }
+        }
+        DispatchQueue.main.async {
+          requestedFrameCompletion(capturedImage)
+        }
+      }
+    }
     guard inferenceOK else { return }
     predictOnFrame(sampleBuffer: sampleBuffer)
   }

--- a/Sources/YOLO/YOLOView.swift
+++ b/Sources/YOLO/YOLOView.swift
@@ -123,8 +123,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   private let minimumZoom: CGFloat = 1.0
   private let maximumZoom: CGFloat = 10.0
   private var lastZoomFactor: CGFloat = 1.0
-
-  private var photoCaptureCompletion: ((UIImage?) -> Void)?
+  private var pausedShareImage: UIImage?
 
   /// Pending camera position to apply after async camera setup completes.
   public var pendingCameraPosition: AVCaptureDevice.Position?
@@ -274,6 +273,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   }
 
   public func resume() {
+    pausedShareImage = nil
     videoCapture.start()
   }
 
@@ -991,6 +991,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
 
   @objc func playTapped() {
     selection.selectionChanged()
+    pausedShareImage = nil
     self.videoCapture.start()
     playButton.isEnabled = false
     pauseButton.isEnabled = true
@@ -998,17 +999,25 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
 
   @objc func pauseTapped() {
     selection.selectionChanged()
-    self.videoCapture.stop()
     playButton.isEnabled = true
     pauseButton.isEnabled = false
+    videoCapture.captureNextFrame { [weak self] image in
+      self?.pausedShareImage = image
+      self?.videoCapture.stop()
+    }
   }
 
   @objc func switchCameraTapped() {
     selection.selectionChanged()
+    pausedShareImage = nil
 
     let currentPosition = videoCapture.captureDevice?.position ?? .back
     let nextCameraPosition: AVCaptureDevice.Position = currentPosition == .back ? .front : .back
-    guard let newCameraDevice = bestCaptureDevice(position: nextCameraPosition) else { return }
+    let newCameraDevice =
+      nextCameraPosition == .back
+      ? captureDevices(position: .back).first { $0.deviceType == .builtInWideAngleCamera }
+      : bestCaptureDevice(position: nextCameraPosition)
+    guard let newCameraDevice else { return }
     switchToCamera(newCameraDevice)
   }
 
@@ -1053,8 +1062,8 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
         return
       }
 
-      self.selectedLensDeviceID = device.position == .back ? device.uniqueID : nil
       let activeDevice = self.videoCapture.captureDevice ?? device
+      self.selectedLensDeviceID = device.position == .back ? device.uniqueID : nil
       let rawZoomFactor =
         zoomFactor(for: device, on: activeDevice)
         ?? min(max(activeDevice.videoZoomFactor, self.minimumZoom), self.maximumZoom)
@@ -1230,215 +1239,47 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   }
 
   public func capturePhoto(completion: @escaping (UIImage?) -> Void) {
-    guard photoCaptureCompletion == nil else {
-      completion(nil)  // Previous capture still in progress
+    if let pausedShareImage, !videoCapture.captureSession.isRunning {
+      completion(renderShareImage(pausedShareImage))
       return
     }
-    self.photoCaptureCompletion = completion
-    let settings = AVCapturePhotoSettings()
-    self.videoCapture.photoOutput.capturePhoto(
-      with: settings, delegate: self as AVCapturePhotoCaptureDelegate
-    )
+
+    videoCapture.captureNextFrame { [weak self] image in
+      guard let self, let image else {
+        completion(nil)
+        return
+      }
+      completion(self.renderShareImage(image))
+    }
+  }
+
+  private func renderShareImage(_ image: UIImage) -> UIImage? {
+    let imageView = UIImageView(image: image)
+    imageView.contentMode = .scaleAspectFill
+    imageView.frame = bounds
+    let imageLayer = imageView.layer
+    layer.insertSublayer(imageLayer, above: videoCapture.previewLayer)
+
+    var tempViews = [UIView]()
+    let boundingBoxInfos = makeBoundingBoxInfos(from: boundingBoxViews)
+    for info in boundingBoxInfos where !info.isHidden {
+      let boxView = createBoxView(from: info)
+      boxView.frame = info.rect
+      addSubview(boxView)
+      tempViews.append(boxView)
+    }
+
+    UIGraphicsBeginImageContextWithOptions(bounds.size, true, 0.0)
+    drawHierarchy(in: bounds, afterScreenUpdates: true)
+    let snapshot = UIGraphicsGetImageFromCurrentImageContext()
+    UIGraphicsEndImageContext()
+    imageLayer.removeFromSuperlayer()
+    tempViews.forEach { $0.removeFromSuperview() }
+    return snapshot
   }
 
   public func setInferenceFlag(ok: Bool) {
     videoCapture.inferenceOK = ok
-  }
-}
-
-// MARK: - Helper Methods for Layer Copying
-
-extension YOLOView {
-  /// Copies layer properties from source to destination
-  private func copyLayerProperties(from source: CALayer, to destination: CALayer) {
-    destination.opacity = source.opacity
-    destination.transform = source.transform
-    destination.masksToBounds = source.masksToBounds
-    destination.contentsGravity = source.contentsGravity
-    destination.contentsRect = source.contentsRect
-    destination.contentsCenter = source.contentsCenter
-    destination.compositingFilter = source.compositingFilter
-    destination.backgroundColor = source.backgroundColor
-    destination.cornerRadius = source.cornerRadius
-  }
-
-  /// Copies CAShapeLayer properties
-  private func copyShapeLayer(_ shapeLayer: CAShapeLayer) -> CAShapeLayer {
-    let copy = CAShapeLayer()
-    copy.frame = shapeLayer.frame
-    copy.path = shapeLayer.path
-    copy.strokeColor = shapeLayer.strokeColor
-    copy.lineWidth = shapeLayer.lineWidth
-    copy.fillColor = shapeLayer.fillColor
-    copy.opacity = shapeLayer.opacity
-    return copy
-  }
-
-  /// Copies CATextLayer properties
-  private func copyTextLayer(_ textLayer: CATextLayer) -> CATextLayer {
-    let copy = CATextLayer()
-    copy.frame = textLayer.frame
-    copy.string = textLayer.string
-    copy.font = textLayer.font
-    copy.fontSize = textLayer.fontSize
-    copy.foregroundColor = textLayer.foregroundColor
-    copy.backgroundColor = textLayer.backgroundColor
-    copy.alignmentMode = textLayer.alignmentMode
-    copy.opacity = textLayer.opacity
-    return copy
-  }
-
-  /// Creates a copy of a visualization layer for capture
-  private func copyVisualizationLayer(_ layer: CALayer, isFullFrame: Bool = false) -> CALayer? {
-    let tempLayer = CALayer()
-    let overlayFrame = self.overlayLayer.frame
-
-    if isFullFrame {
-      tempLayer.frame = CGRect(
-        x: overlayFrame.origin.x,
-        y: overlayFrame.origin.y,
-        width: overlayFrame.width,
-        height: overlayFrame.height
-      )
-    } else {
-      // For mask layer - adjust frame to be relative to main view
-      let layerFrame = layer.frame
-      tempLayer.frame = CGRect(
-        x: overlayFrame.origin.x + layerFrame.origin.x,
-        y: overlayFrame.origin.y + layerFrame.origin.y,
-        width: layerFrame.width,
-        height: layerFrame.height
-      )
-      tempLayer.contents = layer.contents
-    }
-
-    tempLayer.opacity = layer.opacity
-    copyLayerProperties(from: layer, to: tempLayer)
-
-    // Copy sublayers if present
-    if let sublayers = layer.sublayers {
-      for sublayer in sublayers {
-        if let shapeLayer = sublayer as? CAShapeLayer {
-          tempLayer.addSublayer(copyShapeLayer(shapeLayer))
-        } else if let textLayer = sublayer as? CATextLayer {
-          tempLayer.addSublayer(copyTextLayer(textLayer))
-        } else {
-          let copyLayer = CALayer()
-          copyLayer.frame = sublayer.frame
-          copyLayerProperties(from: sublayer, to: copyLayer)
-          tempLayer.addSublayer(copyLayer)
-        }
-      }
-    }
-    return tempLayer
-  }
-}
-
-extension YOLOView: AVCapturePhotoCaptureDelegate {
-  nonisolated public func photoOutput(
-    _ output: AVCapturePhotoOutput, didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?
-  ) {
-    if let error = error {
-      YOLOLog.error("Photo capture error: \(error.localizedDescription)")
-    }
-    if let dataImage = photo.fileDataRepresentation() {
-      guard let dataProvider = CGDataProvider(data: dataImage as CFData),
-        let cgImageRef = CGImage(
-          jpegDataProviderSource: dataProvider, decode: nil, shouldInterpolate: true,
-          intent: .defaultIntent)
-      else {
-        Task { @MainActor [weak self] in
-          self?.photoCaptureCompletion?(nil)
-          self?.photoCaptureCompletion = nil
-        }
-        return
-      }
-
-      Task { @MainActor [weak self] in
-        guard let self = self else { return }
-
-        var isCameraFront = false
-        if let currentInput = self.videoCapture.captureSession.inputs.first
-          as? AVCaptureDeviceInput,
-          currentInput.device.position == .front
-        {
-          isCameraFront = true
-        }
-        var orientation: CGImagePropertyOrientation = isCameraFront ? .leftMirrored : .right
-        switch UIDevice.current.orientation {
-        case .landscapeLeft:
-          orientation = isCameraFront ? .downMirrored : .up
-        case .landscapeRight:
-          orientation = isCameraFront ? .upMirrored : .down
-        default:
-          break
-        }
-        var image = UIImage(cgImage: cgImageRef, scale: 0.5, orientation: .right)
-        if let orientedCIImage = CIImage(image: image)?.oriented(orientation),
-          let cgImage = CIContext().createCGImage(orientedCIImage, from: orientedCIImage.extent)
-        {
-          image = UIImage(cgImage: cgImage)
-        }
-        let imageView = UIImageView(image: image)
-        imageView.contentMode = .scaleAspectFill
-        imageView.frame = self.frame
-        let imageLayer = imageView.layer
-        self.layer.insertSublayer(imageLayer, above: videoCapture.previewLayer)
-
-        // Add visualization layers
-        var tempLayers = [CALayer]()
-
-        // Add mask layer if present (for segmentation task)
-        if let maskLayer = self.maskLayer, !maskLayer.isHidden {
-          if let tempLayer = copyVisualizationLayer(maskLayer, isFullFrame: false) {
-            self.layer.addSublayer(tempLayer)
-            tempLayers.append(tempLayer)
-          }
-        }
-
-        // Add pose layer if present (for pose task)
-        if let poseLayer = self.poseLayer {
-          if let tempLayer = copyVisualizationLayer(poseLayer, isFullFrame: true) {
-            self.layer.addSublayer(tempLayer)
-            tempLayers.append(tempLayer)
-          }
-        }
-
-        // Add OBB layer if present (for OBB task)
-        if let obbLayer = self.obbLayer, !obbLayer.isHidden {
-          if let tempLayer = copyVisualizationLayer(obbLayer, isFullFrame: true) {
-            self.layer.addSublayer(tempLayer)
-            tempLayers.append(tempLayer)
-          }
-        }
-
-        var tempViews = [UIView]()
-        let boundingBoxInfos = makeBoundingBoxInfos(from: boundingBoxViews)
-        for info in boundingBoxInfos where !info.isHidden {
-          let boxView = createBoxView(from: info)
-          boxView.frame = info.rect
-
-          self.addSubview(boxView)
-          tempViews.append(boxView)
-        }
-        let captureBounds = self.bounds
-        UIGraphicsBeginImageContextWithOptions(captureBounds.size, true, 0.0)
-        self.drawHierarchy(in: captureBounds, afterScreenUpdates: true)
-        let img = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-        imageLayer.removeFromSuperlayer()
-        for layer in tempLayers {
-          layer.removeFromSuperlayer()
-        }
-        for v in tempViews {
-          v.removeFromSuperview()
-        }
-        photoCaptureCompletion?(img)
-        photoCaptureCompletion = nil
-      }
-    } else {
-      YOLOLog.error("AVCapturePhotoCaptureDelegate: photo has no file data")
-    }
   }
 }
 

--- a/YOLOiOSApp/YOLOiOSApp.xcodeproj/project.pbxproj
+++ b/YOLOiOSApp/YOLOiOSApp.xcodeproj/project.pbxproj
@@ -369,7 +369,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.8.3;
+				MARKETING_VERSION = 8.8.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ultralytics.iDetection;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -397,7 +397,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.8.3;
+				MARKETING_VERSION = 8.8.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ultralytics.iDetection;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/YOLOiOSApp/YOLOiOSApp/Info.plist
+++ b/YOLOiOSApp/YOLOiOSApp/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>568</string>
+	<string>569</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/YOLOiOSApp/YOLOiOSApp/ViewController.swift
+++ b/YOLOiOSApp/YOLOiOSApp/ViewController.swift
@@ -487,9 +487,11 @@ class ViewController: UIViewController, YOLOViewDelegate {
       self.setLoadingState(false)
       self.isLoadingModel = false
       self.resetDownloadProgress()
+      let hasExternalDisplay = self.hasExternalScreen() || SceneDelegate.hasExternalDisplay
 
       if success {
         let yoloTask = self.tasks.first(where: { $0.name == self.currentTask })?.yoloTask ?? .detect
+        self.currentModelName = processString(modelName)
 
         ModelSelectionManager.setupSegmentedControl(
           self.modelSegmentedControl,
@@ -505,11 +507,7 @@ class ViewController: UIViewController, YOLOViewDelegate {
         )
       }
 
-      // Notify external display of model change (Optional feature)
-      if success {
-        // Update currentModelName
-        self.currentModelName = processString(modelName)
-
+      if success && hasExternalDisplay {
         let yoloTask = self.tasks.first(where: { $0.name == self.currentTask })?.yoloTask ?? .detect
 
         // Determine the correct model path for external display
@@ -559,16 +557,12 @@ class ViewController: UIViewController, YOLOViewDelegate {
         }
       }
 
-      // Check if external display is connected
-      let hasExternalDisplay = self.hasExternalScreen() || SceneDelegate.hasExternalDisplay
-
       // Only set inference flag on YOLOView if no external display
       if !hasExternalDisplay {
         self.yoloView.setInferenceFlag(ok: success)
       }
 
       if success {
-        // currentModelName is already set above in the notification section
         self.labelName.text = processString(modelName)
       }
     }
@@ -696,8 +690,6 @@ class ViewController: UIViewController, YOLOViewDelegate {
         "maxItems": maxItems,
       ]
     )
-
-    print("📊 Threshold changed - Conf: \(conf), IoU: \(iou), Max items: \(maxItems)")
   }
 
   deinit {


### PR DESCRIPTION
## Summary
- replace still-photo sharing with the latest real video frame for both running and paused camera states
- overlay the current bounding boxes on the shared frame using the existing bounding-box snapshot helpers
- remove the AVCapturePhotoOutput share path so sharing no longer triggers separate Fig still-capture work
- route selfie-to-back toggles through the wide lens target so rear camera returns to 1x instead of 0.5x
- sort virtual-camera constituent lenses before mapping selector taps to zoom factors so 0.5/1/telephoto match the actual selected lens
- remove threshold slider console spam and only run external-display model notifications when an external display is connected
- bump the app release to 8.8.4 (build 569)

## Testing
- git diff --check
- xcodebuild -project YOLOiOSApp/YOLOiOSApp.xcodeproj -scheme YOLOiOSApp -destination 'generic/platform=iOS Simulator' build

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📸 This PR simplifies image capture in the iOS app by switching from dedicated photo capture to grabbing the next video frame, while also improving camera switching, paused-state sharing, and a few model-loading/display behaviors.

### 📊 Key Changes
- Replaced `AVCapturePhotoOutput` photo capture with a lighter **next-frame capture** flow from the live video stream.
- Added `captureNextFrame()` in `VideoCapture` to grab a single frame as a `UIImage` directly from the camera feed.
- Removed older photo-specific configuration and delegate code, significantly simplifying capture logic.
- Updated `YOLOView.capturePhoto()` to render a shareable image using the captured frame plus detection overlays.
- Added support for **sharing while paused** by storing the last paused frame and reusing it when the camera is stopped.
- Changed pause behavior so the app first captures the current frame, then stops the camera, improving snapshot reliability.
- Reset paused/share state when resuming playback or switching cameras to avoid stale images.
- Improved **camera switching** so the back camera prefers the built-in wide-angle lens instead of always selecting the best virtual device.
- Refined virtual camera lens handling by filtering and sorting physical lens devices before computing zoom factors.
- Cleaned up model-loading logic in `ViewController`:
  - sets `currentModelName` earlier and more consistently
  - only sends external-display updates when an external display is actually connected
  - removed a debug print statement
- Bumped app version from **8.8.3 to 8.8.4** 🚀

### 🎯 Purpose & Impact
- 📱 **Simpler and more reliable capture pipeline:** Using the live video frame avoids the complexity of a separate photo output path.
- ⚡ **Faster snapshot behavior:** Capturing from the stream should feel more immediate, especially during pause/share actions.
- 🧼 **Lower maintenance burden:** Removing photo delegate code reduces complexity and makes the camera stack easier to manage.
- 🖼️ **Better paused-state sharing:** Users can now pause and still generate a shareable annotated image from the last visible frame.
- 🎥 **More predictable camera behavior:** Camera switching and zoom calculations should behave more consistently across multi-lens iPhones.
- 🖥️ **Cleaner external display handling:** Model updates are only pushed when an external screen exists, reducing unnecessary work.
- 🔧 **User-facing impact:** Most users will notice smoother pause/capture/share behavior, with fewer edge-case issues around camera state and model changes.