### PR TITLE
Bump slackapi/slack-github-action from v3.0.2 to v3.0.3 in /.github/workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -178,7 +178,7 @@ jobs:
           echo "PR_TITLE=${PR_TITLE}" >> "${GITHUB_ENV}"
       - name: Notify Success
         if: needs.release.result == 'success' && github.event_name == 'push'
-        uses: slackapi/slack-github-action@v3.0.2
+        uses: slackapi/slack-github-action@v3.0.3
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_HUBWEB }}
@@ -186,7 +186,7 @@ jobs:
             text: "<!channel> GitHub Actions success for ${{ github.workflow }} ✅\n\n\n*Repository:* https://github.com/${{ github.repository }}\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n*Event:* NEW `YOLO iOS ${{ needs.check.outputs.current_tag }}` release published 🎉\n*Job Status:* ${{ job.status }}\n*Pull Request:* <https://github.com/${{ github.repository }}/pull/${{ env.PR_NUMBER }}> ${{ env.PR_TITLE }}\n*Release Notes:* https://github.com/${{ github.repository }}/releases/tag/${{ needs.check.outputs.current_tag }}\n"
       - name: Notify Failure
         if: needs.release.result != 'success'
-        uses: slackapi/slack-github-action@v3.0.2
+        uses: slackapi/slack-github-action@v3.0.3
         with:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_HUBWEB }}


### PR DESCRIPTION
Bump slackapi/slack-github-action from v3.0.2 to v3.0.3 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔔 This PR makes a small maintenance update by upgrading the Slack GitHub Action used in the release workflow from `v3.0.2` to `v3.0.3`.

### 📊 Key Changes
- Updated the Slack notification step in `.github/workflows/publish.yml` from `slackapi/slack-github-action@v3.0.2` to `slackapi/slack-github-action@v3.0.3` ✅
- Applied the update to both:
  - the **success notification** step
  - the **failure notification** step
- No changes were made to the notification message content or overall release logic 🛠️

### 🎯 Purpose & Impact
- Keeps the GitHub Actions workflow up to date with the latest patch release of the Slack action 🔄
- May improve reliability, compatibility, or include minor upstream fixes from the Slack action maintainers 📬
- Low-risk change: users should expect the same release notification behavior, just with a newer dependency version 👍
- Helps maintain a healthier CI/CD pipeline for publishing the YOLO iOS app 🚀