### PR TITLE
Sweep: bug fixes, perf wins, dead-code purge across SDK and host app

### DIFF
--- a/ExampleApps/YOLORealTimeUIKit/YOLORealTimeUIKit/AppDelegate.swift
+++ b/ExampleApps/YOLORealTimeUIKit/YOLORealTimeUIKit/AppDelegate.swift
@@ -1,17 +1,7 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-//  This file is part of the Example Apps of Ultralytics YOLO Package, providing the application delegate for the real-time UIKit example.
-//  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
-//  Access the source code: https://github.com/ultralytics/yolo-ios-app
-//
-//  The AppDelegate handles application lifecycle events and configures the application environment.
-
 import UIKit
 
-/// The application delegate class responsible for managing the application's lifecycle.
-///
-/// This class handles application-level events such as launch, termination, and state transitions.
-/// It's the primary entry point for the real-time YOLO object detection UIKit example app.
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
@@ -19,28 +9,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    // Override point for customization after application launch.
     return true
   }
-
-  // MARK: UISceneSession Lifecycle
 
   func application(
     _ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession,
     options: UIScene.ConnectionOptions
   ) -> UISceneConfiguration {
-    // Called when a new scene session is being created.
-    // Use this method to select a configuration to create the new scene with.
     return UISceneConfiguration(
       name: "Default Configuration", sessionRole: connectingSceneSession.role)
   }
-
-  func application(
-    _ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>
-  ) {
-    // Called when the user discards a scene session.
-    // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
-    // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
-  }
-
 }

--- a/ExampleApps/YOLORealTimeUIKit/YOLORealTimeUIKit/SceneDelegate.swift
+++ b/ExampleApps/YOLORealTimeUIKit/YOLORealTimeUIKit/SceneDelegate.swift
@@ -1,58 +1,7 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-//  This file is part of the Example Apps of Ultralytics YOLO Package, providing the scene delegate for the real-time UIKit example.
-//  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
-//  Access the source code: https://github.com/ultralytics/yolo-ios-app
-//
-//  The SceneDelegate manages the scene lifecycle and configures the user interface environment.
-
 import UIKit
 
-/// Manages scene-specific lifecycle events and UI state for the application.
-///
-/// The SceneDelegate handles state transitions for a single scene instance of the app,
-/// supporting iOS 13's ability to have multiple scenes of the same app open simultaneously.
-/// It manages the window hierarchy and responds to scene state changes.
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-
   var window: UIWindow?
-
-  func scene(
-    _ scene: UIScene, willConnectTo session: UISceneSession,
-    options connectionOptions: UIScene.ConnectionOptions
-  ) {
-    // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
-    // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
-    // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
-    guard (scene as? UIWindowScene) != nil else { return }
-  }
-
-  func sceneDidDisconnect(_ scene: UIScene) {
-    // Called as the scene is being released by the system.
-    // This occurs shortly after the scene enters the background, or when its session is discarded.
-    // Release any resources associated with this scene that can be re-created the next time the scene connects.
-    // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
-  }
-
-  func sceneDidBecomeActive(_ scene: UIScene) {
-    // Called when the scene has moved from an inactive state to an active state.
-    // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
-  }
-
-  func sceneWillResignActive(_ scene: UIScene) {
-    // Called when the scene will move from an active state to an inactive state.
-    // This may occur due to temporary interruptions (ex. an incoming phone call).
-  }
-
-  func sceneWillEnterForeground(_ scene: UIScene) {
-    // Called as the scene transitions from the background to the foreground.
-    // Use this method to undo the changes made on entering the background.
-  }
-
-  func sceneDidEnterBackground(_ scene: UIScene) {
-    // Called as the scene transitions from the foreground to the background.
-    // Use this method to save data, release shared resources, and store enough scene-specific state information
-    // to restore the scene back to its current state.
-  }
-
 }

--- a/ExampleApps/YOLOSingleImageUIKit/YOLOSingleImageUIKit/AppDelegate.swift
+++ b/ExampleApps/YOLOSingleImageUIKit/YOLOSingleImageUIKit/AppDelegate.swift
@@ -1,18 +1,7 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-//  This file is part of the Example Apps of Ultralytics YOLO Package, providing the application delegate for the UIKit example.
-//  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
-//  Access the source code: https://github.com/ultralytics/yolo-ios-app
-//
-//  The AppDelegate handles application lifecycle events and configures the application environment.
-
 import UIKit
 
-/// The application delegate class responsible for managing the application's lifecycle.
-///
-/// This class handles application-level events such as launch, termination, and state transitions.
-/// It's the primary entry point for the YOLO single image processing UIKit example app that demonstrates
-/// using YOLO models on images from the photo library.
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
@@ -20,28 +9,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    // Override point for customization after application launch.
     return true
   }
-
-  // MARK: UISceneSession Lifecycle
 
   func application(
     _ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession,
     options: UIScene.ConnectionOptions
   ) -> UISceneConfiguration {
-    // Called when a new scene session is being created.
-    // Use this method to select a configuration to create the new scene with.
     return UISceneConfiguration(
       name: "Default Configuration", sessionRole: connectingSceneSession.role)
   }
-
-  func application(
-    _ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>
-  ) {
-    // Called when the user discards a scene session.
-    // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
-    // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
-  }
-
 }

--- a/ExampleApps/YOLOSingleImageUIKit/YOLOSingleImageUIKit/SceneDelegate.swift
+++ b/ExampleApps/YOLOSingleImageUIKit/YOLOSingleImageUIKit/SceneDelegate.swift
@@ -1,59 +1,7 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-//  This file is part of the Example Apps of Ultralytics YOLO Package, providing the scene delegate for the UIKit example.
-//  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
-//  Access the source code: https://github.com/ultralytics/yolo-ios-app
-//
-//  The SceneDelegate manages the scene lifecycle and configures the user interface environment.
-
 import UIKit
 
-/// Manages scene-specific lifecycle events and UI state for the application.
-///
-/// The SceneDelegate handles state transitions for a single scene instance of the app,
-/// supporting iOS 13's ability to have multiple scenes of the same app open simultaneously.
-/// It manages the window hierarchy and responds to scene state changes for the YOLO
-/// single image processing example app.
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-
   var window: UIWindow?
-
-  func scene(
-    _ scene: UIScene, willConnectTo session: UISceneSession,
-    options connectionOptions: UIScene.ConnectionOptions
-  ) {
-    // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
-    // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
-    // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
-    guard (scene as? UIWindowScene) != nil else { return }
-  }
-
-  func sceneDidDisconnect(_ scene: UIScene) {
-    // Called as the scene is being released by the system.
-    // This occurs shortly after the scene enters the background, or when its session is discarded.
-    // Release any resources associated with this scene that can be re-created the next time the scene connects.
-    // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
-  }
-
-  func sceneDidBecomeActive(_ scene: UIScene) {
-    // Called when the scene has moved from an inactive state to an active state.
-    // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
-  }
-
-  func sceneWillResignActive(_ scene: UIScene) {
-    // Called when the scene will move from an active state to an inactive state.
-    // This may occur due to temporary interruptions (ex. an incoming phone call).
-  }
-
-  func sceneWillEnterForeground(_ scene: UIScene) {
-    // Called as the scene transitions from the background to the foreground.
-    // Use this method to undo the changes made on entering the background.
-  }
-
-  func sceneDidEnterBackground(_ scene: UIScene) {
-    // Called as the scene transitions from the foreground to the background.
-    // Use this method to save data, release shared resources, and store enough scene-specific state information
-    // to restore the scene back to its current state.
-  }
-
 }

--- a/ExampleApps/YOLOSingleImageUIKit/YOLOSingleImageUIKit/ViewController.swift
+++ b/ExampleApps/YOLOSingleImageUIKit/YOLOSingleImageUIKit/ViewController.swift
@@ -35,14 +35,11 @@ class ViewController: UIViewController, PHPickerViewControllerDelegate {
   /// Sets up the view and initializes the YOLO model.
   override func viewDidLoad() {
     super.viewDidLoad()
-    //      view.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(presentPhPicker)))
-    // Initialize YOLO model with a segmentation task
-    // You can change the model or task type to use detection, classification, etc.
-    model = YOLO("yolo26n", task: .detect) { [self] result in
+    // Initialize YOLO model. Change modelPathOrName/task to use other model types.
+    model = YOLO("yolo26n", task: .detect) { [weak self] result in
       switch result {
-      case .success(_):
-        print("predictor initialized")
-        setupView()
+      case .success:
+        self?.setupView()
       case .failure(let error):
         fatalError(error.localizedDescription)
       }
@@ -50,26 +47,18 @@ class ViewController: UIViewController, PHPickerViewControllerDelegate {
   }
 
   /// Handles the result from the photo picker and performs YOLO inference on the selected image.
-  ///
-  /// - Parameters:
-  ///   - picker: The photo picker view controller.
-  ///   - results: The array of selected photo picker results.
   func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
     picker.dismiss(animated: true)
-    guard let result = results.first else { return }
-    if result.itemProvider.canLoadObject(ofClass: UIImage.self) {
-      result.itemProvider.loadObject(ofClass: UIImage.self) { [weak self] image, error in
-        if let image = image as? UIImage, let safeSelf = self {
-          let correctOrientImage = safeSelf.getCorrectOrientationUIImage(uiImage: image)
-          let date = Date()
-          let result = safeSelf.model(correctOrientImage)
-          let time = Date().timeIntervalSince(date)
-          print(result)
-          DispatchQueue.main.async {
-            UIImageWriteToSavedPhotosAlbum(result.annotatedImage!, self, nil, nil)
-            safeSelf.imageView.image = result.annotatedImage
-          }
-        }
+    guard let provider = results.first?.itemProvider,
+      provider.canLoadObject(ofClass: UIImage.self)
+    else { return }
+
+    provider.loadObject(ofClass: UIImage.self) { [weak self] image, _ in
+      guard let self = self, let image = image as? UIImage else { return }
+      let oriented = self.getCorrectOrientationUIImage(uiImage: image)
+      let inference = self.model(oriented)
+      DispatchQueue.main.async {
+        self.imageView.image = inference.annotatedImage
       }
     }
   }

--- a/Sources/YOLO/Classifier.swift
+++ b/Sources/YOLO/Classifier.swift
@@ -74,13 +74,19 @@ public final class Classifier: BasePredictor, @unchecked Sendable {
 
   /// Applies softmax to raw logits and returns the top-1/top-5 probabilities.
   private func softmaxProbs(from multiArray: MLMultiArray) -> Probs {
+    guard multiArray.dataType == .float32 else {
+      return Probs(top1: "", top5: [], top1Conf: 0, top5Confs: [])
+    }
     let count = multiArray.count
-    var logits = [Float](repeating: 0, count: count)
-    for i in 0..<count { logits[i] = multiArray[i].floatValue }
+    let src = multiArray.dataPointer.assumingMemoryBound(to: Float.self)
 
     var output = [Float](repeating: 0, count: count)
+    var maxLogit: Float = 0
+    vDSP_maxv(src, 1, &maxLogit, vDSP_Length(count))
+    var negMax = -maxLogit
+    vDSP_vsadd(src, 1, &negMax, &output, 1, vDSP_Length(count))
     var n = Int32(count)
-    vvexpf(&output, logits, &n)
+    vvexpf(&output, output, &n)
     var sum: Float = 0
     vDSP_sve(output, 1, &sum, vDSP_Length(count))
     if sum > 0 {

--- a/Sources/YOLO/Classifier.swift
+++ b/Sources/YOLO/Classifier.swift
@@ -74,17 +74,20 @@ public final class Classifier: BasePredictor, @unchecked Sendable {
 
   /// Applies softmax to raw logits and returns the top-1/top-5 probabilities.
   private func softmaxProbs(from multiArray: MLMultiArray) -> Probs {
-    guard multiArray.dataType == .float32 else {
-      return Probs(top1: "", top5: [], top1Conf: 0, top5Confs: [])
-    }
     let count = multiArray.count
-    let src = multiArray.dataPointer.assumingMemoryBound(to: Float.self)
+    var logits = [Float](repeating: 0, count: count)
+    if multiArray.dataType == .float32, multiArray.strides.last?.intValue == 1 {
+      let src = multiArray.dataPointer.assumingMemoryBound(to: Float.self)
+      logits.withUnsafeMutableBufferPointer { $0.baseAddress!.update(from: src, count: count) }
+    } else {
+      for i in 0..<count { logits[i] = multiArray[i].floatValue }
+    }
 
     var output = [Float](repeating: 0, count: count)
     var maxLogit: Float = 0
-    vDSP_maxv(src, 1, &maxLogit, vDSP_Length(count))
+    vDSP_maxv(logits, 1, &maxLogit, vDSP_Length(count))
     var negMax = -maxLogit
-    vDSP_vsadd(src, 1, &negMax, &output, 1, vDSP_Length(count))
+    vDSP_vsadd(logits, 1, &negMax, &output, 1, vDSP_Length(count))
     var n = Int32(count)
     vvexpf(&output, output, &n)
     var sum: Float = 0

--- a/Sources/YOLO/NonMaxSuppression.swift
+++ b/Sources/YOLO/NonMaxSuppression.swift
@@ -21,23 +21,26 @@ import Foundation
 ///   - threshold: The minimum overlap ratio required to suppress a box.
 /// - Returns: Indices of the selected bounding boxes after suppression.
 public func nonMaxSuppression(boxes: [CGRect], scores: [Float], threshold: Float) -> [Int] {
+  let count = boxes.count
   let sortedIndices = scores.enumerated().sorted { $0.element > $1.element }.map { $0.offset }
+  let areas = boxes.map { $0.area }
   var selectedIndices = [Int]()
-  var activeIndices = [Bool](repeating: true, count: boxes.count)
+  var activeIndices = [Bool](repeating: true, count: count)
+  let iouThreshold = CGFloat(threshold)
 
   for i in 0..<sortedIndices.count {
     let idx = sortedIndices[i]
-    if activeIndices[idx] {
-      selectedIndices.append(idx)
-      for j in i + 1..<sortedIndices.count {
-        let otherIdx = sortedIndices[j]
-        if activeIndices[otherIdx] {
-          let intersection = boxes[idx].intersection(boxes[otherIdx])
-          let union = boxes[idx].area + boxes[otherIdx].area - intersection.area
-          if union > 0 && intersection.area / union > CGFloat(threshold) {
-            activeIndices[otherIdx] = false
-          }
-        }
+    if !activeIndices[idx] { continue }
+    selectedIndices.append(idx)
+    let boxA = boxes[idx]
+    let areaA = areas[idx]
+    for j in (i + 1)..<sortedIndices.count {
+      let otherIdx = sortedIndices[j]
+      if !activeIndices[otherIdx] { continue }
+      let interArea = boxA.intersection(boxes[otherIdx]).area
+      let union = areaA + areas[otherIdx] - interArea
+      if union > 0 && interArea / union > iouThreshold {
+        activeIndices[otherIdx] = false
       }
     }
   }

--- a/Sources/YOLO/ObjectDetector.swift
+++ b/Sources/YOLO/ObjectDetector.swift
@@ -217,10 +217,11 @@ public final class ObjectDetector: BasePredictor, @unchecked Sendable {
     var candidateClasses = [Int]()
 
     for j in 0..<numAnchors {
+      let anchorOffset = j * anchorStride
       var bestScore: Float = 0
       var bestClass = 0
       for c in 0..<numClasses {
-        let score = pointer[(4 + c) * featureStride + j * anchorStride]
+        let score = pointer[(4 + c) * featureStride + anchorOffset]
         if score > bestScore {
           bestScore = score
           bestClass = c
@@ -228,10 +229,10 @@ public final class ObjectDetector: BasePredictor, @unchecked Sendable {
       }
       guard bestScore > confThreshold else { continue }
 
-      let x = pointer[j * anchorStride]
-      let y = pointer[featureStride + j * anchorStride]
-      let w = pointer[2 * featureStride + j * anchorStride]
-      let h = pointer[3 * featureStride + j * anchorStride]
+      let x = pointer[anchorOffset]
+      let y = pointer[featureStride + anchorOffset]
+      let w = pointer[2 * featureStride + anchorOffset]
+      let h = pointer[3 * featureStride + anchorOffset]
       candidateBoxes.append(
         CGRect(x: CGFloat(x - w / 2), y: CGFloat(y - h / 2), width: CGFloat(w), height: CGFloat(h))
       )

--- a/Sources/YOLO/PoseEstimator.swift
+++ b/Sources/YOLO/PoseEstimator.swift
@@ -56,7 +56,6 @@ public final class PoseEstimator: BasePredictor, @unchecked Sendable {
     let imageWidth = image.extent.width
     let imageHeight = image.extent.height
     self.inputSize = CGSize(width: imageWidth, height: imageHeight)
-    let result = YOLOResult(orig_shape: .zero, boxes: [], speed: 0, names: labels)
 
     do {
       try requestHandler.perform([request])
@@ -99,7 +98,7 @@ public final class PoseEstimator: BasePredictor, @unchecked Sendable {
     } catch {
       YOLOLog.error("Pose estimation failed: \(error)")
     }
-    return result
+    return YOLOResult(orig_shape: inputSize, boxes: [], speed: 0, names: labels)
   }
 
   func PostProcessPose(
@@ -122,16 +121,12 @@ public final class PoseEstimator: BasePredictor, @unchecked Sendable {
     let numAnchors = shape[2]
     let featureCount = shape[1] - 5
 
-    var boxes = [CGRect]()
-    var scores = [Float]()
-    var features = [[Float]]()
-
     // Wrapper for thread-safe collections
     final class CollectionsWrapper: @unchecked Sendable {
       private let lock = NSLock()
-      private var boxes: [CGRect] = []
-      private var scores: [Float] = []
-      private var features: [[Float]] = []
+      private(set) var boxes: [CGRect] = []
+      private(set) var scores: [Float] = []
+      private(set) var features: [[Float]] = []
 
       func append(box: CGRect, score: Float, feature: [Float]) {
         lock.lock()
@@ -139,10 +134,6 @@ public final class PoseEstimator: BasePredictor, @unchecked Sendable {
         scores.append(score)
         features.append(feature)
         lock.unlock()
-      }
-
-      func getCollections() -> (boxes: [CGRect], scores: [Float], features: [[Float]]) {
-        return (boxes, scores, features)
       }
     }
 
@@ -156,38 +147,31 @@ public final class PoseEstimator: BasePredictor, @unchecked Sendable {
     let collectionsWrapper = CollectionsWrapper()
 
     DispatchQueue.concurrentPerform(iterations: numAnchors) { j in
-      let confIndex = 4 * numAnchors + j
-      let confidence = pointerWrapper.pointer[confIndex]
+      let confidence = pointerWrapper.pointer[4 * numAnchors + j]
+      guard confidence > confidenceThreshold else { return }
 
-      if confidence > confidenceThreshold {
-        let x = pointerWrapper.pointer[j]
-        let y = pointerWrapper.pointer[numAnchors + j]
-        let width = pointerWrapper.pointer[2 * numAnchors + j]
-        let height = pointerWrapper.pointer[3 * numAnchors + j]
+      let x = pointerWrapper.pointer[j]
+      let y = pointerWrapper.pointer[numAnchors + j]
+      let width = pointerWrapper.pointer[2 * numAnchors + j]
+      let height = pointerWrapper.pointer[3 * numAnchors + j]
 
-        let boxWidth = CGFloat(width)
-        let boxHeight = CGFloat(height)
-        let boxX = CGFloat(x - width / 2.0)
-        let boxY = CGFloat(y - height / 2.0)
-        let boundingBox = CGRect(
-          x: boxX, y: boxY,
-          width: boxWidth, height: boxHeight)
+      let boundingBox = CGRect(
+        x: CGFloat(x - width / 2),
+        y: CGFloat(y - height / 2),
+        width: CGFloat(width),
+        height: CGFloat(height))
 
-        var boxFeatures = [Float](repeating: 0, count: featureCount)
-        for k in 0..<featureCount {
-          let key = (5 + k) * numAnchors + j
-          boxFeatures[k] = pointerWrapper.pointer[key]
-        }
-
-        collectionsWrapper.append(box: boundingBox, score: confidence, feature: boxFeatures)
+      var boxFeatures = [Float](repeating: 0, count: featureCount)
+      for k in 0..<featureCount {
+        boxFeatures[k] = pointerWrapper.pointer[(5 + k) * numAnchors + j]
       }
+
+      collectionsWrapper.append(box: boundingBox, score: confidence, feature: boxFeatures)
     }
 
-    // Get collections from wrapper
-    let collections = collectionsWrapper.getCollections()
-    boxes = collections.boxes
-    scores = collections.scores
-    features = collections.features
+    let boxes = collectionsWrapper.boxes
+    let scores = collectionsWrapper.scores
+    let features = collectionsWrapper.features
 
     let selectedIndices = nonMaxSuppression(boxes: boxes, scores: scores, threshold: iouThreshold)
 

--- a/Sources/YOLO/Segmenter.swift
+++ b/Sources/YOLO/Segmenter.swift
@@ -165,30 +165,19 @@ public final class Segmenter: BasePredictor, @unchecked Sendable {
     let maskConfidenceLength = 32
     let numClasses = numFeatures - boxFeatureLength - maskConfidenceLength
 
-    // Pre-allocate result arrays with estimated capacity
-    let estimatedCapacity = min(numAnchors / 10, 100)  // Estimate ~10% detection rate
-    let resultsWrapper = ResultsWrapper(capacity: estimatedCapacity)
-
     // Wrapper for thread-safe results collection
     final class ResultsWrapper: @unchecked Sendable {
       private let lock = NSLock()
-      private var results: [(CGRect, Int, Float, MLMultiArray)]
-
-      init(capacity: Int) {
-        self.results = []
-        self.results.reserveCapacity(capacity)
-      }
+      private(set) var results: [(CGRect, Int, Float, MLMultiArray)] = []
 
       func append(_ result: (CGRect, Int, Float, MLMultiArray)) {
         lock.lock()
         results.append(result)
         lock.unlock()
       }
-
-      func getResults() -> [(CGRect, Int, Float, MLMultiArray)] {
-        return results
-      }
     }
+
+    let resultsWrapper = ResultsWrapper()
 
     let featurePointer = feature.dataPointer.assumingMemoryBound(to: Float.self)
     let pointerWrapper = FloatPointerWrapper(featurePointer)
@@ -244,18 +233,12 @@ public final class Segmenter: BasePredictor, @unchecked Sendable {
       }
     }
 
-    // Get results from wrapper
-    let collectedResults = resultsWrapper.getResults()
+    let collectedResults = resultsWrapper.results
 
-    // Optimize NMS by grouping results by class first
+    // Group results by class for per-class NMS
     var classBuckets: [Int: [(CGRect, Int, Float, MLMultiArray)]] = [:]
     for result in collectedResults {
-      let classIndex = result.1
-      if classBuckets[classIndex] == nil {
-        classBuckets[classIndex] = []
-        classBuckets[classIndex]!.reserveCapacity(collectedResults.count / numClasses + 1)
-      }
-      classBuckets[classIndex]?.append(result)
+      classBuckets[result.1, default: []].append(result)
     }
 
     var selectedBoxesAndFeatures: [(CGRect, Int, Float, MLMultiArray)] = []

--- a/Sources/YOLO/ThresholdProvider.swift
+++ b/Sources/YOLO/ThresholdProvider.swift
@@ -15,7 +15,7 @@ import CoreML
 /// Provides custom IoU and confidence thresholds for adjusting model predictions.
 public final class ThresholdProvider: MLFeatureProvider {
   /// Stores IoU and confidence thresholds as MLFeatureValue objects.
-  var values: [String: MLFeatureValue]
+  let values: [String: MLFeatureValue]
 
   /// The set of feature names provided by this provider.
   public var featureNames: Set<String> {

--- a/Sources/YOLO/VideoCapture.swift
+++ b/Sources/YOLO/VideoCapture.swift
@@ -154,7 +154,6 @@ public final class VideoCapture: NSObject, @unchecked Sendable {
   var shortSide: CGFloat = 4
   var frameSizeCaptured = false
 
-  private var currentBuffer: CVPixelBuffer?
   private lazy var imageContext = CIContext()
   private var frameCaptureCompletion: ((UIImage?) -> Void)?
 
@@ -384,22 +383,15 @@ public final class VideoCapture: NSObject, @unchecked Sendable {
   }
 
   private func predictOnFrame(sampleBuffer: CMSampleBuffer) {
-    guard let predictor = predictor else {
-      return
+    guard let predictor = predictor else { return }
+    if !frameSizeCaptured, let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) {
+      let frameWidth = CGFloat(CVPixelBufferGetWidth(pixelBuffer))
+      let frameHeight = CGFloat(CVPixelBufferGetHeight(pixelBuffer))
+      longSide = max(frameWidth, frameHeight)
+      shortSide = min(frameWidth, frameHeight)
+      frameSizeCaptured = true
     }
-    if currentBuffer == nil, let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) {
-      currentBuffer = pixelBuffer
-      if !frameSizeCaptured {
-        let frameWidth = CGFloat(CVPixelBufferGetWidth(pixelBuffer))
-        let frameHeight = CGFloat(CVPixelBufferGetHeight(pixelBuffer))
-        longSide = max(frameWidth, frameHeight)
-        shortSide = min(frameWidth, frameHeight)
-        frameSizeCaptured = true
-      }
-
-      predictor.predict(sampleBuffer: sampleBuffer, onResultsListener: self, onInferenceTime: self)
-      currentBuffer = nil
-    }
+    predictor.predict(sampleBuffer: sampleBuffer, onResultsListener: self, onInferenceTime: self)
   }
 
   func updateVideoOrientation(orientation: AVCaptureVideoOrientation) {

--- a/Sources/YOLO/VideoCapture.swift
+++ b/Sources/YOLO/VideoCapture.swift
@@ -154,6 +154,7 @@ public final class VideoCapture: NSObject, @unchecked Sendable {
   var shortSide: CGFloat = 4
   var frameSizeCaptured = false
 
+  private var currentBuffer: CVPixelBuffer?
   private lazy var imageContext = CIContext()
   private var frameCaptureCompletion: ((UIImage?) -> Void)?
 
@@ -383,15 +384,19 @@ public final class VideoCapture: NSObject, @unchecked Sendable {
   }
 
   private func predictOnFrame(sampleBuffer: CMSampleBuffer) {
-    guard let predictor = predictor else { return }
-    if !frameSizeCaptured, let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) {
-      let frameWidth = CGFloat(CVPixelBufferGetWidth(pixelBuffer))
-      let frameHeight = CGFloat(CVPixelBufferGetHeight(pixelBuffer))
-      longSide = max(frameWidth, frameHeight)
-      shortSide = min(frameWidth, frameHeight)
+    guard let predictor = predictor, currentBuffer == nil,
+      let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer)
+    else { return }
+    currentBuffer = pixelBuffer
+    if !frameSizeCaptured {
+      let w = CGFloat(CVPixelBufferGetWidth(pixelBuffer))
+      let h = CGFloat(CVPixelBufferGetHeight(pixelBuffer))
+      longSide = max(w, h)
+      shortSide = min(w, h)
       frameSizeCaptured = true
     }
     predictor.predict(sampleBuffer: sampleBuffer, onResultsListener: self, onInferenceTime: self)
+    currentBuffer = nil
   }
 
   func updateVideoOrientation(orientation: AVCaptureVideoOrientation) {

--- a/Sources/YOLO/YOLOModelCache.swift
+++ b/Sources/YOLO/YOLOModelCache.swift
@@ -61,8 +61,7 @@ public final class YOLOModelCache {
   public func cacheKey(for url: URL, task: YOLOTask? = nil) -> String {
     let urlString =
       task.map { url.absoluteString + "_" + String(describing: $0) } ?? url.absoluteString
-    let key = urlString.data(using: .utf8)?.sha256() ?? url.lastPathComponent
-    return key.replacingOccurrences(of: "/", with: "_")
+    return Data(urlString.utf8).sha256()
   }
 
   /// Check if model is cached

--- a/Sources/YOLO/YOLOView.swift
+++ b/Sources/YOLO/YOLOView.swift
@@ -169,14 +169,12 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
 
   public override func awakeFromNib() {
     super.awakeFromNib()
-    Task { @MainActor in
-      setUpOrientationChangeNotification()
-      setUpBoundingBoxViews()
-      setupUI()
-      videoCapture.delegate = self
-      start(position: .back)
-      setupOverlayLayer()
-    }
+    setUpOrientationChangeNotification()
+    setUpBoundingBoxViews()
+    setupUI()
+    videoCapture.delegate = self
+    start(position: .back)
+    setupOverlayLayer()
   }
 
   public func setModel(
@@ -229,41 +227,35 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   }
 
   private func start(position: AVCaptureDevice.Position) {
-    if !busy {
-      busy = true
-      let orientation = UIDevice.current.orientation
-      videoCapture.setUp(sessionPreset: .photo, position: position, orientation: orientation) {
-        [weak self] success in
-        Task { @MainActor in
-          guard let self = self else { return }
-          if success {
-            // Add the video preview into the UI.
-            if let previewLayer = self.videoCapture.previewLayer {
-              self.layer.insertSublayer(previewLayer, at: 0)
-              self.videoCapture.previewLayer?.frame = self.bounds  // resize preview layer
-              for box in self.boundingBoxViews {
-                box.addToLayer(previewLayer)
-              }
-            }
-            self.videoCapture.previewLayer?.addSublayer(self.overlayLayer)
-            // Once everything is set up, we can start capturing live video.
-            self.videoCapture.start()
-
-            // Apply deferred camera position if set (e.g., front camera from SwiftUI)
-            if let pending = self.pendingCameraPosition, pending != .back {
-              self.pendingCameraPosition = nil
-              self.switchCameraTapped()
-            }
-            if let device = self.videoCapture.captureDevice {
-              self.lastZoomFactor = device.videoZoomFactor
-              self.labelZoom.text = self.zoomLabelText(
-                rawZoomFactor: self.lastZoomFactor, device: device)
-            }
-            self.updateLensControl()
-
-            self.busy = false
+    guard !busy else { return }
+    busy = true
+    let orientation = UIDevice.current.orientation
+    videoCapture.setUp(sessionPreset: .photo, position: position, orientation: orientation) {
+      [weak self] success in
+      Task { @MainActor in
+        guard let self = self else { return }
+        defer { self.busy = false }
+        guard success else { return }
+        if let previewLayer = self.videoCapture.previewLayer {
+          self.layer.insertSublayer(previewLayer, at: 0)
+          previewLayer.frame = self.bounds
+          for box in self.boundingBoxViews {
+            box.addToLayer(previewLayer)
           }
+          previewLayer.addSublayer(self.overlayLayer)
         }
+        self.videoCapture.start()
+
+        if let pending = self.pendingCameraPosition, pending != .back {
+          self.pendingCameraPosition = nil
+          self.switchCameraTapped()
+        }
+        if let device = self.videoCapture.captureDevice {
+          self.lastZoomFactor = device.videoZoomFactor
+          self.labelZoom.text = self.zoomLabelText(
+            rawZoomFactor: self.lastZoomFactor, device: device)
+        }
+        self.updateLensControl()
       }
     }
   }
@@ -428,9 +420,6 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
       setupPoseLayerIfNeeded()
     case .obb:
       setupObbLayerIfNeeded()
-      if let obbLayer = obbLayer, obbLayer.superlayer !== overlayLayer {
-        overlayLayer.addSublayer(obbLayer)
-      }
       obbLayer?.isHidden = false
     default: break
     }
@@ -438,10 +427,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
 
   func removeAllSubLayers(parentLayer: CALayer?) {
     guard let parentLayer = parentLayer else { return }
-    parentLayer.sublayers?.forEach { layer in
-      layer.removeFromSuperlayer()
-    }
-    parentLayer.sublayers = nil
+    parentLayer.sublayers?.forEach { $0.removeFromSuperlayer() }
     parentLayer.contents = nil
   }
 
@@ -717,8 +703,6 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     let isLandscape = bounds.width > bounds.height
     activityIndicator.frame = CGRect(x: center.x - 50, y: center.y - 50, width: 100, height: 100)
 
-    // Apply consistent toolbar styling
-    applyToolbarStyling(isLandscape: isLandscape)
     updateLensControlVisibility()
 
     if isLandscape {
@@ -729,15 +713,6 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
 
     self.videoCapture.previewLayer?.frame = self.bounds
     cameraTransitionView?.frame = self.bounds
-  }
-
-  /// Apply consistent toolbar and button styling
-  private func applyToolbarStyling(isLandscape: Bool) {
-    toolbar.backgroundColor = .black.withAlphaComponent(0.7)
-    let buttonColor: UIColor = isLandscape ? .white : .white
-    [playButton, pauseButton, switchCameraButton, shareButton, infoButton].forEach { button in
-      button.tintColor = buttonColor
-    }
   }
 
   /// Layout views for landscape orientation

--- a/YOLOiOSApp/YOLOiOSApp/AppDelegate.swift
+++ b/YOLOiOSApp/YOLOiOSApp/AppDelegate.swift
@@ -1,69 +1,16 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-//  This file is part of the Ultralytics YOLO app, enabling YOLO11 model previews on iOS devices.
-//  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
-//  Access the source code: https://github.com/ultralytics/yolo-ios-app
-//
-//  The AppDelegate initializes app settings, manages system-level configurations, and facilitates
-//  the integration of additional services such as Firebase analytics.
-//  This file includes the app's delegate class, responsible for handling the app's lifecycle events,
-//  configuring global settings (such as disabling the idle timer and enabling battery monitoring),
-//  and storing app version and device UUID in UserDefaults for easy access throughout the app.
-//  An extension to CALayer is also provided to enable easy screenshot functionality for any layer
-//  within the app, utilizing the device's screen scale for high-resolution captures.
-
 import UIKit
 
-/// The main application delegate, handling global app behavior and configuration.
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
   var window: UIWindow?
 
-  /// Called when the app finishes launching, used here to set global app settings.
   func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    // Disable screen dimming and auto-lock to keep the app active during long operations.
     UIApplication.shared.isIdleTimerDisabled = true
-
-    // Enable battery monitoring to allow the app to adapt its behavior based on battery level.
-    UIDevice.current.isBatteryMonitoringEnabled = true
-
-    // Store the app version and build version in UserDefaults for easy access elsewhere in the app.
-    if let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,
-      let buildVersion = Bundle.main.infoDictionary?["CFBundleVersion"] as? String
-    {
-      UserDefaults.standard.set("\(appVersion) (\(buildVersion))", forKey: "app_version")
-    }
-
-    // Store the device's UUID in UserDefaults for identification purposes.
-    if let uuid = UIDevice.current.identifierForVendor?.uuidString {
-      UserDefaults.standard.set(uuid, forKey: "uuid")
-    }
-
-    // Ensure UserDefaults changes are immediately saved.
-    UserDefaults.standard.synchronize()
-
     return true
-  }
-}
-
-/// Extension to CALayer to add functionality for generating screenshots of any layer.
-extension CALayer {
-  var screenShot: UIImage? {
-    // Begin a new image context, using the device's screen scale to ensure high-resolution output.
-    UIGraphicsBeginImageContextWithOptions(frame.size, false, UIScreen.main.scale)
-    defer {
-      UIGraphicsEndImageContext()
-    }  // Ensure the image context is cleaned up correctly.
-
-    if let context = UIGraphicsGetCurrentContext() {
-      // Render the layer into the current context.
-      render(in: context)
-      // Attempt to generate an image from the current context.
-      return UIGraphicsGetImageFromCurrentImageContext()
-    }
-    return nil  // Return nil if the operation fails.
   }
 }

--- a/YOLOiOSApp/YOLOiOSApp/ExternalDisplay/ExternalViewController.swift
+++ b/YOLOiOSApp/YOLOiOSApp/ExternalDisplay/ExternalViewController.swift
@@ -277,7 +277,8 @@ class ExternalViewController: UIViewController, YOLOViewDelegate {
       guard ModelCacheManager.shared.isModelDownloaded(key: modelName) else { return }
       let documentsDirectory = FileManager.default.urls(
         for: .documentDirectory, in: .userDomainMask)[0]
-      actualModelPath = documentsDirectory.appendingPathComponent(modelName)
+      actualModelPath =
+        documentsDirectory.appendingPathComponent(modelName)
         .appendingPathExtension("mlmodelc").path
     }
 

--- a/YOLOiOSApp/YOLOiOSApp/ExternalDisplay/ExternalViewController.swift
+++ b/YOLOiOSApp/YOLOiOSApp/ExternalDisplay/ExternalViewController.swift
@@ -217,9 +217,8 @@ class ExternalViewController: UIViewController, YOLOViewDelegate {
     let scaleFactor = calculateScaleFactor(for: view.bounds.size)
     setupConstraints(scaleFactor: scaleFactor)
 
-    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-      self.hideYOLOViewControls()
-      // Don't load initial model - wait for main app to notify us
+    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in
+      self?.hideYOLOViewControls()
       NotificationCenter.default.post(name: .externalDisplayReady, object: nil)
     }
   }
@@ -271,38 +270,19 @@ class ExternalViewController: UIViewController, YOLOViewDelegate {
       }
     }
 
-    // Determine the actual model path to use
     var actualModelPath = modelName
-
-    // Check if this is a full path (local bundle model) or just an identifier (downloaded model)
     if !modelName.hasPrefix("/") && !modelName.contains(".mlpackage")
       && !modelName.contains(".mlmodel")
     {
-      // This is a downloaded model identifier
-      // First check if the model is actually downloaded
-      if ModelCacheManager.shared.isModelDownloaded(key: modelName) {
-        // Construct the full path for the downloaded model
-        let documentsDirectory = FileManager.default.urls(
-          for: .documentDirectory, in: .userDomainMask)[0]
-        let localModelURL = documentsDirectory.appendingPathComponent(modelName)
-          .appendingPathExtension("mlmodelc")
-        actualModelPath = localModelURL.path
-        print("📱 External display loading cached model from: \(actualModelPath)")
-      } else {
-        print("❌ Model not downloaded yet: \(modelName)")
-        return  // Exit early if model is not downloaded
-      }
-    } else {
-      print("📱 External display loading bundle model from: \(actualModelPath)")
+      guard ModelCacheManager.shared.isModelDownloaded(key: modelName) else { return }
+      let documentsDirectory = FileManager.default.urls(
+        for: .documentDirectory, in: .userDomainMask)[0]
+      actualModelPath = documentsDirectory.appendingPathComponent(modelName)
+        .appendingPathExtension("mlmodelc").path
     }
 
-    let capturedModelPath = actualModelPath
-    yoloView?.setModel(modelPathOrName: capturedModelPath, task: task) { [weak self] result in
-      guard case .success = result else {
-        print("❌ Failed to load model on external display: \(capturedModelPath)")
-        return
-      }
-
+    yoloView?.setModel(modelPathOrName: actualModelPath, task: task) { [weak self] result in
+      guard case .success = result else { return }
       DispatchQueue.main.async {
         self?.updateModelNameLabel()
         self?.yoloView?.setNeedsDisplay()
@@ -344,10 +324,9 @@ class ExternalViewController: UIViewController, YOLOViewDelegate {
       return
     }
 
-    // Find the task in our tasks array and update segment control
     if let taskIndex = tasks.firstIndex(where: { $0.name == taskName }) {
-      DispatchQueue.main.async {
-        self.segmentedControl.selectedSegmentIndex = taskIndex
+      DispatchQueue.main.async { [weak self] in
+        self?.segmentedControl.selectedSegmentIndex = taskIndex
       }
     }
   }

--- a/YOLOiOSApp/YOLOiOSApp/ExternalDisplay/ViewController+ExternalDisplay.swift
+++ b/YOLOiOSApp/YOLOiOSApp/ExternalDisplay/ViewController+ExternalDisplay.swift
@@ -21,74 +21,42 @@ import YOLO
 // MARK: - External Display Support
 extension ViewController {
 
-  // Associated object key for tracking external display state
-  private struct AssociatedKeys {
-    static var isExternalDisplayConnected: UInt8 = 0
-  }
-
-  private var isExternalDisplayConnected: Bool {
-    get {
-      return objc_getAssociatedObject(self, &AssociatedKeys.isExternalDisplayConnected) as? Bool
-        ?? false
-    }
-    set {
-      objc_setAssociatedObject(
-        self, &AssociatedKeys.isExternalDisplayConnected, newValue,
-        .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-    }
-  }
-
-  // Helper function to check for external screens (iOS 16+ compatible)
-  private func hasExternalScreen() -> Bool {
-    if #available(iOS 16.0, *) {
-      return UIApplication.shared.connectedScenes
-        .compactMap { $0 as? UIWindowScene }
-        .contains { $0.screen != UIScreen.main }
-    } else {
-      return UIScreen.screens.count > 1
-    }
+  func hasExternalScreen() -> Bool {
+    UIApplication.shared.connectedScenes
+      .compactMap { $0 as? UIWindowScene }
+      .contains { $0.screen != UIScreen.main }
   }
 
   func setupExternalDisplayNotifications() {
-    print("Setting up external display notifications")
-
-    // Check if external display is already connected at startup
     if hasExternalScreen() {
-      print("External display already connected at startup - triggering connection handler")
-      DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+        guard let self = self else { return }
         self.handleExternalDisplayConnected(Notification(name: .externalDisplayConnected))
       }
     }
 
-    // Listen for external display connection
     NotificationCenter.default.addObserver(
       self,
       selector: #selector(handleExternalDisplayConnected(_:)),
       name: .externalDisplayConnected,
       object: nil
     )
-
-    // Listen for external display disconnection
     NotificationCenter.default.addObserver(
       self,
       selector: #selector(handleExternalDisplayDisconnected(_:)),
       name: .externalDisplayDisconnected,
       object: nil
     )
-
-    // Listen for when external display is ready
     NotificationCenter.default.addObserver(
       self,
       selector: #selector(handleExternalDisplayReady(_:)),
       name: .externalDisplayReady,
       object: nil
     )
-
   }
 
   @objc func handleExternalDisplayConnected(_ notification: Notification) {
     DispatchQueue.main.async {
-      self.isExternalDisplayConnected = true
       self.yoloView.stop()
       self.yoloView.setInferenceFlag(ok: false)
       self.showExternalDisplayStatus()
@@ -96,8 +64,6 @@ extension ViewController {
       self.requestLandscapeOrientation()
 
       DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-        self.adjustLayoutForExternalDisplayIfNeeded()
-
         self.view.setNeedsLayout()
         self.view.layoutIfNeeded()
         [
@@ -132,13 +98,8 @@ extension ViewController {
 
   private func requestLandscapeOrientation() {
     guard let windowScene = view.window?.windowScene else { return }
-
-    if #available(iOS 16.0, *) {
-      windowScene.requestGeometryUpdate(
-        .iOS(interfaceOrientations: [.landscapeLeft, .landscapeRight]))
-    } else {
-      UIViewController.attemptRotationToDeviceOrientation()
-    }
+    windowScene.requestGeometryUpdate(
+      .iOS(interfaceOrientations: [.landscapeLeft, .landscapeRight]))
   }
 
   func notifyExternalDisplayOfCurrentModel() {
@@ -160,7 +121,6 @@ extension ViewController {
 
   @objc func handleExternalDisplayDisconnected(_ notification: Notification) {
     DispatchQueue.main.async {
-      self.isExternalDisplayConnected = false
       self.yoloView.isHidden = false
       self.hideExternalDisplayStatus()
 
@@ -186,32 +146,13 @@ extension ViewController {
 
   private func requestPortraitOrientation() {
     guard let windowScene = view.window?.windowScene else { return }
+    windowScene.requestGeometryUpdate(
+      .iOS(interfaceOrientations: [.portrait, .landscapeLeft, .landscapeRight]))
+    setNeedsUpdateOfSupportedInterfaceOrientations()
 
-    if #available(iOS 16.0, *) {
-      windowScene.requestGeometryUpdate(
-        .iOS(interfaceOrientations: [.portrait, .landscapeLeft, .landscapeRight]))
-      setNeedsUpdateOfSupportedInterfaceOrientations()
-
-      if UIDevice.current.orientation.isLandscape {
-        UIDevice.current.setValue(UIInterfaceOrientation.portrait.rawValue, forKey: "orientation")
-      }
-    } else {
-      UIViewController.attemptRotationToDeviceOrientation()
-
-      if UIDevice.current.orientation.isLandscape {
-        UIDevice.current.setValue(UIInterfaceOrientation.portrait.rawValue, forKey: "orientation")
-      }
+    if UIDevice.current.orientation.isLandscape {
+      UIDevice.current.setValue(UIInterfaceOrientation.portrait.rawValue, forKey: "orientation")
     }
-  }
-
-  // MARK: - Layout Adjustments for External Display
-
-  func adjustLayoutForExternalDisplayIfNeeded() {
-    let hasExternalDisplay = hasExternalScreen() || SceneDelegate.hasExternalDisplay
-
-    guard hasExternalDisplay else { return }
-
-    // Layout adjustments for external display mode if needed
   }
 
   @objc func handleExternalDisplayReady(_ notification: Notification) {
@@ -238,24 +179,10 @@ extension ViewController {
   }
 
   func checkAndNotifyExternalDisplayIfReady() {
-    let hasExternalDisplay = UIApplication.shared.connectedScenes
-      .compactMap({ $0 as? UIWindowScene })
-      .contains(where: { $0.screen != UIScreen.main })
-
-    if hasExternalDisplay {
-      DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-        self.handleExternalDisplayReady(Notification(name: .externalDisplayReady))
-      }
-    }
-  }
-
-  func checkForExternalDisplays() {
-    let hasExternalDisplay = hasExternalScreen()
-
-    if hasExternalDisplay {
-      _ = UIApplication.shared.connectedScenes
-        .compactMap({ $0 as? UIWindowScene })
-        .first(where: { $0.screen != UIScreen.main })
+    guard hasExternalScreen() else { return }
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+      guard let self = self else { return }
+      self.handleExternalDisplayReady(Notification(name: .externalDisplayReady))
     }
   }
 

--- a/YOLOiOSApp/YOLOiOSApp/ModelDownloadManager.swift
+++ b/YOLOiOSApp/YOLOiOSApp/ModelDownloadManager.swift
@@ -25,31 +25,17 @@ struct ModelEntry {
   let displayName: String
   let identifier: String
   let isLocalBundle: Bool
-  let isRemote: Bool
   let remoteURL: URL?
-
-  init(
-    displayName: String, identifier: String, isLocalBundle: Bool = false, isRemote: Bool = false,
-    remoteURL: URL? = nil
-  ) {
-    self.displayName = displayName
-    self.identifier = identifier
-    self.isLocalBundle = isLocalBundle
-    self.isRemote = isRemote
-    self.remoteURL = remoteURL
-  }
 }
 
 class ModelCacheManager {
   static let shared = ModelCacheManager()
-  var modelCache: [String: MLModel] = [:]
+  private var modelCache: [String: MLModel] = [:]
   private var accessOrder: [String] = []
   private let cacheLimit = 3
-  private var currentSelectedModelKey: String?
 
   private init() {}
 
-  /// Update cache access order for key.
   private func updateAccessOrder(for key: String) {
     if let index = accessOrder.firstIndex(of: key) {
       accessOrder.remove(at: index)
@@ -57,33 +43,11 @@ class ModelCacheManager {
     accessOrder.append(key)
   }
 
-  /// Get model URL in documents directory.
   private func modelURL(for key: String) -> URL {
     documentsDirectory.appendingPathComponent(key).appendingPathExtension("mlmodelc")
   }
 
-  func loadBundledModel() {
-    guard let url = getModelFileURL(fileName: "yolov8m"),
-      let bundledModel = try? MLModel(contentsOf: url)
-    else {
-      print("Failed to load bundled model")
-      return
-    }
-
-    addModelToCache(bundledModel, for: "yolov8m")
-    let destinationURL = modelURL(for: "yolov8m")
-
-    do {
-      if !FileManager.default.fileExists(atPath: destinationURL.path) {
-        try FileManager.default.copyItem(at: url, to: destinationURL)
-        print("File copied to documents directory: \(destinationURL.path)")
-      }
-    } catch {
-      print("Error copying file: \(error)")
-    }
-  }
-
-  func loadLocalModel(key: String, completion: @escaping (MLModel?, String) -> Void) {
+  private func loadLocalModel(key: String, completion: @escaping (MLModel?, String) -> Void) {
     if let cachedModel = modelCache[key] {
       updateAccessOrder(for: key)
       completion(cachedModel, key)
@@ -91,14 +55,13 @@ class ModelCacheManager {
     }
 
     let localModelURL = modelURL(for: key)
-    guard FileManager.default.fileExists(atPath: localModelURL.path) else { return }
-
     do {
       let model = try MLModel(contentsOf: localModelURL)
       addModelToCache(model, for: key)
       completion(model, key)
     } catch {
       print("Error loading local model: \(error)")
+      completion(nil, key)
     }
   }
 
@@ -132,82 +95,30 @@ class ModelCacheManager {
   func isModelDownloaded(key: String) -> Bool {
     FileManager.default.fileExists(atPath: modelURL(for: key).path)
   }
-
-  func prioritizeDownload(for fileName: String, completion: @escaping (MLModel?, String) -> Void) {
-    ModelDownloadManager.shared.prioritizeDownload(for: fileName, completion: completion)
-  }
-
-  func setCurrentSelectedModelKey(_ key: String) { currentSelectedModelKey = key }
-  func getCurrentSelectedModelKey() -> String? { currentSelectedModelKey }
 }
 
 class ModelDownloadManager: NSObject {
   static let shared = ModelDownloadManager()
   private var downloadTasks: [URLSessionDownloadTask: (url: URL, key: String)] = [:]
   private var downloadCompletionHandlers: [URLSessionDownloadTask: (MLModel?, String) -> Void] = [:]
-  private var priorityTask: URLSessionDownloadTask?
+  private lazy var session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
   var progressHandler: ((Double) -> Void)?
 
   private override init() {}
 
-  /// Complete download task and cleanup.
   private func completeTask(_ task: URLSessionDownloadTask, model: MLModel?, key: String) {
     downloadCompletionHandlers[task]?(model, key)
     downloadCompletionHandlers.removeValue(forKey: task)
   }
 
-  /// Create priority download task.
-  private func createPriorityTask(
-    from task: URLSessionDownloadTask, urlKeyPair: (url: URL, key: String),
-    completion: @escaping (MLModel?, String) -> Void
-  ) {
-    let session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
-    let priorityDownloadTask = session.downloadTask(with: task.originalRequest!)
-    priorityDownloadTask.priority = URLSessionTask.highPriority
-    downloadTasks[priorityDownloadTask] = urlKeyPair
-    downloadCompletionHandlers[priorityDownloadTask] = completion
-    priorityTask = priorityDownloadTask
-    priorityDownloadTask.resume()
-  }
-
   func startDownload(
     url: URL, fileName: String, key: String, completion: @escaping (MLModel?, String) -> Void
   ) {
-    let session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
     let downloadTask = session.downloadTask(with: url)
     let destinationURL = documentsDirectory.appendingPathComponent(fileName)
     downloadTasks[downloadTask] = (url: destinationURL, key: key)
     downloadCompletionHandlers[downloadTask] = completion
     downloadTask.resume()
-  }
-
-  func prioritizeDownload(for fileName: String, completion: @escaping (MLModel?, String) -> Void) {
-    for (task, urlKeyPair) in downloadTasks {
-      guard urlKeyPair.url.lastPathComponent.contains(fileName) else { continue }
-
-      task.cancel(byProducingResumeData: { resumeData in
-        let session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
-        let priorityDownloadTask: URLSessionDownloadTask
-
-        if let resumeData = resumeData {
-          priorityDownloadTask = session.downloadTask(withResumeData: resumeData)
-        } else {
-          priorityDownloadTask = session.downloadTask(with: task.originalRequest!)
-        }
-
-        priorityDownloadTask.priority = URLSessionTask.highPriority
-        self.downloadTasks[priorityDownloadTask] = urlKeyPair
-        self.downloadCompletionHandlers[priorityDownloadTask] = completion
-        self.priorityTask = priorityDownloadTask
-        priorityDownloadTask.resume()
-      })
-      break
-    }
-  }
-
-  func cancelCurrentDownload() {
-    priorityTask?.cancel()
-    priorityTask = nil
   }
 }
 
@@ -222,7 +133,7 @@ extension ModelDownloadManager: URLSessionDownloadDelegate {
 
     do {
       let zipURL = destinationURL
-      if fileExists(at: zipURL) {
+      if FileManager.default.fileExists(atPath: zipURL.path) {
         try FileManager.default.removeItem(at: zipURL)
       }
       try FileManager.default.moveItem(at: location, to: zipURL)
@@ -300,47 +211,9 @@ extension ModelDownloadManager: URLSessionDownloadDelegate {
     _ session: URLSession, downloadTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64,
     totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64
   ) {
+    guard totalBytesExpectedToWrite > 0 else { return }
     let progress = Double(totalBytesWritten) / Double(totalBytesExpectedToWrite)
     DispatchQueue.main.async { self.progressHandler?(progress) }
-  }
-}
-
-class ModelFileManager {
-  static let shared = ModelFileManager()
-  private init() {}
-
-  func deleteAllDownloadedModels() {
-    do {
-      let fileURLs = try FileManager.default.contentsOfDirectory(
-        at: documentsDirectory, includingPropertiesForKeys: nil)
-      for fileURL in fileURLs
-      where ["mlmodel", "mlmodelc", "mlpackage"].contains(fileURL.pathExtension) {
-        try FileManager.default.removeItem(at: fileURL)
-        print("Deleted file: \(fileURL.lastPathComponent)")
-      }
-    } catch {
-      print("Error deleting files: \(error)")
-    }
-  }
-}
-
-func getModelFileURL(fileName: String) -> URL? {
-  Bundle.main.url(forResource: fileName, withExtension: "mlmodelc")
-}
-
-func fileExists(at url: URL) -> Bool {
-  FileManager.default.fileExists(atPath: url.path)
-}
-
-extension URL {
-  func changingFileExtension(to newExtension: String) -> URL? {
-    var urlString = self.absoluteString
-    if let range = urlString.range(of: "\\.[^./]*$", options: .regularExpression) {
-      urlString.replaceSubrange(range, with: ".\(newExtension)")
-    } else {
-      urlString.append(".\(newExtension)")
-    }
-    return URL(string: urlString)
   }
 }
 

--- a/YOLOiOSApp/YOLOiOSApp/ModelSelectionManager.swift
+++ b/YOLOiOSApp/YOLOiOSApp/ModelSelectionManager.swift
@@ -23,17 +23,10 @@ struct ModelSelectionManager {
     let name: String
     let url: URL?
     let isLocal: Bool
-    let size: ModelSize?
   }
 
-  private static let modelSizeRegex: NSRegularExpression = {
-    do {
-      return try NSRegularExpression(pattern: "^\\d+([nsmxl])", options: [])
-    } catch {
-      print("Failed to create model size regex: \(error)")
-      return try! NSRegularExpression(pattern: "^$", options: [])
-    }
-  }()
+  private static let modelSizeRegex = try! NSRegularExpression(
+    pattern: "^\\d+([nsmxl])", options: [])
 
   static func categorizeModels(from models: [(name: String, url: URL?, isLocal: Bool)])
     -> [ModelSize: ModelInfo]
@@ -52,8 +45,7 @@ struct ModelSelectionManager {
           standardModels[size] = ModelInfo(
             name: model.name,
             url: model.url,
-            isLocal: model.isLocal,
-            size: size
+            isLocal: model.isLocal
           )
         }
       }
@@ -188,32 +180,21 @@ struct ModelSelectionManager {
   private static func setSegmentTextColor(
     _ control: UISegmentedControl, at index: Int, color: UIColor
   ) {
-    if #available(iOS 13.0, *) {
-      if let title = control.titleForSegment(at: index) {
-        control.setTitle(title, forSegmentAt: index)
+    guard let title = control.titleForSegment(at: index) else { return }
+    control.setTitle(title, forSegmentAt: index)
 
-        if let image = control.imageForSegment(at: index) {
-          control.setImage(
-            image.withTintColor(color, renderingMode: .alwaysOriginal), forSegmentAt: index)
-        }
+    if let image = control.imageForSegment(at: index) {
+      control.setImage(
+        image.withTintColor(color, renderingMode: .alwaysOriginal), forSegmentAt: index)
+    }
 
-        control.subviews.forEach { subview in
-          if subview.subviews.count > 0 {
-            subview.subviews.forEach { label in
-              if let label = label as? UILabel, label.text == title {
-                label.textColor = color
-              }
-            }
-          }
+    control.subviews.forEach { subview in
+      subview.subviews.forEach { label in
+        if let label = label as? UILabel, label.text == title {
+          label.textColor = color
         }
       }
     }
-  }
-
-  static func getModelForSelection(size: ModelSize, standardModels: [ModelSize: ModelInfo])
-    -> ModelInfo?
-  {
-    return standardModels[size]
   }
 
   private static func setupResponsiveFontSize(for control: UISegmentedControl) {

--- a/YOLOiOSApp/YOLOiOSApp/SceneDelegate.swift
+++ b/YOLOiOSApp/YOLOiOSApp/SceneDelegate.swift
@@ -64,27 +64,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
   }
 
   private func updateOrientationLock() {
-    // Force orientation update
-    if let windowScene = window?.windowScene {
-      if #available(iOS 16.0, *) {
-        windowScene.requestGeometryUpdate(
-          .iOS(interfaceOrientations: supportedInterfaceOrientations))
-
-        // Also force the view controller to update its orientation
-        if let rootVC = window?.rootViewController {
-          rootVC.setNeedsUpdateOfSupportedInterfaceOrientations()
-        }
-      } else {
-        // For older iOS versions, we need to trigger orientation update
-        UIViewController.attemptRotationToDeviceOrientation()
-
-        // Force the view to layout again
-        if let rootVC = window?.rootViewController {
-          rootVC.view.setNeedsLayout()
-          rootVC.view.layoutIfNeeded()
-        }
-      }
-    }
+    guard let windowScene = window?.windowScene else { return }
+    windowScene.requestGeometryUpdate(
+      .iOS(interfaceOrientations: supportedInterfaceOrientations))
+    window?.rootViewController?.setNeedsUpdateOfSupportedInterfaceOrientations()
   }
 
   var supportedInterfaceOrientations: UIInterfaceOrientationMask {
@@ -97,23 +80,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
   }
 
-  func sceneDidDisconnect(_ scene: UIScene) {
-    // Called as the scene is being released by the system.
-  }
-
-  func sceneDidBecomeActive(_ scene: UIScene) {
-    // Called when the scene has moved from an inactive state to an active state.
-  }
-
-  func sceneWillResignActive(_ scene: UIScene) {
-    // Called when the scene will move from an active state to an inactive state.
-  }
-
-  func sceneWillEnterForeground(_ scene: UIScene) {
-    // Called as the scene transitions from the background to the foreground.
-  }
-
-  func sceneDidEnterBackground(_ scene: UIScene) {
-    // Called as the scene transitions from the foreground to the background.
+  deinit {
+    NotificationCenter.default.removeObserver(self)
   }
 }

--- a/YOLOiOSApp/YOLOiOSApp/ViewController.swift
+++ b/YOLOiOSApp/YOLOiOSApp/ViewController.swift
@@ -464,7 +464,8 @@ class ViewController: UIViewController, YOLOViewDelegate {
             fullModelPath = entry.identifier
             let documentsDirectory = FileManager.default.urls(
               for: .documentDirectory, in: .userDomainMask)[0]
-            let localModelURL = documentsDirectory
+            let localModelURL =
+              documentsDirectory
               .appendingPathComponent(entry.identifier)
               .appendingPathExtension("mlmodelc")
             if !FileManager.default.fileExists(atPath: localModelURL.path) { return }

--- a/YOLOiOSApp/YOLOiOSApp/ViewController.swift
+++ b/YOLOiOSApp/YOLOiOSApp/ViewController.swift
@@ -18,17 +18,6 @@ import CoreMedia
 import UIKit
 import YOLO
 
-// MARK: - Extensions
-extension Result {
-  var isSuccess: Bool { if case .success = self { return true } else { return false } }
-}
-
-extension Array {
-  subscript(safe index: Int) -> Element? {
-    return indices.contains(index) ? self[index] : nil
-  }
-}
-
 /// The main view controller for the YOLO iOS application, handling model selection and visualization.
 class ViewController: UIViewController, YOLOViewDelegate {
 
@@ -74,22 +63,8 @@ class ViewController: UIViewController, YOLOViewDelegate {
   // MARK: - Constants
   private struct Constants {
     static let defaultTaskIndex = 2  // Detect
-    static let tableRowHeight: CGFloat = 30
     static let logoURL = "https://www.ultralytics.com"
     static let progressViewWidth: CGFloat = 200
-  }
-
-  // MARK: - Helper Methods
-
-  // Helper function to check for external screens (iOS 16+ compatible)
-  private func hasExternalScreen() -> Bool {
-    if #available(iOS 16.0, *) {
-      return UIApplication.shared.connectedScenes
-        .compactMap { $0 as? UIWindowScene }
-        .contains { $0.screen != UIScreen.main }
-    } else {
-      return UIScreen.screens.count > 1
-    }
   }
 
   // MARK: - Loading State Management
@@ -144,12 +119,8 @@ class ViewController: UIViewController, YOLOViewDelegate {
     // Setup external display notifications
     setupExternalDisplayNotifications()
 
-    // Check for already connected external displays
-    checkForExternalDisplays()
-
     // If external display is already connected, ensure YOLOView doesn't interfere
     if hasExternalScreen() {
-      print("External display already connected at startup - deferring camera init")
       yoloView.isHidden = true
     }
 
@@ -168,11 +139,6 @@ class ViewController: UIViewController, YOLOViewDelegate {
 
       // Always load models initially - external display handling will stop camera if needed
       reloadModelEntriesAndLoadFirst(for: currentTask)
-
-      // Check for external display after initial setup
-      if hasExternalScreen() {
-        print("External display may be connected at startup - will be handled by notifications")
-      }
     }
 
     // Setup gestures and delegates
@@ -235,10 +201,6 @@ class ViewController: UIViewController, YOLOViewDelegate {
     view.overrideUserInterfaceStyle = .dark
   }
 
-  override func viewDidAppear(_ animated: Bool) {
-    super.viewDidAppear(animated)
-  }
-
   private func getModelFiles(in folderName: String) -> [String] {
     guard let folderURL = Bundle.main.url(forResource: folderName, withExtension: nil),
       let fileURLs = try? FileManager.default.contentsOfDirectory(
@@ -284,7 +246,6 @@ class ViewController: UIViewController, YOLOViewDelegate {
         displayName: (model.name as NSString).deletingPathExtension,
         identifier: model.name,
         isLocalBundle: model.isLocal,
-        isRemote: model.url != nil,
         remoteURL: model.url
       )
       loadModel(entry: entry, forTask: taskName)
@@ -294,29 +255,23 @@ class ViewController: UIViewController, YOLOViewDelegate {
   private func makeModelEntries(for taskName: String) -> [ModelEntry] {
     let localFileNames = modelsForTask[taskName] ?? []
     let localEntries = localFileNames.map { fileName -> ModelEntry in
-      let display = (fileName as NSString).deletingPathExtension
-      return ModelEntry(
-        displayName: display,
+      ModelEntry(
+        displayName: (fileName as NSString).deletingPathExtension,
         identifier: fileName,
         isLocalBundle: true,
-        isRemote: false,
         remoteURL: nil
       )
     }
 
-    // Get local model names for filtering
     let localModelNames = Set(localEntries.map { $0.displayName.lowercased() })
 
     let remoteList = remoteModelsInfo[taskName] ?? []
     let remoteEntries = remoteList.compactMap { (modelName, url) -> ModelEntry? in
-      // Only include remote models if no local model with the same name exists
       guard !localModelNames.contains(modelName.lowercased()) else { return nil }
-
       return ModelEntry(
         displayName: modelName,
         identifier: modelName,
         isLocalBundle: false,
-        isRemote: true,
         remoteURL: url
       )
     }
@@ -342,13 +297,6 @@ class ViewController: UIViewController, YOLOViewDelegate {
 
     setLoadingState(true, showOverlay: true)
     resetDownloadProgress()
-
-    print("Start loading model: \(entry.displayName)")
-    print("  - displayName: \(entry.displayName)")
-    print("  - identifier: \(entry.identifier)")
-    print("  - isLocalBundle: \(entry.isLocalBundle)")
-    print("  - task: \(task)")
-    print("  - hasExternalDisplay: \(hasExternalDisplay)")
 
     // Store current entry for external display notification
     currentLoadingEntry = entry
@@ -378,11 +326,8 @@ class ViewController: UIViewController, YOLOViewDelegate {
           let hasExternalDisplay = self.hasExternalScreen() || SceneDelegate.hasExternalDisplay
 
           if hasExternalDisplay {
-            // External display is connected - skip YOLOView loading, just notify external display
-            print("External display connected - skipping main YOLOView model load")
             self.finishLoadingModel(success: true, modelName: entry.displayName)
           } else {
-            // Normal model loading on main YOLOView
             self.yoloView.setModel(modelPathOrName: modelURL.path, task: yoloTask) {
               [weak self] result in
               DispatchQueue.main.async {
@@ -454,11 +399,8 @@ class ViewController: UIViewController, YOLOViewDelegate {
       let hasExternalDisplay = self.hasExternalScreen() || SceneDelegate.hasExternalDisplay
 
       if hasExternalDisplay {
-        // External display is connected - skip YOLOView loading, just notify external display
-        print("External display connected - skipping main YOLOView cached model load")
         self.finishLoadingModel(success: true, modelName: displayName)
       } else {
-        // Normal model loading on main YOLOView
         self.yoloView.setModel(modelPathOrName: localModelURL.path, task: yoloTask) {
           [weak self] result in
           DispatchQueue.main.async {
@@ -509,51 +451,29 @@ class ViewController: UIViewController, YOLOViewDelegate {
 
       if success && hasExternalDisplay {
         let yoloTask = self.tasks.first(where: { $0.name == self.currentTask })?.yoloTask ?? .detect
-
-        // Determine the correct model path for external display
         var fullModelPath = ""
 
-        // Use the stored entry from loadModel
         if let entry = self.currentLoadingEntry {
           if entry.isLocalBundle {
-            // For local bundle models
             if let folderURL = self.tasks.first(where: { $0.name == self.currentTask })?.folder,
               let folderPathURL = Bundle.main.url(forResource: folderURL, withExtension: nil)
             {
-              let modelURL = folderPathURL.appendingPathComponent(entry.identifier)
-              fullModelPath = modelURL.path
-              print("📦 External display local model path: \(fullModelPath)")
+              fullModelPath = folderPathURL.appendingPathComponent(entry.identifier).path
             }
           } else {
-            // For remote/downloaded models, we need to pass the identifier only
-            // The external display will handle loading from cache
             fullModelPath = entry.identifier
-            print("☁️ External display will load cached model: \(fullModelPath)")
-
-            // Verify the cached model exists locally first
             let documentsDirectory = FileManager.default.urls(
               for: .documentDirectory, in: .userDomainMask)[0]
-            let localModelURL =
-              documentsDirectory
+            let localModelURL = documentsDirectory
               .appendingPathComponent(entry.identifier)
               .appendingPathExtension("mlmodelc")
-
-            if !FileManager.default.fileExists(atPath: localModelURL.path) {
-              print("❌ Cached model not found at: \(localModelURL.path)")
-              return
-            }
+            if !FileManager.default.fileExists(atPath: localModelURL.path) { return }
           }
         }
 
-        // Only notify if we have a valid path
         if !fullModelPath.isEmpty {
           ExternalDisplayManager.shared.notifyModelChange(task: yoloTask, modelName: fullModelPath)
-          print("✅ Model loaded successfully and notified to external display: \(modelName)")
-
-          // Also check if external display is waiting for initial model
           self.checkAndNotifyExternalDisplayIfReady()
-        } else {
-          print("❌ Could not determine model path for external display")
         }
       }
 
@@ -619,17 +539,6 @@ class ViewController: UIViewController, YOLOViewDelegate {
     ])
   }
 
-  func updateModelSegmentedControlAppearance() {
-    guard modelSegmentedControl != nil else { return }
-
-    modelSegmentedControl.overrideUserInterfaceStyle = .dark
-    modelSegmentedControl.backgroundColor = .clear
-
-    let yoloTask = tasks.first(where: { $0.name == currentTask })?.yoloTask ?? .detect
-    ModelSelectionManager.updateSegmentAppearance(
-      modelSegmentedControl, standardModels: standardModels, currentTask: yoloTask)
-  }
-
   @objc private func modelSizeChanged(_ sender: UISegmentedControl) {
     selection.selectionChanged()
 
@@ -640,7 +549,6 @@ class ViewController: UIViewController, YOLOViewDelegate {
           displayName: (model.name as NSString).deletingPathExtension,
           identifier: model.name,
           isLocalBundle: model.isLocal,
-          isRemote: model.url != nil,
           remoteURL: model.url
         )
         loadModel(entry: entry, forTask: currentTask)
@@ -650,7 +558,6 @@ class ViewController: UIViewController, YOLOViewDelegate {
 
   override func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()
-    adjustLayoutForExternalDisplayIfNeeded()
     alignLogoWithThresholdSliders()
   }
 
@@ -708,12 +615,8 @@ extension ViewController {
   }
 
   func yoloView(_ view: YOLOView, didReceiveResult result: YOLOResult) {
-    DispatchQueue.main.async { [weak self] in
-      guard self != nil else { return }
-      // Share results with external display (Optional external display feature)
+    DispatchQueue.main.async {
       ExternalDisplayManager.shared.shareResults(result)
-
-      // Also send via notification for direct communication (Optional external display feature)
       NotificationCenter.default.post(
         name: .yoloResultsAvailable,
         object: nil,


### PR DESCRIPTION
## Summary
Multi-agent audit across `Sources/YOLO`, `YOLOiOSApp`, and `ExampleApps`. All changes follow Delete > Replace > Add — net **-643 lines** (180 added, 823 removed) across 21 files with no new files, no new abstractions, no new dependencies.

### Predictor pipeline (`Sources/YOLO/`)
- **Bug — Classifier softmax numerical stability**: subtract max-logit before `vvexpf` so large logits don't explode to Inf and produce NaN top-N. Also reads `MLMultiArray` via `dataPointer` (gated on `.float32`) instead of NSNumber-boxing each element.
- **Bug — PoseEstimator return shape**: `predictOnImage` returned a `YOLOResult(orig_shape: .zero, ...)` on the no-prediction path, throwing away the `inputSize` it had just measured. Now returns the actual shape.
- **Perf — NonMaxSuppression**: hoisted box/area lookups out of the inner `j` loop and pre-computed `areas[]` once. Roughly 2× fewer property accesses on the hot path.
- **Perf — ObjectDetector**: hoisted `j * anchorStride` out of the per-class loop.
- **Perf — Segmenter**: collapsed `if classBuckets[k] == nil { ... } classBuckets[k]?.append(...)` two-step into `classBuckets[k, default: []].append(...)`. Dropped two bogus `reserveCapacity` heuristics.
- **Cleanup**: removed dead `getCollections()` indirection in PoseEstimator/Segmenter (`private(set)` direct reads are fine — `concurrentPerform` provides the barrier on completion). Removed dead `currentBuffer` gate in `VideoCapture.predictOnFrame` (the load-bearing one is in `BasePredictor`).

### `YOLOView`
- **Bug — `busy` flag stuck on failure**: `busy = false` lived inside the success branch, so a failed `setUp(...)` permanently locked out `start()`. Now reset via `defer`.
- Drop the `Task { @MainActor in ... }` wrapper in `awakeFromNib` (already on main; the hop delayed view setup until after the runloop tick).
- Remove a no-op styling helper that ran every `layoutSubviews`.
- Remove redundant `addSublayer` and `parentLayer.sublayers = nil` after `removeFromSuperlayer()`.

### Models / utilities
- `YOLOModelCache`: `Data(s.utf8).sha256()` — drop the dead `data(using:.utf8) ?? lastPathComponent` fallback (Swift strings are valid UTF-8) and the `/` scrub on hex output.
- `ThresholdProvider`: `var values` → `let values` on the immutable feature dictionary.

### `YOLOiOSApp` host
- **Bug — `SceneDelegate` observer leak**: missing `removeObserver` in `deinit` for two notifications added in `scene(_:willConnectTo:)`.
- **Bug — `ModelDownloadManager.loadLocalModel`** silently dropped its completion handler on file-load failure (UI hung). Also fixed divide-by-zero / `NSURLSessionTransferSizeUnknown` (-1) in the progress callback.
- **Perf — single `URLSession`** instead of one per `startDownload` call.
- `[weak self]` added to `asyncAfter` blocks in `ExternalViewController` and `ViewController+ExternalDisplay` that outlive the controller.
- `AppDelegate`: strip unused battery monitoring, no-op `UserDefaults.synchronize`, never-read `app_version`/`uuid` writes, and an unused `CALayer.screenShot` extension. Now ~14 lines.
- Collapse dead pre-iOS 16 `if #available` branches (project min is iOS 16).
- Drop unused associated-object plumbing in `ViewController+ExternalDisplay` (`isExternalDisplayConnected` was set in 2 places, read in 0).

### Examples
- Strip Apple-template boilerplate (empty scene-lifecycle stubs, doc comments).
- `YOLOSingleImageUIKit/ViewController`: drop `result.annotatedImage!` force-unwrap and the surprising auto-save to Photos (no `NSPhotoLibraryAddUsageDescription`, bad UX for an example).

### Intentionally not changed
- `@unchecked Sendable` annotations (ObjC interop boundary)
- `DispatchQueue.concurrentPerform` (synchronous parallel loop, intentional)
- OBB pixel-space rotation in `Plot.swift` (~8° max error at 45° but stable during phone rotation)
- Color palette duplication between `Segmenter` and `BoundingBoxView` (different formats for different purposes)
- Traditional non-end2end MLMultiArray indexing without `.strides` (shipped working with YOLO11; end2end paths already use strides)
- External-display orchestration timing (hard to test without hardware)

## Test plan
- [x] `xcodebuild -scheme YOLO test` — 62/62 pass
- [x] `xcodebuild -project YOLOiOSApp.xcodeproj -scheme YOLOiOSApp build` — succeeds
- [ ] Smoke-test camera start/stop, model swap, and external-display flow on a device

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧹 This PR mainly cleans up and streamlines the iOS app and example apps, while also improving YOLO inference performance, code safety, and external display behavior.

### 📊 Key Changes
- 🗑️ Removed large amounts of unused boilerplate, comments, empty lifecycle methods, and helper code across the app and example UIKit projects.
- ⚡ Improved core inference internals:
  - optimized classification softmax processing in `Classifier.swift`
  - reduced repeated indexing in `ObjectDetector.swift`
  - streamlined non-max suppression in `NonMaxSuppression.swift`
  - simplified parallel result collection in `PoseEstimator.swift` and `Segmenter.swift`
- 🧠 Improved memory safety and callback handling by using `[weak self]` in several async closures, including image picker and external display flows.
- 📷 Simplified camera/frame prediction flow in `VideoCapture.swift` and startup logic in `YOLOView.swift`, reducing nesting and making capture setup cleaner.
- 🖥️ Refined external display support:
  - simplified external screen detection
  - cleaned up orientation handling for iOS 16+
  - improved external model loading logic for cached/downloaded models
  - reduced redundant state tracking and debug logging
- 🧾 Simplified model download/cache code:
  - made cache internals more private
  - removed unused download-priority and file-management helpers
  - simplified cache key generation in `YOLOModelCache.swift`
- 📱 Updated the single-image UIKit example to use a cleaner image-loading/inference flow and removed automatic saving of annotated images to Photos.
- 🔒 Minor API/code-quality improvements, such as making threshold provider values immutable and removing unused properties/methods.

### 🎯 Purpose & Impact
- 🚀 Users may see better runtime efficiency, especially in postprocessing-heavy tasks like classification, detection, pose, and segmentation.
- 🧼 The codebase becomes easier to maintain, read, and extend, which helps future development and reduces bugs.
- 🛡️ Safer async handling lowers the risk of retain cycles and UI issues in long-running or delayed operations.
- 🖥️ External display workflows should be more reliable and predictable, especially when switching orientation or loading downloaded models.
- 📷 The example apps are now leaner and clearer for developers learning how to integrate YOLO on iOS.
- 📉 There are no major user-facing feature additions, but the app should feel more polished, stable, and maintainable overall.