### PR TITLE
chore: enforce YOLO acronym capitalization

### DIFF
--- a/YOLOiOSApp/YOLOiOSApp/ModelSelectionManager.swift
+++ b/YOLOiOSApp/YOLOiOSApp/ModelSelectionManager.swift
@@ -66,16 +66,16 @@ struct ModelSelectionManager {
     }
 
     if nameWithoutSuffix.hasPrefix("yolo") && !nameWithoutSuffix.dropFirst(4).isEmpty {
-      let afterYolo = nameWithoutSuffix.dropFirst(4)
-      let afterYoloString = String(afterYolo)
-      let range = NSRange(location: 0, length: afterYoloString.count)
+      let afterYOLO = nameWithoutSuffix.dropFirst(4)
+      let afterYOLOString = String(afterYOLO)
+      let range = NSRange(location: 0, length: afterYOLOString.count)
 
-      if let match = modelSizeRegex.firstMatch(in: afterYoloString, options: [], range: range),
+      if let match = modelSizeRegex.firstMatch(in: afterYOLOString, options: [], range: range),
         match.numberOfRanges > 1
       {
         let sizeRange = match.range(at: 1)
-        if let range = Range(sizeRange, in: afterYoloString) {
-          return afterYoloString[range].first
+        if let range = Range(sizeRange, in: afterYOLOString) {
+          return afterYOLOString[range].first
         }
       }
     }
@@ -95,8 +95,8 @@ struct ModelSelectionManager {
     }
 
     if result.lowercased().hasPrefix("yolo") {
-      let afterYolo = result.dropFirst(4)
-      result = "YOLO" + afterYolo
+      let afterYOLO = result.dropFirst(4)
+      result = "YOLO" + afterYOLO
     }
 
     return result


### PR DESCRIPTION
## Summary

Apply Swift API Design Guidelines uniform-case rule for acronyms: when `YOLO` appears in the middle or end of a Swift identifier it must be ALL CAPS. Names only, no behavior changes.

## What changed

**Swift identifiers** (`YOLOiOSApp/YOLOiOSApp/ModelSelectionManager.swift`):
- `afterYolo` -> `afterYOLO`
- `afterYoloString` -> `afterYOLOString`

Both are function-local variables; 8 references updated across one file.

**Markdown prose:** none - existing READMEs already use the correct `YOLO` casing throughout.

## What was deliberately not changed

- lowerCamelCase identifiers that start with `yolo` (e.g. `yoloView`, `yoloTask`, `yoloDelegate`) - these are correct per Swift convention (acronyms at the start of a lowerCamelCase name are all-lowercase, same as `urlSession`).
- File paths, URLs, repo name (`yolo-ios-app`), model file names (e.g. `yolo26n.mlpackage`), `import YOLO` statements, package names.

## Test plan

- [x] `grep -rnE "[A-Za-z]Yolo[A-Z]|[A-Za-z]Yolo\b" --include="*.swift" .` returns nothing.
- [x] `grep -rwE "Yolo" --include="*.md" --include="*.swift" .` returns nothing.
- [x] `xcrun swiftc -parse` on the changed file: exit 0, no syntax errors.
- [ ] `swift build` from repo root: package depends on `UIKit` (iOS-only), so building the SwiftPM target on a macOS host is not possible; no UIKit-related changes were made.
- [ ] `xcodebuild -sdk iphonesimulator` could not run on the CI host - `CoreSimulator` is out-of-date and the iOS 26.5 platform is missing on this machine. Recommend a CI rebuild to confirm.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR makes a small cleanup in `ModelSelectionManager.swift` by standardizing internal variable names from `afterYolo` to `afterYOLO` for better consistency and readability.

### 📊 Key Changes
- Renamed local variables in `ModelSelectionManager.swift`:
  - `afterYolo` → `afterYOLO`
  - `afterYoloString` → `afterYOLOString`
- Updated related references in:
  - model size parsing logic
  - YOLO name formatting logic
- No behavior changes were introduced; this is a code readability and style improvement only ✨

### 🎯 Purpose & Impact
- Improves code consistency by matching the `YOLO` branding/capitalization throughout the implementation ✅
- Makes the parsing and formatting logic easier for developers to read and maintain 👀
- Reduces minor naming ambiguity for future contributors working on model selection code 🔧
- Has little to no end-user impact, since the app’s functionality should remain the same 📱