### PR TITLE
chore: enforce YOLO acronym capitalization

### DIFF
--- a/YOLOiOSApp/YOLOiOSApp/ModelSelectionManager.swift
+++ b/YOLOiOSApp/YOLOiOSApp/ModelSelectionManager.swift
@@ -66,16 +66,16 @@ struct ModelSelectionManager {
     }
 
     if nameWithoutSuffix.hasPrefix("yolo") && !nameWithoutSuffix.dropFirst(4).isEmpty {
-      let afterYolo = nameWithoutSuffix.dropFirst(4)
-      let afterYoloString = String(afterYolo)
-      let range = NSRange(location: 0, length: afterYoloString.count)
+      let afterYOLO = nameWithoutSuffix.dropFirst(4)
+      let afterYOLOString = String(afterYOLO)
+      let range = NSRange(location: 0, length: afterYOLOString.count)
 
-      if let match = modelSizeRegex.firstMatch(in: afterYoloString, options: [], range: range),
+      if let match = modelSizeRegex.firstMatch(in: afterYOLOString, options: [], range: range),
         match.numberOfRanges > 1
       {
         let sizeRange = match.range(at: 1)
-        if let range = Range(sizeRange, in: afterYoloString) {
-          return afterYoloString[range].first
+        if let range = Range(sizeRange, in: afterYOLOString) {
+          return afterYOLOString[range].first
         }
       }
     }
@@ -95,8 +95,8 @@ struct ModelSelectionManager {
     }
 
     if result.lowercased().hasPrefix("yolo") {
-      let afterYolo = result.dropFirst(4)
-      result = "YOLO" + afterYolo
+      let afterYOLO = result.dropFirst(4)
+      result = "YOLO" + afterYOLO
     }
 
     return result


### PR DESCRIPTION
## Summary

Apply Swift API Design Guidelines uniform-case rule for acronyms: when `YOLO` appears in the middle or end of a Swift identifier it must be ALL CAPS. Names only, no behavior changes.

## What changed

**Swift identifiers** (`YOLOiOSApp/YOLOiOSApp/ModelSelectionManager.swift`):
- `afterYolo` → `afterYOLO`
- `afterYoloString` → `afterYOLOString`

Both are function-local variables; 8 references updated across one file.

**Markdown prose:** none — existing READMEs already use the correct `YOLO` casing throughout.

## What was deliberately not changed

- lowerCamelCase identifiers that start with `yolo` (e.g. `yoloView`, `yoloTask`, `yoloDelegate`) — these are correct per Swift convention (acronyms at the start of a lowerCamelCase name are all-lowercase, same as `urlSession`).
- File paths, URLs, repo name (`yolo-ios-app`), model file names (e.g. `yolo26n.mlpackage`), `import YOLO` statements, package names.

## Test plan

- [x] `grep -rnE "[A-Za-z]Yolo[A-Z]|[A-Za-z]Yolo\b" --include="*.swift" .` returns nothing.
- [x] `grep -rwE "Yolo" --include="*.md" --include="*.swift" .` returns nothing.
- [x] `xcrun swiftc -parse` on the changed file: exit 0, no syntax errors.
- [ ] `xcodebuild -sdk iphonesimulator` build via CI.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧹 This PR makes a small code cleanup in `ModelSelectionManager.swift` by renaming internal variables from `afterYolo` to `afterYOLO` for clearer, more consistent naming.

### 📊 Key Changes
- Renamed local variables in model name parsing logic:
  - `afterYolo` → `afterYOLO`
  - `afterYoloString` → `afterYOLOString`
- Updated all related references in:
  - model size extraction logic
  - YOLO name formatting logic
- No behavioral or functional changes were introduced ⚙️

### 🎯 Purpose & Impact
- Improves code readability and consistency by matching the preferred uppercase `YOLO` branding/style ✨
- Makes the parsing code easier for developers to understand and maintain
- Reduces minor naming ambiguity in string-processing logic
- No expected impact for app users; this is a developer-focused cleanup with no change to features or model behavior 📱