### PR TITLE
Standardize comment width at 120 chars and clean copy

### DIFF
--- a/ExampleApps/YOLORealTimeSwiftUI/YOLORealTimeSwiftUI/ContentView.swift
+++ b/ExampleApps/YOLORealTimeSwiftUI/YOLORealTimeSwiftUI/ContentView.swift
@@ -1,15 +1,14 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-//  This file is part of the Example Apps of Ultralytics YOLO Package, providing a SwiftUI example for real-time object detection.
+//  This file is part of the Example Apps of Ultralytics YOLO Package, providing a SwiftUI example for real-time object
+//  detection.
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 //
-//  The ContentView demonstrates how to implement real-time object detection using the YOLOCamera
-//  SwiftUI component. It shows how to create a full-screen camera view that performs continuous
-//  object detection with a specified YOLO model. This example specifically uses the oriented
-//  bounding box (OBB) model variant, but can be easily modified to use other model types like
-//  detection, segmentation, or pose estimation by changing the task parameter and model name.
-//  The view ignores safe areas to provide a full-screen camera experience.
+//  The ContentView shows how to run real-time object detection with the YOLOCamera SwiftUI component. It creates a
+//  full-screen camera view that performs continuous detection with a specified YOLO model. This example uses a YOLO
+//  detection model, but can be switched to segmentation, classification, pose, or OBB by changing the task parameter
+//  and model name. The view ignores safe areas to provide a full-screen camera experience.
 
 import SwiftUI
 import YOLO

--- a/ExampleApps/YOLORealTimeSwiftUI/YOLORealTimeSwiftUI/YOLORealTimeSwiftUIApp.swift
+++ b/ExampleApps/YOLORealTimeSwiftUI/YOLORealTimeSwiftUI/YOLORealTimeSwiftUIApp.swift
@@ -1,22 +1,19 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-//  This file is part of the Example Apps of Ultralytics YOLO Package, providing the SwiftUI app entry point for real-time object detection.
+//  This file is part of the Example Apps of Ultralytics YOLO Package, providing the SwiftUI app entry point for
+//  real-time object detection.
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 //
-//  The YOLORealTimeSwiftUIApp serves as the main application entry point for the SwiftUI-based
-//  real-time object detection example. It initializes the application's window group and sets
-//  ContentView as the root view. This structure follows the standard SwiftUI app lifecycle
-//  pattern, where the @main attribute designates this struct as the application's entry point.
-//  The app demonstrates how to integrate YOLO models for continuous object detection in a SwiftUI
-//  application, providing a simple but effective implementation that developers can build upon.
+//  YOLORealTimeSwiftUIApp is the entry point for the SwiftUI real-time object detection example. It initializes the
+//  window group and sets ContentView as the root view, following the standard SwiftUI app lifecycle with the @main
+//  attribute. The app shows how to integrate YOLO models for continuous object detection in a SwiftUI application.
 
 import SwiftUI
 
 /// The main entry point for the YOLO real-time detection SwiftUI example app.
 ///
-/// This struct represents the application instance and defines the app's scene structure.
-/// It creates a single window group containing the ContentView, which provides real-time
+/// Defines the app's scene structure with a single window group containing the ContentView, which provides real-time
 /// camera-based object detection using the YOLOCamera component.
 ///
 /// - Note: This app requires camera permissions in Info.plist and at least iOS 16.0 to run.

--- a/ExampleApps/YOLORealTimeSwiftUI/YOLORealTimeSwiftUITests/YOLORealTimeSwiftUITests.swift
+++ b/ExampleApps/YOLORealTimeSwiftUI/YOLORealTimeSwiftUITests/YOLORealTimeSwiftUITests.swift
@@ -1,6 +1,7 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-//  This file is part of the Example Apps of Ultralytics YOLO Package, providing unit tests for the real-time SwiftUI example.
+//  This file is part of the Example Apps of Ultralytics YOLO Package, providing unit tests for the real-time SwiftUI
+//  example.
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 
@@ -13,11 +14,10 @@ import XCTest
 @testable import YOLO
 @testable import YOLORealTimeSwiftUI
 
-/// Unit tests for the YOLO RealTime SwiftUI example application.
+/// Unit tests for the YOLO real-time SwiftUI example application.
 ///
-/// This test suite verifies the functionality of the real-time object detection application
-/// that uses SwiftUI and the YOLO framework. It contains tests that validate the core features
-/// of the app, including model initialization, camera preview functionality, and UI interactions.
+/// Verifies the real-time object detection app built with SwiftUI and the YOLO framework, covering model
+/// initialization, camera preview functionality, and UI interactions.
 ///
 /// - Note: These tests require the application to be built with testing enabled.
 /// - Important: Some tests require the YOLO26 OBB model to be available in the project.

--- a/ExampleApps/YOLORealTimeSwiftUI/YOLORealTimeSwiftUIUITests/YOLORealTimeSwiftUIUITests.swift
+++ b/ExampleApps/YOLORealTimeSwiftUI/YOLORealTimeSwiftUIUITests/YOLORealTimeSwiftUIUITests.swift
@@ -1,10 +1,12 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-//  This file is part of the Example Apps of Ultralytics YOLO Package, providing UI tests for the SwiftUI real-time example.
+//  This file is part of the Example Apps of Ultralytics YOLO Package, providing UI tests for the SwiftUI real-time
+//  example.
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 //
-//  These UI tests verify the user interface functionality and interaction flow of the YOLO Real-Time SwiftUI application.
+//  These UI tests verify the user interface functionality and interaction flow of the YOLO Real-Time SwiftUI
+//  application.
 
 import XCTest
 
@@ -16,7 +18,8 @@ final class YOLORealTimeSwiftUIUITests: XCTestCase {
     // In UI tests it is usually best to stop immediately when a failure occurs.
     continueAfterFailure = false
 
-    // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests
+    // before they run. The setUp method is a good place to do this.
   }
 
   override func tearDownWithError() throws {

--- a/ExampleApps/YOLORealTimeSwiftUI/YOLORealTimeSwiftUIUITests/YOLORealTimeSwiftUIUITestsLaunchTests.swift
+++ b/ExampleApps/YOLORealTimeSwiftUI/YOLORealTimeSwiftUIUITests/YOLORealTimeSwiftUIUITestsLaunchTests.swift
@@ -1,6 +1,7 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-//  This file is part of the Example Apps of Ultralytics YOLO Package, providing launch tests for the SwiftUI real-time example.
+//  This file is part of the Example Apps of Ultralytics YOLO Package, providing launch tests for the SwiftUI real-time
+//  example.
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 //

--- a/ExampleApps/YOLORealTimeUIKit/YOLORealTimeUIKit/ViewController.swift
+++ b/ExampleApps/YOLORealTimeUIKit/YOLORealTimeUIKit/ViewController.swift
@@ -1,25 +1,25 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-//  This file is part of the Example Apps of Ultralytics YOLO Package, providing a UIKit example for real-time object detection.
+//  This file is part of the Example Apps of Ultralytics YOLO Package, providing a UIKit example for real-time object
+//  detection.
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 //
-//  The ViewController demonstrates how to implement real-time object detection using YOLO models in UIKit.
-//  It provides a camera interface that continuously detects objects in the camera feed using the YOLO framework.
-//  The example shows how to initialize the YOLO model for detection, set up a camera preview, and display
-//  detection results in real-time with bounding boxes and labels.
+//  The ViewController shows how to run real-time object detection with YOLO models in UIKit. It provides a camera
+//  interface that continuously detects objects in the camera feed using the YOLO framework, including how to initialize
+//  the YOLO model, set up a camera preview, and display detection results in real-time with bounding boxes and labels.
 
 import UIKit
 import YOLO
 
-/// A view controller that demonstrates real-time object detection, segmentation, or other YOLO tasks using the UIKit framework.
+/// A view controller that demonstrates real-time object detection, segmentation, or other YOLO tasks using the UIKit
+/// framework.
 ///
-/// This view controller sets up a `YOLOView` which handles camera input, model inference, and visualization
-/// of the detection results in real-time. It uses a segmentation model by default but can be modified
-/// to use other YOLO model types.
+/// Sets up a `YOLOView` which handles camera input, model inference, and visualization of the results in real-time.
+/// Uses a detection model by default but can be modified to use other YOLO task types.
 ///
 /// - Note: This example requires camera permissions to be added to the Info.plist file.
-/// - Important: The app requires at least iOS 16.0 or higher to run.
+/// - Important: The app requires at least iOS 16.0 to run.
 class ViewController: UIViewController {
 
   /// The YOLO view that handles camera capture, model inference, and visualization.
@@ -27,8 +27,8 @@ class ViewController: UIViewController {
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    // Initialize YOLOView with a segmentation model
-    // You can change the model or task type to use detection, semantic segmentation, classification, etc.
+    // Initialize YOLOView with a detection model.
+    // Change the model or task to use segmentation, semantic segmentation, classification, pose, or OBB.
     yoloView = YOLOView(frame: view.bounds, modelPathOrName: "yolo26n", task: .detect)
     view.addSubview(yoloView)
   }

--- a/ExampleApps/YOLORealTimeUIKit/YOLORealTimeUIKitTests/YOLORealTimeUIKitTests.swift
+++ b/ExampleApps/YOLORealTimeUIKit/YOLORealTimeUIKitTests/YOLORealTimeUIKitTests.swift
@@ -1,6 +1,7 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-//  This file is part of the Example Apps of Ultralytics YOLO Package, providing unit tests for the real-time UIKit example.
+//  This file is part of the Example Apps of Ultralytics YOLO Package, providing unit tests for the real-time UIKit
+//  example.
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 
@@ -13,11 +14,10 @@ import XCTest
 @testable import YOLO
 @testable import YOLORealTimeUIKit
 
-/// Unit tests for the YOLO RealTime UIKit example application.
+/// Unit tests for the YOLO real-time UIKit example application.
 ///
-/// This test suite verifies the functionality of the real-time object detection application
-/// that uses UIKit and the YOLO framework. It contains tests that validate the core features
-/// of the app, including model initialization, camera configuration, and UI interactions.
+/// Verifies the real-time object detection app built with UIKit and the YOLO framework, covering model initialization,
+/// camera configuration, and UI interactions.
 ///
 /// - Note: These tests require the application to be built with testing enabled.
 /// - Important: Some tests may require the YOLO26 detection model to be available.

--- a/ExampleApps/YOLORealTimeUIKit/YOLORealTimeUIKitUITests/YOLORealTimeUIKitUITests.swift
+++ b/ExampleApps/YOLORealTimeUIKit/YOLORealTimeUIKitUITests/YOLORealTimeUIKitUITests.swift
@@ -1,6 +1,7 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-//  This file is part of the Example Apps of Ultralytics YOLO Package, providing UI tests for the real-time UIKit example.
+//  This file is part of the Example Apps of Ultralytics YOLO Package, providing UI tests for the real-time UIKit
+//  example.
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 //
@@ -16,7 +17,8 @@ final class YOLORealTimeUIKitUITests: XCTestCase {
     // In UI tests it is usually best to stop immediately when a failure occurs.
     continueAfterFailure = false
 
-    // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests
+    // before they run. The setUp method is a good place to do this.
   }
 
   override func tearDownWithError() throws {

--- a/ExampleApps/YOLORealTimeUIKit/YOLORealTimeUIKitUITests/YOLORealTimeUIKitUITestsLaunchTests.swift
+++ b/ExampleApps/YOLORealTimeUIKit/YOLORealTimeUIKitUITests/YOLORealTimeUIKitUITestsLaunchTests.swift
@@ -1,6 +1,7 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-//  This file is part of the Example Apps of Ultralytics YOLO Package, providing launch tests for the real-time UIKit example.
+//  This file is part of the Example Apps of Ultralytics YOLO Package, providing launch tests for the real-time UIKit
+//  example.
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 //

--- a/ExampleApps/YOLOSingleImageSwiftUI/YOLOSingleImageSwiftUI/ContentView.swift
+++ b/ExampleApps/YOLOSingleImageSwiftUI/YOLOSingleImageSwiftUI/ContentView.swift
@@ -1,15 +1,15 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-//  This file is part of the Example Apps of Ultralytics YOLO Package, providing a SwiftUI example for single image object detection.
+//  This file is part of the Example Apps of Ultralytics YOLO Package, providing a SwiftUI example for single image
+//  object detection.
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 //
-//  The ContentView demonstrates how to implement static image analysis using YOLO models in SwiftUI.
-//  It provides a user interface with a PhotosPicker for selecting images from the device's photo library
-//  and displays both the original and processed images with detection results. The example shows how to
-//  initialize a YOLO model for segmentation, load images from the photo picker, handle image orientation
-//  correction, and run inference on the selected image. This pattern can be adapted for other model
-//  types by changing the task parameter and model name during initialization.
+//  The ContentView shows how to run static image analysis with YOLO models in SwiftUI. It provides a user interface
+//  with a PhotosPicker for selecting images from the device's photo library and displays both the original and
+//  processed images with detection results. The example covers initializing a YOLO detection model, loading images from
+//  the photo picker, correcting image orientation, and running inference on the selected image. The pattern can be
+//  adapted for other task types by changing the task parameter and model name during initialization.
 
 import PhotosUI
 import SwiftUI
@@ -65,10 +65,10 @@ struct ContentView: View {
   }
 }
 
-/// Corrects the orientation of an image to ensure proper processing by the YOLO model.
+/// Corrects the orientation of an image for processing by the YOLO model.
 ///
-/// Images from the photo library might have orientation metadata rather than correctly oriented pixels.
-/// This function ensures the image is properly oriented for processing by the YOLO model.
+/// Images from the photo library may carry orientation metadata rather than correctly oriented pixels. This function
+/// applies the orientation so the returned image has its pixels in the correct order for inference.
 ///
 /// - Parameter uiImage: The input image that may have incorrect orientation metadata.
 /// - Returns: A new UIImage with the correct orientation for processing.

--- a/ExampleApps/YOLOSingleImageSwiftUI/YOLOSingleImageSwiftUI/YOLOSingleImageSwiftUIApp.swift
+++ b/ExampleApps/YOLOSingleImageSwiftUI/YOLOSingleImageSwiftUI/YOLOSingleImageSwiftUIApp.swift
@@ -1,27 +1,24 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-//  This file is part of the Example Apps of Ultralytics YOLO Package, providing the SwiftUI app entry point for single image object detection.
+//  This file is part of the Example Apps of Ultralytics YOLO Package, providing the SwiftUI app entry point for single
+//  image object detection.
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 //
-//  The YOLOSingleImageSwiftUIApp serves as the main application entry point for the SwiftUI-based
-//  single image object detection example. It initializes the application's window group and sets
-//  ContentView as the root view. This structure follows the standard SwiftUI app lifecycle
-//  pattern, where the @main attribute designates this struct as the application's entry point.
-//  The app demonstrates how to integrate YOLO models for still image analysis in a SwiftUI
-//  application, allowing users to select images from their photo library for processing.
+//  YOLOSingleImageSwiftUIApp is the entry point for the SwiftUI single image object detection example. It initializes
+//  the window group and sets ContentView as the root view, following the standard SwiftUI app lifecycle with the @main
+//  attribute. The app shows how to integrate YOLO models for still image analysis in SwiftUI, letting users select
+//  images from their photo library for processing.
 
 import SwiftUI
 
 /// The main entry point for the YOLO single image analysis SwiftUI example app.
 ///
-/// This struct represents the application instance and defines the app's scene structure.
-/// It creates a single window group containing the ContentView, which provides the user interface
-/// for selecting and analyzing images with YOLO models.
+/// Defines the app's scene structure with a single window group containing the ContentView, which provides the user
+/// interface for selecting and analyzing images with YOLO models.
 ///
 /// - Note: This app requires at least iOS 16.0 to run due to PhotosPicker API requirements.
-/// - Important: To use this app, you need to include proper privacy descriptions in Info.plist
-///   for accessing the photo library.
+/// - Important: Include proper photo library privacy descriptions in Info.plist.
 @main
 struct YOLOSingleImageSwiftUIApp: App {
   var body: some Scene {

--- a/ExampleApps/YOLOSingleImageSwiftUI/YOLOSingleImageSwiftUITests/YOLOSingleImageSwiftUITests.swift
+++ b/ExampleApps/YOLOSingleImageSwiftUI/YOLOSingleImageSwiftUITests/YOLOSingleImageSwiftUITests.swift
@@ -1,6 +1,7 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-//  This file is part of the Example Apps of Ultralytics YOLO Package, providing unit tests for the single image SwiftUI example.
+//  This file is part of the Example Apps of Ultralytics YOLO Package, providing unit tests for the single image SwiftUI
+//  example.
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 
@@ -13,11 +14,10 @@ import XCTest
 @testable import YOLO
 @testable import YOLOSingleImageSwiftUI
 
-/// Unit tests for the YOLO Single Image SwiftUI example application.
+/// Unit tests for the YOLO single image SwiftUI example application.
 ///
-/// This test suite verifies the functionality of the single image processing application
-/// that uses SwiftUI and the YOLO framework. It contains tests that validate the core features
-/// of the app, including model initialization, image processing, and UI interactions.
+/// Verifies the single image processing app built with SwiftUI and the YOLO framework, covering model initialization,
+/// image processing, and UI interactions.
 ///
 /// - Note: These tests require the application to be built with testing enabled.
 /// - Important: Some tests may require the YOLO26 segmentation model to be available.

--- a/ExampleApps/YOLOSingleImageSwiftUI/YOLOSingleImageSwiftUIUITests/YOLOSingleImageSwiftUIUITests.swift
+++ b/ExampleApps/YOLOSingleImageSwiftUI/YOLOSingleImageSwiftUIUITests/YOLOSingleImageSwiftUIUITests.swift
@@ -1,10 +1,12 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-//  This file is part of the Example Apps of Ultralytics YOLO Package, providing UI tests for the SwiftUI single image example.
+//  This file is part of the Example Apps of Ultralytics YOLO Package, providing UI tests for the SwiftUI single image
+//  example.
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 //
-//  These UI tests verify the user interface functionality and interaction flow of the YOLO Single Image SwiftUI application.
+//  These UI tests verify the user interface functionality and interaction flow of the YOLO Single Image SwiftUI
+//  application.
 
 import XCTest
 
@@ -16,7 +18,8 @@ final class YOLOSingleImageSwiftUIUITests: XCTestCase {
     // In UI tests it is usually best to stop immediately when a failure occurs.
     continueAfterFailure = false
 
-    // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests
+    // before they run. The setUp method is a good place to do this.
   }
 
   override func tearDownWithError() throws {

--- a/ExampleApps/YOLOSingleImageSwiftUI/YOLOSingleImageSwiftUIUITests/YOLOSingleImageSwiftUIUITestsLaunchTests.swift
+++ b/ExampleApps/YOLOSingleImageSwiftUI/YOLOSingleImageSwiftUIUITests/YOLOSingleImageSwiftUIUITestsLaunchTests.swift
@@ -1,6 +1,7 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-//  This file is part of the Example Apps of Ultralytics YOLO Package, providing launch tests for the SwiftUI single image example.
+//  This file is part of the Example Apps of Ultralytics YOLO Package, providing launch tests for the SwiftUI single
+//  image example.
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 //

--- a/ExampleApps/YOLOSingleImageUIKit/YOLOSingleImageUIKit/ViewController.swift
+++ b/ExampleApps/YOLOSingleImageUIKit/YOLOSingleImageUIKit/ViewController.swift
@@ -1,13 +1,14 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-//  This file is part of the Example Apps of Ultralytics YOLO Package, providing a UIKit example for single image object detection.
+//  This file is part of the Example Apps of Ultralytics YOLO Package, providing a UIKit example for single image object
+//  detection.
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 //
-//  The ViewController demonstrates how to implement static image analysis using YOLO models in UIKit.
-//  It provides a user interface for selecting images from the device's photo library and displays
-//  both the original and processed images with detection results. The example shows how to initialize
-//  a YOLO model for segmentation, handle image orientation correction, and run inference on selected images.
+//  The ViewController shows how to run static image analysis with YOLO models in UIKit. It provides a user interface
+//  for selecting images from the device's photo library and displays both the original and processed images with
+//  detection results. The example covers initializing a YOLO detection model, correcting image orientation, and
+//  running inference on selected images.
 
 import PhotosUI
 import UIKit
@@ -15,12 +16,12 @@ import YOLO
 
 /// A view controller that demonstrates YOLO model inference on a single image using UIKit.
 ///
-/// This view controller allows users to select an image from their photo library and performs
-/// YOLO model inference on the selected image. It uses a segmentation model by default but can be
-/// configured to use other YOLO task types like detection, semantic segmentation, classification, or pose estimation.
+/// Allows users to select an image from their photo library and runs YOLO model inference on the selected image. Uses
+/// a detection model by default but can be configured to use other YOLO task types like segmentation, semantic
+/// segmentation, classification, pose estimation, or OBB.
 ///
 /// - Note: This example uses the PhotosUI framework for image selection and requires photo library access.
-/// - Important: The app requires at least iOS 16.0 or higher to run.
+/// - Important: The app requires at least iOS 16.0 to run.
 class ViewController: UIViewController, PHPickerViewControllerDelegate {
 
   /// The YOLO model instance used for inference.
@@ -73,7 +74,7 @@ class ViewController: UIViewController, PHPickerViewControllerDelegate {
     self.present(picker, animated: true)
   }
 
-  /// Corrects the orientation of the image to ensure proper processing by the YOLO model.
+  /// Corrects the orientation of the image for processing by the YOLO model.
   ///
   /// - Parameter uiImage: The input image that may have incorrect orientation metadata.
   /// - Returns: A UIImage with the correct orientation for processing.

--- a/ExampleApps/YOLOSingleImageUIKit/YOLOSingleImageUIKitTests/YOLOSingleImageUIKitTests.swift
+++ b/ExampleApps/YOLOSingleImageUIKit/YOLOSingleImageUIKitTests/YOLOSingleImageUIKitTests.swift
@@ -1,6 +1,7 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-//  This file is part of the Example Apps of Ultralytics YOLO Package, providing unit tests for the single image UIKit example.
+//  This file is part of the Example Apps of Ultralytics YOLO Package, providing unit tests for the single image UIKit
+//  example.
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 
@@ -13,14 +14,13 @@ import XCTest
 @testable import YOLO
 @testable import YOLOSingleImageUIKit
 
-/// Unit tests for the YOLO Single Image UIKit example application.
+/// Unit tests for the YOLO single image UIKit example application.
 ///
-/// This test suite verifies the functionality of the single image processing application
-/// that uses UIKit and the YOLO framework. It contains tests that validate the core features
-/// of the app, including model initialization, image processing, and UI interactions.
+/// Verifies the single image processing app built with UIKit and the YOLO framework, covering model initialization,
+/// image processing, and UI interactions.
 ///
 /// - Note: These tests require the application to be built with testing enabled.
-/// - Important: Some tests may require the YOLO11 segmentation model to be available.
+/// - Important: Some tests may require a YOLO detection model to be available.
 struct YOLOSingleImageUIKitTests {
 
   // Flag to skip model-dependent tests if model is not available

--- a/ExampleApps/YOLOSingleImageUIKit/YOLOSingleImageUIKitUITests/YOLOSingleImageUIKitUITests.swift
+++ b/ExampleApps/YOLOSingleImageUIKit/YOLOSingleImageUIKitUITests/YOLOSingleImageUIKitUITests.swift
@@ -1,20 +1,19 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-//  This file is part of the Example Apps of Ultralytics YOLO Package, providing UI tests for the single image UIKit example.
+//  This file is part of the Example Apps of Ultralytics YOLO Package, providing UI tests for the single image UIKit
+//  example.
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 
 import XCTest
 
-/// UI tests for the YOLO Single Image UIKit example application.
+/// UI tests for the YOLO single image UIKit example application.
 ///
-/// This test class verifies the user interface functionality of the YOLO Single Image UIKit app.
-/// It tests the app's UI workflow, including image selection, processing, and result display.
-/// The tests ensure that the app's interface responds correctly to user interactions and
-/// displays expected visual elements.
+/// Verifies the app's UI workflow, including image selection, processing, and result display, ensuring the interface
+/// responds correctly to user interactions and displays the expected visual elements.
 ///
 /// - Note: UI tests launch the actual application and simulate user interaction.
-/// - Important: These tests require a device with camera and photo library permissions.
+/// - Important: These tests require photo library permissions.
 final class YOLOSingleImageUIKitUITests: XCTestCase {
 
   override func setUpWithError() throws {
@@ -23,7 +22,8 @@ final class YOLOSingleImageUIKitUITests: XCTestCase {
     // In UI tests it is usually best to stop immediately when a failure occurs.
     continueAfterFailure = false
 
-    // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests
+    // before they run. The setUp method is a good place to do this.
   }
 
   override func tearDownWithError() throws {

--- a/ExampleApps/YOLOSingleImageUIKit/YOLOSingleImageUIKitUITests/YOLOSingleImageUIKitUITestsLaunchTests.swift
+++ b/ExampleApps/YOLOSingleImageUIKit/YOLOSingleImageUIKitUITests/YOLOSingleImageUIKitUITestsLaunchTests.swift
@@ -1,16 +1,16 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-//  This file is part of the Example Apps of Ultralytics YOLO Package, providing launch tests for the single image UIKit example.
+//  This file is part of the Example Apps of Ultralytics YOLO Package, providing launch tests for the single image
+//  UIKit example.
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 
 import XCTest
 
-/// Launch performance tests for the YOLO Single Image UIKit example application.
+/// Launch performance tests for the YOLO single image UIKit example application.
 ///
-/// This test class focuses specifically on measuring and verifying the app's launch performance.
-/// It captures screenshots of the launch process and measures the time taken to launch the application.
-/// These tests help ensure the app launches efficiently and displays the correct initial interface.
+/// Measures the app's launch performance and captures screenshots of the launch process to help catch regressions and
+/// verify the initial interface.
 ///
 /// - Note: These tests run for each target application UI configuration.
 /// - Important: Launch tests are critical for monitoring performance regressions between app versions.

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,5 @@
 // swift-tools-version: 5.10
-// WARNING: <=5.10 requires for GitHub Actions CI
+// WARNING: <=5.10 required for GitHub Actions CI
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Sources/YOLO/BasePredictor.swift
+++ b/Sources/YOLO/BasePredictor.swift
@@ -1,16 +1,13 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-//  This file is part of the Ultralytics YOLO Package, providing the base infrastructure for model prediction.
+//  This file is part of the Ultralytics YOLO SDK, providing the base infrastructure for model prediction.
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 //
-//  The BasePredictor class is the foundation for all task-specific predictors in the YOLO framework.
-//  It manages the loading and initialization of Core ML models, handling common operations such as
-//  model loading, class label extraction, and inference timing. The class provides an asynchronous
-//  model loading mechanism that runs on background threads and includes support for configuring
-//  model parameters like confidence thresholds and IoU thresholds. Specific task implementations
-//  (detection, segmentation, semantic segmentation, classification, etc.) inherit from this base class and override
-//  the prediction-specific methods.
+//  BasePredictor is the foundation for all task-specific predictors. It loads Core ML models asynchronously on a
+//  background thread, extracts class labels, measures inference timing, and exposes confidence and IoU thresholds.
+//  Task-specific subclasses (detection, segmentation, semantic segmentation, classification, pose, OBB) override the
+//  prediction methods to handle their own output formats.
 
 import Foundation
 import UIKit
@@ -18,14 +15,11 @@ import Vision
 
 /// Base class for all YOLO model predictors, handling common model loading and inference logic.
 ///
-/// The BasePredictor serves as the foundation for all task-specific YOLO model predictors.
-/// It manages Core ML model loading, initialization, and common inference operations.
-/// Specialized predictors (for detection, segmentation, etc.) inherit from this class
-/// and override the prediction-specific methods to handle task-specific processing.
+/// Manages Core ML model loading, initialization, and shared inference operations. Specialized subclasses (detection,
+/// segmentation, classification, pose, OBB) override the prediction methods to handle task-specific processing.
 ///
-/// - Note: This class is marked as `@unchecked Sendable` to support concurrent operations.
-/// - Important: Task-specific implementations must override the `processObservations` and
-///   `predictOnImage` methods to provide proper functionality.
+/// - Note: Marked `@unchecked Sendable` to support concurrent use across threads.
+/// - Important: Subclasses must override `processObservations` and `predictOnImage`.
 public class BasePredictor: Predictor, @unchecked Sendable {
   /// Flag indicating if the model has been successfully loaded and is ready for inference.
   private(set) var isModelLoaded: Bool = false
@@ -36,8 +30,8 @@ public class BasePredictor: Predictor, @unchecked Sendable {
   /// The Vision request that processes images using the Core ML model.
   var visionRequest: VNCoreMLRequest?
 
-  /// Vision preprocessing mode for this predictor. Localization tasks use Ultralytics
-  /// LetterBox-style aspect-fit preprocessing; classification overrides this to center crop.
+  /// Vision preprocessing mode for this predictor. Localization tasks use Ultralytics LetterBox-style aspect-fit
+  /// preprocessing; classification overrides this to center crop.
   var imageCropAndScaleOption: VNImageCropAndScaleOption { .scaleFit }
 
   /// The class labels used by the model for categorizing detections.
@@ -85,24 +79,17 @@ public class BasePredictor: Predictor, @unchecked Sendable {
   /// Flag indicating whether the predictor is currently processing an update.
   public var isUpdating: Bool = false
 
-  /// Required initializer for creating predictor instances.
-  ///
-  /// This empty initializer is required for the factory pattern used in the `create` method.
-  /// Subclasses may override this to perform additional initialization.
+  /// Required initializer for the factory pattern used by `create`. Subclasses may override to add initialization.
   required init() {
     // Intentionally left empty
   }
 
-  /// Performs cleanup when the predictor is deallocated.
-  ///
-  /// Releases the Vision request so its completion handler can no longer retain `self`.
+  /// Releases the Vision request on deinit so its completion handler can no longer retain `self`.
   deinit {
     visionRequest = nil
   }
 
-  /// Dispatches `create` to the concrete predictor type for the given task.
-  ///
-  /// Centralizes the task → predictor mapping so callers don't duplicate the switch.
+  /// Dispatches `create` to the concrete predictor type for the given task, centralizing the task → predictor mapping.
   public static func create(
     for task: YOLOTask,
     modelURL: URL,
@@ -129,17 +116,15 @@ public class BasePredictor: Predictor, @unchecked Sendable {
     }
   }
 
-  /// Factory method to asynchronously create and initialize a predictor with the specified model.
+  /// Asynchronously creates and initializes a predictor with the specified model.
   ///
-  /// This method loads the Core ML model in a background thread and sets up the prediction
-  /// infrastructure. The completion handler is called on the main thread with either a
-  /// successfully initialized predictor or an error.
+  /// Loads the Core ML model on a background thread, then invokes the completion handler on the main thread with the
+  /// initialized predictor or an error.
   ///
   /// - Parameters:
   ///   - unwrappedModelURL: The URL of the Core ML model file to load.
-  ///   - isRealTime: Flag indicating if the predictor will be used for real-time processing (camera feed).
+  ///   - isRealTime: Pass `true` when the predictor will be driven by a camera feed.
   ///   - completion: Callback that receives the initialized predictor or an error.
-  /// - Note: Model loading happens on a background thread to avoid blocking the main thread.
   public static func create(
     unwrappedModelURL: URL,
     isRealTime: Bool = false,
@@ -246,11 +231,10 @@ public class BasePredictor: Predictor, @unchecked Sendable {
     }
   }
 
-  /// Processes a camera frame buffer and delivers results via callbacks.
+  /// Runs inference on a camera frame buffer and delivers results via callbacks.
   ///
-  /// This method takes a camera sample buffer, performs inference using the Vision framework,
-  /// and notifies listeners with the results and performance metrics. It's designed to be
-  /// called repeatedly with frames from a camera feed.
+  /// Called repeatedly with frames from a camera feed; runs the Vision request and notifies listeners with the
+  /// detection results and performance metrics.
   ///
   /// - Parameters:
   ///   - sampleBuffer: The camera frame buffer to process.
@@ -268,8 +252,8 @@ public class BasePredictor: Predictor, @unchecked Sendable {
       currentOnInferenceTimeListener = onInferenceTime
 
       /// - Tag: MappingOrientation
-      // The frame is always oriented based on the camera sensor,
-      // so in most cases Vision needs to rotate it for the model to work as expected.
+      // The frame is always oriented based on the camera sensor, so in most cases Vision needs to rotate it for the
+      // model to work as expected.
       let imageOrientation: CGImagePropertyOrientation = .up
 
       // Invoke a VNRequestHandler with that image
@@ -305,8 +289,6 @@ public class BasePredictor: Predictor, @unchecked Sendable {
   }
 
   /// The IoU (Intersection over Union) threshold for non-maximum suppression (default: 0.7).
-  ///
-  /// Used to filter overlapping detections during non-maximum suppression.
   var iouThreshold = 0.7
 
   /// Sets the IoU threshold for non-maximum suppression.
@@ -320,8 +302,6 @@ public class BasePredictor: Predictor, @unchecked Sendable {
   }
 
   /// The maximum number of detections to return in results (default: 30).
-  ///
-  /// Limits the number of detection items in the final results to prevent overwhelming processing.
   var numItemsThreshold = 30
 
   /// Sets the maximum number of detection items to include in results.
@@ -333,9 +313,8 @@ public class BasePredictor: Predictor, @unchecked Sendable {
 
   /// Processes Vision framework observations from model inference.
   ///
-  /// This method is called when Vision completes a request with the model's outputs.
-  /// Subclasses must override this method to implement task-specific processing of the
-  /// model's output features (e.g., parsing detection boxes, segmentation masks, etc.).
+  /// Invoked when Vision completes a request with the model's outputs. Subclasses must override to parse task-specific
+  /// outputs (detection boxes, segmentation masks, etc.).
   ///
   /// - Parameters:
   ///   - request: The completed Vision request containing model outputs.
@@ -344,10 +323,7 @@ public class BasePredictor: Predictor, @unchecked Sendable {
     // Base implementation is empty - must be overridden by subclasses
   }
 
-  /// Processes a static image and returns results synchronously.
-  ///
-  /// This method performs model inference on a static image and returns the results.
-  /// Subclasses must override this method to implement task-specific processing.
+  /// Runs synchronous inference on a static image. Subclasses must override to implement task-specific processing.
   ///
   /// - Parameter image: The CIImage to process.
   /// - Returns: A YOLOResult containing the prediction outputs.
@@ -356,11 +332,7 @@ public class BasePredictor: Predictor, @unchecked Sendable {
     return .empty
   }
 
-  /// Extracts the required input dimensions from the model description.
-  ///
-  /// This utility method determines the expected input size for the Core ML model
-  /// by examining its input description, which is essential for properly sizing
-  /// and formatting images before inference.
+  /// Extracts the required input dimensions from the model description, used to properly size images before inference.
   ///
   /// - Parameter model: The Core ML model to analyze.
   /// - Returns: A tuple containing the width and height in pixels required by the model.
@@ -498,8 +470,8 @@ public class BasePredictor: Predictor, @unchecked Sendable {
 
   /// Updates the smoothed inference time and FPS, then notifies the timing listener.
   ///
-  /// Call this once per processed frame after `t1` is set. Uses an EMA with
-  /// `emaAlpha` weight on new samples and skips obvious outliers above `maxValidDt`.
+  /// Call this once per processed frame after `t1` is set. Uses an EMA with `emaAlpha` weight on new samples and skips
+  /// obvious outliers above `maxValidDt`.
   func updateTime() {
     let alpha = Self.emaAlpha
     if self.t1 < Self.maxValidDt {  // valid dt

--- a/Sources/YOLO/BoundingBoxView.swift
+++ b/Sources/YOLO/BoundingBoxView.swift
@@ -1,13 +1,13 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-//  BoundingBoxView for Ultralytics YOLO App
-//  This class is designed to visualize bounding boxes and labels for detected objects in the YOLOv8 models within the Ultralytics YOLO app.
-//  It leverages Core Animation layers to draw the bounding boxes and text labels dynamically on the detection video feed.
+//  BoundingBoxView for the Ultralytics YOLO SDK
+//  Visualizes bounding boxes and labels for detected objects using Core Animation layers drawn dynamically on the
+//  detection video feed.
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 //
-//  BoundingBoxView facilitates the clear representation of detection results, improving user interaction with the app by
-//  providing immediate visual feedback on detected objects, including their classification and confidence level.
+//  BoundingBoxView renders detection results — bounding box, class label, and confidence — for immediate visual
+//  feedback in camera and image previews.
 
 import Foundation
 import UIKit
@@ -83,12 +83,12 @@ public final class BoundingBoxView {
   /// Initializes a new BoundingBoxView with configured shape and text layers.
   init() {
     shapeLayer = CAShapeLayer()
-    shapeLayer.fillColor = UIColor.clear.cgColor  // No fill to only show the bounding outline
-    shapeLayer.lineWidth = 4  // Set the stroke line width
-    shapeLayer.isHidden = true  // Initially hidden; shown when a detection occurs
+    shapeLayer.fillColor = UIColor.clear.cgColor  // outline only, no fill
+    shapeLayer.lineWidth = 4
+    shapeLayer.isHidden = true  // shown when a detection occurs
 
     textLayer = CATextLayer()
-    textLayer.isHidden = true  // Initially hidden; shown with label when a detection occurs
+    textLayer.isHidden = true  // shown when a detection occurs
     DetectionLabelStyle.configure(textLayer, fontSize: baseFontSize)
   }
 
@@ -119,7 +119,7 @@ public final class BoundingBoxView {
   ///   - angle: Optional rotation angle in radians for oriented boxes.
   func show(frame: CGRect, label: String, color: UIColor, alpha: CGFloat, angle: CGFloat? = nil) {
     CATransaction.begin()
-    CATransaction.setDisableActions(true)  // Disable implicit animations
+    CATransaction.setDisableActions(true)  // disable implicit animations
 
     let path = UIBezierPath(roundedRect: frame, cornerRadius: 6.0)
     if let angle {
@@ -129,13 +129,13 @@ public final class BoundingBoxView {
       path.apply(transform)
     }
     shapeLayer.path = path.cgPath
-    shapeLayer.strokeColor = color.withAlphaComponent(alpha).cgColor  // Apply color and alpha to the stroke
-    shapeLayer.isHidden = false  // Make the shape layer visible
+    shapeLayer.strokeColor = color.withAlphaComponent(alpha).cgColor
+    shapeLayer.isHidden = false
 
-    textLayer.string = label  // Set the label text
-    textLayer.backgroundColor = color.withAlphaComponent(alpha).cgColor  // Apply color and alpha to the background
-    textLayer.isHidden = false  // Make the text layer visible
-    textLayer.foregroundColor = UIColor.white.withAlphaComponent(alpha).cgColor  // Set text color
+    textLayer.string = label
+    textLayer.backgroundColor = color.withAlphaComponent(alpha).cgColor
+    textLayer.isHidden = false
+    textLayer.foregroundColor = UIColor.white.withAlphaComponent(alpha).cgColor
 
     textLayer.frame = DetectionLabelStyle.frame(
       for: label,

--- a/Sources/YOLO/Classifier.swift
+++ b/Sources/YOLO/Classifier.swift
@@ -1,16 +1,12 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-//  This file is part of the Ultralytics YOLO Package, implementing image classification functionality.
+//  This file is part of the Ultralytics YOLO SDK, implementing image classification.
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 //
-//  The Classifier class implements image classification using YOLO models. Unlike object detection
-//  or segmentation, it focuses on identifying the primary subject of an image rather than locating
-//  objects within it. The class processes model outputs to extract classification probabilities,
-//  identifying the top predicted class and confidence score. It supports multiple output formats
-//  from Vision framework requests, handling both VNCoreMLFeatureValueObservation and
-//  VNClassificationObservation result types. The implementation extracts both the top prediction
-//  and the top 5 predictions with their confidence scores, enabling rich user feedback.
+//  Classifier identifies the primary subject of an image rather than locating objects within it. It accepts both
+//  `VNCoreMLFeatureValueObservation` (raw logits requiring softmax) and `VNClassificationObservation` (already
+//  normalized) result types, and reports the top-1 plus top-5 predictions with confidence scores.
 
 import Accelerate
 import Foundation
@@ -52,10 +48,9 @@ public final class Classifier: BasePredictor, @unchecked Sendable {
     return result
   }
 
-  /// Extracts top-1 and top-5 probabilities from a Vision request result.
-  ///
-  /// Handles both `VNCoreMLFeatureValueObservation` (raw logits that require softmax) and
-  /// `VNClassificationObservation` (already-normalized scores).
+  /// Extracts top-1 and top-5 probabilities from a Vision request result, handling both
+  /// `VNCoreMLFeatureValueObservation` (raw logits requiring softmax) and `VNClassificationObservation` (already
+  /// normalized scores).
   private func extractProbs(from request: VNRequest) -> Probs {
     if let observations = request.results as? [VNCoreMLFeatureValueObservation],
       let multiArray = observations.first?.featureValue.multiArrayValue

--- a/Sources/YOLO/Logger.swift
+++ b/Sources/YOLO/Logger.swift
@@ -4,8 +4,8 @@ import OSLog
 
 /// Unified logger for the Ultralytics YOLO SDK.
 ///
-/// Routes diagnostic output through Apple's unified logging system so messages appear in
-/// Console.app and can be filtered by subsystem. Debug builds also echo to stdout.
+/// Routes diagnostic output through Apple's unified logging system so messages appear in Console.app and can be
+/// filtered by subsystem. Debug builds also echo to stdout.
 enum YOLOLog {
   private static let logger = Logger(subsystem: "com.ultralytics.yolo", category: "YOLO")
 

--- a/Sources/YOLO/ModelPathResolver.swift
+++ b/Sources/YOLO/ModelPathResolver.swift
@@ -4,8 +4,8 @@ import Foundation
 
 /// Resolves a user-supplied model string to an on-disk URL.
 ///
-/// Accepts either an absolute filesystem path to `.mlmodel`/`.mlpackage`/`.mlmodelc`, or a
-/// bundle resource name (searched for `.mlmodelc` then `.mlpackage` in the main bundle).
+/// Accepts either an absolute filesystem path to `.mlmodel`/`.mlpackage`/`.mlmodelc`, or a bundle resource name
+/// (searched for `.mlmodelc` then `.mlpackage` in the main bundle).
 enum ModelPathResolver {
   static func resolve(_ modelPathOrName: String) -> URL? {
     let lowercased = modelPathOrName.lowercased()

--- a/Sources/YOLO/NonMaxSuppression.swift
+++ b/Sources/YOLO/NonMaxSuppression.swift
@@ -1,16 +1,12 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-//  This file is part of the Ultralytics YOLO Package, providing utilities for post-processing detections.
+//  This file is part of the Ultralytics YOLO SDK, providing utilities for post-processing detections.
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 //
-//  The NonMaxSuppression utility provides a fundamental algorithm for filtering redundant
-//  object detections. When multiple bounding boxes detect the same object, non-maximum suppression
-//  selects the best detection and suppresses overlapping boxes with lower confidence scores.
-//  This implementation sorts detection candidates by confidence score, then iteratively selects
-//  the highest-scoring boxes while removing others that have significant overlap (measured by
-//  intersection over minimum area). The algorithm is essential for producing clean detection
-//  results by removing duplicate predictions.
+//  Filters redundant axis-aligned detections via non-maximum suppression. Candidates are sorted by confidence; the
+//  highest-scoring box is kept and any lower-scoring box whose IoU (intersection-over-union) with it exceeds the
+//  threshold is suppressed. Used after traditional (non-NMS-free) YOLO model decoding.
 
 import Foundation
 

--- a/Sources/YOLO/ObbDetector.swift
+++ b/Sources/YOLO/ObbDetector.swift
@@ -1,16 +1,13 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-//  This file is part of the Ultralytics YOLO Package, implementing oriented bounding box detection.
+//  This file is part of the Ultralytics YOLO SDK, implementing oriented bounding box (OBB) detection.
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 //
-//  The ObbDetector class provides functionality for detecting objects with oriented (rotated)
-//  bounding boxes. Unlike standard object detection that uses axis-aligned boxes, this implementation
-//  handles objects at arbitrary orientations by predicting the center, width, height, and rotation
-//  angle of each bounding box. The class includes specialized algorithms for non-maximum suppression
-//  of oriented boxes, computing polygon intersections using the Sutherland-Hodgman algorithm, and
-//  efficient IoU calculations. These optimizations enable real-time performance even when dealing
-//  with the computational complexity of rotated geometry operations.
+//  ObbDetector detects objects at arbitrary orientations, predicting center, width, height, and rotation angle for
+//  each box. Supports both traditional and YOLO26 end2end OBB output formats and includes a fast NMS that caches each
+//  box's polygon, area, and axis-aligned bounding box, using AABB overlap as a cheap filter before computing polygon
+//  intersection via the Sutherland–Hodgman algorithm.
 
 import Accelerate
 import CoreML
@@ -172,10 +169,9 @@ public final class ObbDetector: BasePredictor, @unchecked Sendable {
     return results
   }
 
-  /// Processes YOLO26 end2end OBB output: [1, max_det, 7].
-  /// Each detection: [cx, cy, w, h, conf, class_id, angle] in xywh pixel coords.
-  /// OBB uses dist2rbox() which always outputs center-based xywh (NOT xyxy like detect).
-  /// NMS is already applied by the model.
+  /// Processes YOLO26 end2end OBB output `[1, max_det, 7]` where each detection is
+  /// `[cx, cy, w, h, conf, class_id, angle]` in pixel coords. OBB uses `dist2rbox()` which always outputs center-based
+  /// xywh (not xyxy like detect). NMS is already applied by the model.
   private func postProcessEnd2EndOBB(
     feature: MLMultiArray,
     shape: [Int],
@@ -215,9 +211,8 @@ public final class ObbDetector: BasePredictor, @unchecked Sendable {
     return results
   }
 
-  /// Fast NMS for oriented bounding boxes.
-  /// Internally, it caches each box's polygon, area, and axis-aligned bounding box.
-  /// Then it does a quick AABB overlap check before polygon intersection to skip expensive IoU.
+  /// Fast NMS for oriented bounding boxes. Caches each box's polygon, area, and axis-aligned bounding box, then uses a
+  /// cheap AABB overlap check before computing polygon intersection IoU.
   public func nonMaxSuppressionOBB(
     boxes: [OBB],
     scores: [Float],
@@ -267,14 +262,12 @@ public final class ObbDetector: BasePredictor, @unchecked Sendable {
 
 }
 
-/// Returns the polygon formed by clipping subjectPolygon to clipPolygon using
-/// the Sutherland–Hodgman algorithm.
+/// Returns the polygon formed by clipping subjectPolygon to clipPolygon using the Sutherland–Hodgman algorithm.
 func polygonIntersection(subjectPolygon: Polygon, clipPolygon: Polygon) -> Polygon {
   var outputList = subjectPolygon
   let clipEdgeCount = clipPolygon.count
 
-  // If the polygon is not closed, append the first point at the end
-  // so we can iterate edges easily.
+  // Close the polygon by appending the first point so we can iterate edges easily.
   let closedClipPolygon = clipPolygon + [clipPolygon[0]]
 
   for i in 0..<clipEdgeCount {
@@ -334,40 +327,32 @@ func polygonIntersection(subjectPolygon: Polygon, clipPolygon: Polygon) -> Polyg
   return outputList
 }
 
-/// Determine if a point is inside the "half-plane" defined by the directed edge
-/// from edgeStart -> edgeEnd. We treat "left-turn" or "right-turn" checks.
+/// Returns true if `point` lies in the half-plane to the left of (or on) the directed edge `edgeStart` → `edgeEnd`.
+///
+/// Sutherland–Hodgman keeps the polygon on the left of each clip edge, assuming a clockwise clip polygon.
 func isInside(
   point: CGPoint,
   edgeStart: CGPoint,
   edgeEnd: CGPoint
 ) -> Bool {
-  // We can use cross product to check which side of the directed edge we are on.
-  // For a standard "clip left" convention, use the sign of the cross product:
-  // Vector(edgeEnd - edgeStart) x Vector(point - edgeStart).
+  // Sign of the 2D cross product (edgeEnd - edgeStart) x (point - edgeStart) indicates the side.
   let cross =
     (edgeEnd.x - edgeStart.x) * (point.y - edgeStart.y)
     - (edgeEnd.y - edgeStart.y) * (point.x - edgeStart.x)
-  // If cross >= 0, point is to the left or on the line.
-  // This depends on which side we treat as "inside".
-  // Sutherland–Hodgman typically keeps polygon inside to the left of each edge
-  // (assuming a clockwise clip polygon).
   return cross >= 0
 }
 
-/// Compute intersection between the line segment p1->p2 and the infinite line
-/// defined by clipStart->clipEnd.
+/// Returns the intersection point between the line segment `p1`→`p2` and the infinite line through
+/// `clipStart`→`clipEnd`, or `nil` if the lines are parallel.
+///
+/// Sutherland–Hodgman uses this in a context that already classifies endpoints as inside/outside, so `t` is not
+/// clamped to `[0, 1]`.
 func computeIntersection(
   p1: CGPoint,
   p2: CGPoint,
   clipStart: CGPoint,
   clipEnd: CGPoint
 ) -> CGPoint? {
-  // Solve for parametric intersection.
-  // Parametric line eqn:
-  //   p1 + t (p2 - p1)
-  //   clipStart + u (clipEnd - clipStart)
-  // We want to find t where lines intersect in 2D. Then check if 0..1 for the segment.
-
   let x1 = p1.x
   let y1 = p1.y
   let x2 = p2.x
@@ -379,19 +364,11 @@ func computeIntersection(
 
   let denom = (x1 - x2) * (y3 - y4) - (y1 - y2) * (x3 - x4)
   if abs(denom) < 1e-10 {
-    // Lines are parallel or extremely close to parallel
+    // Lines are parallel (or nearly so)
     return nil
   }
-  // Intersection parameter t on p1->p2
+  // Parametric intersection on p1→p2
   let t = ((x1 - x3) * (y3 - y4) - (y1 - y3) * (x3 - x4)) / denom
-
-  // We only need the point, not strictly to check 0<=t<=1,
-  // because Sutherland–Hodgman calls this in a context where
-  // it decides how to treat inside vs outside.
-  // But it's nice to be consistent:
-  // if t < 0 or t > 1 => intersection not on the segment p1->p2.
-  // For standard polygon clipping, we still use the intersection anyway.
-  // So we won't clamp T here, but you can if you want to discard outside segments.
 
   let ix = x1 + t * (x2 - x1)
   let iy = y1 + t * (y2 - y1)
@@ -410,7 +387,7 @@ func polygonArea(_ poly: Polygon) -> CGFloat {
   return abs(area) * 0.5
 }
 
-/// Store cached geometry for faster OBB IoU checks.
+/// Cached geometry (polygon, area, axis-aligned bounding box) for faster OBB IoU checks.
 public struct OBBInfo {
   let polygon: Polygon  // The 4 corners in order
   let area: CGFloat
@@ -422,13 +399,13 @@ public struct OBBInfo {
     self.aabb = obb.toAABB()
   }
 
-  /// Quickly check if the axis-aligned bounding boxes intersect.
-  /// If not, the IoU is 0, so we can skip the expensive polygon intersection.
+  /// Returns true if the axis-aligned bounding boxes overlap. If false, IoU is 0 and the expensive polygon
+  /// intersection can be skipped.
   func aabbIntersects(with other: OBBInfo) -> Bool {
     return aabb.intersects(other.aabb)
   }
 
-  /// Compute actual IoU using polygon intersection if bounding boxes overlap.
+  /// Computes IoU between two OBBs using their polygon intersection.
   func iou(with other: OBBInfo) -> Float {
     let interPoly = polygonIntersection(
       subjectPolygon: polygon,
@@ -441,7 +418,7 @@ public struct OBBInfo {
 }
 
 extension OBB {
-  /// Return the axis-aligned bounding box around this rotated box
+  /// Returns the axis-aligned bounding box enclosing this rotated box.
   func toAABB() -> CGRect {
     let poly = toPolygon()
     var minX = CGFloat.infinity

--- a/Sources/YOLO/ObjectDetector.swift
+++ b/Sources/YOLO/ObjectDetector.swift
@@ -1,16 +1,13 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-//  This file is part of the Ultralytics YOLO Package, implementing object detection functionality.
+//  This file is part of the Ultralytics YOLO SDK, implementing object detection.
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 //
-//  The ObjectDetector class provides specialized functionality for detecting objects in images
-//  using YOLO models. It processes Vision framework results to extract bounding boxes, class labels,
-//  and confidence scores from model predictions. The class handles both real-time frame processing
-//  and single image analysis, converting the Vision API's normalized coordinates to image coordinates,
-//  and packaging the results in the standardized YOLOResult format. It includes performance monitoring
-//  for inference time and frame rate, and offers runtime adjustable parameters such as confidence
-//  threshold and IoU threshold for non-maximum suppression.
+//  ObjectDetector extracts bounding boxes, class labels, and confidence scores from YOLO detection model outputs,
+//  handling both real-time camera frames and single-image analysis. It supports the traditional Vision NMS pipeline
+//  (YOLO11, returning `VNRecognizedObjectObservation`) and NMS-free end2end models (YOLO26, returning raw
+//  `MLMultiArray` tensors), converting model coordinates to input-image space and packaging results as `YOLOResult`.
 
 import CoreML
 import Foundation
@@ -19,20 +16,17 @@ import Vision
 
 /// Specialized predictor for YOLO object detection models that identifies and localizes objects in images.
 ///
-/// This class processes the outputs from YOLO object detection models, extracting bounding boxes,
-/// class labels, and confidence scores. It handles both real-time camera feed processing and
-/// single image analysis, converting the normalized coordinates from the Vision framework
-/// to image coordinates and applying non-maximum suppression to filter duplicative detections.
+/// Handles both real-time camera frames and single-image analysis, converting Vision-normalized coordinates to
+/// image-space rectangles. Traditional models pass through the Vision NMS pipeline; NMS-free YOLO26 models are
+/// decoded directly from raw `MLMultiArray` tensors with optional Swift-side NMS.
 ///
-/// - Note: Object detection models output rectangular bounding boxes around detected objects.
-/// - SeeAlso: `Segmenter` for models that produce pixel-level masks for objects.
+/// - SeeAlso: `Segmenter` for models that also produce pixel-level masks.
 public final class ObjectDetector: BasePredictor, @unchecked Sendable {
 
   /// Processes the results from the Vision framework's object detection request.
   ///
-  /// This method extracts bounding boxes, class labels, and confidence scores from the
-  /// Vision object detection results, converts coordinates to the original image space,
-  /// and notifies listeners with the structured detection results.
+  /// Decodes boxes from `request.results`, converts them to image-space coordinates, and notifies the results
+  /// listener.
   ///
   /// - Parameters:
   ///   - request: The completed Vision request containing object detection results.
@@ -47,8 +41,8 @@ public final class ObjectDetector: BasePredictor, @unchecked Sendable {
 
   /// Decodes detection boxes from a completed Vision request.
   ///
-  /// Handles both NMS-pipelined models (`VNRecognizedObjectObservation`, e.g. YOLO11)
-  /// and NMS-free models (`VNCoreMLFeatureValueObservation` raw tensors, e.g. YOLO26).
+  /// Handles both NMS-pipelined models (`VNRecognizedObjectObservation`, e.g. YOLO11) and NMS-free models
+  /// (`VNCoreMLFeatureValueObservation` raw tensors, e.g. YOLO26).
   private func decodeBoxes(from request: VNRequest) -> [Box] {
     // NMS-pipelined models (YOLO11 etc.) return VNRecognizedObjectObservation
     if let results = request.results as? [VNRecognizedObjectObservation] {
@@ -62,8 +56,8 @@ public final class ObjectDetector: BasePredictor, @unchecked Sendable {
         let imageRect = VNImageRectForNormalizedRect(
           invertedBox, Int(inputSize.width), Int(inputSize.height))
 
-        // The labels array is a list of VNClassificationObservation objects,
-        // with the highest scoring class first in the list.
+        // The labels array is a list of VNClassificationObservation objects, with the highest scoring class first in
+        // the list.
         let label = prediction.labels[0].identifier
         let index = self.labels.firstIndex(of: label) ?? 0
         let confidence = prediction.labels[0].confidence
@@ -81,11 +75,7 @@ public final class ObjectDetector: BasePredictor, @unchecked Sendable {
     return []
   }
 
-  /// Processes a static image and returns object detection results.
-  ///
-  /// This method performs object detection on a static image and returns the
-  /// detection results synchronously. It handles the entire inference pipeline
-  /// from setting up the Vision request to processing the detection results.
+  /// Runs synchronous object detection on a static image and returns the results.
   ///
   /// - Parameter image: The CIImage to analyze for object detection.
   /// - Returns: A YOLOResult containing the detected objects with bounding boxes, class labels, and confidence scores.
@@ -119,7 +109,7 @@ public final class ObjectDetector: BasePredictor, @unchecked Sendable {
 
   // MARK: - Raw tensor processing (NMS-free YOLO26)
 
-  /// Dispatches raw MLMultiArray tensor to the appropriate processing method based on output format.
+  /// Dispatches a raw `MLMultiArray` tensor to the appropriate decoder based on output shape (end2end vs traditional).
   ///
   /// - Parameter prediction: The raw MLMultiArray output from the model.
   /// - Returns: An array of detected boxes.

--- a/Sources/YOLO/Plot.swift
+++ b/Sources/YOLO/Plot.swift
@@ -4,13 +4,9 @@
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 //
-//  The Plot module provides visualization utilities for rendering YOLO model results.
-//  It includes functions for drawing bounding boxes, segmentation masks, pose keypoints,
-//  classification results, and oriented bounding boxes on images. The module implements
-//  specialized rendering algorithms for each type of prediction, handles color management
-//  for different classes, and supports both static image and real-time visualization scenarios.
-//  Each visualization function is optimized for the specific task to provide clear and
-//  informative visual feedback to users with minimal performance impact.
+//  The Plot module renders YOLO inference results. It draws bounding boxes, segmentation masks, pose keypoints,
+//  classification labels, and oriented bounding boxes onto images, with per-class color management and support for
+//  both static-image and real-time scenarios.
 
 import Accelerate
 import CoreImage
@@ -92,8 +88,8 @@ let skeleton = [
 
 /// Executes `body` inside a bitmap graphics context rendered at pixel scale.
 ///
-/// Flips the y-axis so drawing matches UIKit's top-left origin and draws `cgImage` as the
-/// background. The same boilerplate appeared across every `draw…` visualization helper.
+/// Flips the y-axis so drawing matches UIKit's top-left origin and draws the source image as the background, then
+/// invokes `body` with the context and pixel size for callers to add their overlays.
 private func renderWithBackground(
   _ ciImage: CIImage,
   targetSize: CGSize? = nil,

--- a/Sources/YOLO/PoseEstimator.swift
+++ b/Sources/YOLO/PoseEstimator.swift
@@ -4,13 +4,10 @@
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 //
-//  The PoseEstimator class extends the BasePredictor to provide human pose and keypoint detection.
-//  It processes model outputs to identify human subjects and their body keypoints (joints such as
-//  eyes, shoulders, elbows, wrists, hips, knees, ankles, etc.). The class converts the model's raw
-//  output into structured data representing each detected person's bounding box and associated
-//  keypoints with their confidence scores. This implementation supports both real-time processing
-//  for camera feeds and single image analysis, producing visualizable results that can be overlaid
-//  on the source image to show the detected pose skeleton.
+//  PoseEstimator extends BasePredictor to detect human subjects and their body keypoints (eyes, shoulders, elbows,
+//  wrists, hips, knees, ankles, etc.). It converts raw model output into per-person bounding boxes and keypoints
+//  with confidence scores, and supports both real-time camera frames and single-image inference. The results can be
+//  overlaid on the source image to draw the pose skeleton.
 
 import Accelerate
 import CoreML

--- a/Sources/YOLO/Predictor.swift
+++ b/Sources/YOLO/Predictor.swift
@@ -4,20 +4,17 @@
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 //
-//  The Predictor protocol and related interfaces define the contract for all YOLO model prediction
-//  implementations. This includes methods for processing images and camera frames, as well as
-//  listener protocols for receiving prediction results and performance metrics. The protocol-based
-//  design enables a consistent API across different model types (detection, segmentation, semantic segmentation, classification)
-//  while allowing for specialized implementations. Error types related to prediction processes
-//  are also defined here, providing standardized error handling throughout the application.
+//  Defines the Predictor protocol and listener interfaces shared by every YOLO model implementation. Predictors
+//  process static images and camera frames; listeners receive results and timing metrics. The protocol-based design
+//  keeps a consistent API across detection, segmentation, semantic segmentation, classification, pose, and OBB
+//  tasks. Error types for model loading and inference are also defined here.
 
 import CoreImage
 import Vision
 
-/// Protocol for receiving YOLO model prediction results.
+/// Callback protocol for receiving YOLO inference results.
 ///
-/// This protocol defines a callback mechanism for receiving results from YOLO model inference.
-/// Implementers receive notifications with processed results when model inference is complete.
+/// Implementers are notified with processed results when each inference completes.
 public protocol ResultsListener: AnyObject {
   /// Called when a new prediction result is available.
   ///
@@ -26,10 +23,9 @@ public protocol ResultsListener: AnyObject {
   func on(result: YOLOResult)
 }
 
-/// Protocol for receiving model inference performance metrics.
+/// Callback protocol for receiving YOLO inference performance metrics.
 ///
-/// This protocol defines a callback mechanism for monitoring the performance of YOLO model inference.
-/// Implementers receive notifications with timing information to track inference speed.
+/// Implementers are notified with timing information so they can monitor inference speed.
 public protocol InferenceTimeListener: AnyObject {
   /// Called when inference timing information is available.
   ///
@@ -41,9 +37,9 @@ public protocol InferenceTimeListener: AnyObject {
 
 /// Core protocol for YOLO model predictors.
 ///
-/// This protocol defines the contract that all YOLO model prediction implementations must fulfill.
-/// It provides methods for processing both camera frames and static images, and managing prediction state.
-/// Specialized implementations exist for different model types (detection, segmentation, etc.).
+/// Defines the contract every YOLO prediction implementation must fulfill: methods for processing camera frames and
+/// static images, plus prediction state. Specialized implementations exist for each task (detection, segmentation,
+/// semantic, classification, pose, OBB).
 public protocol Predictor {
   /// Processes a camera frame buffer and delivers results via callback.
   ///
@@ -68,10 +64,7 @@ public protocol Predictor {
   var isUpdating: Bool { get set }
 }
 
-/// Errors that can occur during YOLO model prediction.
-///
-/// This enumeration defines the different types of errors that may be encountered
-/// during model loading, configuration, and inference operations.
+/// Errors that can occur during YOLO model loading, configuration, or inference.
 public enum PredictorError: Error {
   /// The model file could not be found at the specified location.
   case modelFileNotFound

--- a/Sources/YOLO/Segmenter.swift
+++ b/Sources/YOLO/Segmenter.swift
@@ -4,13 +4,10 @@
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 //
-//  The Segmenter class extends BasePredictor to provide instance segmentation capabilities.
-//  Instance segmentation not only detects objects but also identifies the precise pixels
-//  belonging to each object. The class processes complex model outputs including prototype masks
-//  and detection results, performs non-maximum suppression to filter detections, and combines
-//  results into visualizable mask images. It leverages the Accelerate framework for efficient
-//  matrix operations and includes parallel processing to optimize performance on mobile devices.
-//  The results include both bounding boxes and pixel-level masks that can be overlaid on images.
+//  Segmenter extends BasePredictor for instance segmentation, where each detection has both a bounding box and a
+//  per-pixel mask. It parses prototype masks and detection features from the model output, runs non-maximum
+//  suppression, and combines results into a single mask image. Accelerate's vDSP and parallel dispatch keep
+//  per-frame cost low on mobile devices.
 
 import Accelerate
 @preconcurrency import CoreML
@@ -111,9 +108,9 @@ public final class Segmenter: BasePredictor, @unchecked Sendable {
     return result
   }
 
-  /// Pulls the `(pred, masks, detectedObjects)` tuple out of a completed Vision request.
-  /// The shape-4 output is the prototype masks and the other is the detection features;
-  /// their order depends on the exported model.
+  /// Pulls the `(masks, detectedObjects)` tuple out of a completed Vision request. The shape-4 output is the
+  /// prototype masks and the other is the detection features; their order in `request.results` depends on the
+  /// exported model.
   private func parseSegmentationRequest(
     _ request: VNRequest
   ) -> (masks: MLMultiArray, detectedObjects: [(CGRect, Int, Float, MLMultiArray)])? {

--- a/Sources/YOLO/SemanticSegmenter.swift
+++ b/Sources/YOLO/SemanticSegmenter.swift
@@ -1,5 +1,13 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
+//  This file is part of the Ultralytics YOLO Package, implementing semantic segmentation functionality.
+//  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
+//  Access the source code: https://github.com/ultralytics/yolo-ios-app
+//
+//  SemanticSegmenter extends BasePredictor to produce a dense class map for the full scene without separating
+//  individual object instances. It supports both [1, C, H, W] and [1, H, W, C] tensor layouts, removes letterbox
+//  padding via the input mask crop rect, and renders a color overlay for visualization.
+
 import CoreML
 import Foundation
 import UIKit

--- a/Sources/YOLO/ThresholdProvider.swift
+++ b/Sources/YOLO/ThresholdProvider.swift
@@ -1,14 +1,12 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-//  Threshold Provider for Ultralytics YOLO App
-//  This class is designed to supply custom Intersection Over Union (IoU) and confidence thresholds
-//  for the YOLOv8 object detection models within the Ultralytics YOLO app. It conforms to the MLFeatureProvider protocol,
-//  allowing these thresholds to be dynamically adjusted and applied to model predictions.
+//  This file is part of the Ultralytics YOLO Package, supplying runtime IoU and confidence thresholds to YOLO models.
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 //
-//  The ThresholdProvider class enables fine-tuning of detection sensitivity and precision by modifying the
-//  IoU and confidence thresholds, which are crucial for balancing the detection accuracy and the number of false positives.
+//  ThresholdProvider conforms to MLFeatureProvider so it can inject Intersection over Union (IoU) and confidence
+//  thresholds into a Core ML model at inference time. Adjusting these values tunes detection sensitivity and the
+//  trade-off between recall and false positives.
 
 import CoreML
 
@@ -22,10 +20,10 @@ public final class ThresholdProvider: MLFeatureProvider {
     return Set(values.keys)
   }
 
-  /// Initializes the provider with specified IoU and confidence thresholds.
+  /// Creates a provider with the given IoU and confidence thresholds.
   /// - Parameters:
-  ///   - iouThreshold: The IoU threshold for determining object overlap.
-  ///   - confidenceThreshold: The minimum confidence for considering a detection valid.
+  ///   - iouThreshold: IoU threshold used by NMS to merge overlapping detections.
+  ///   - confidenceThreshold: Minimum confidence required for a detection to be kept.
   init(iouThreshold: Double = 0.7, confidenceThreshold: Double = 0.25) {
     values = [
       "iouThreshold": MLFeatureValue(double: iouThreshold),
@@ -34,8 +32,8 @@ public final class ThresholdProvider: MLFeatureProvider {
   }
 
   /// Returns the feature value for the given feature name.
-  /// - Parameter featureName: The name of the feature.
-  /// - Returns: The MLFeatureValue object corresponding to the feature name.
+  /// - Parameter featureName: The feature name to look up (`iouThreshold` or `confidenceThreshold`).
+  /// - Returns: The matching `MLFeatureValue`, or `nil` if the name is unknown.
   public func featureValue(for featureName: String) -> MLFeatureValue? {
     return values[featureName]
   }

--- a/Sources/YOLO/VideoCapture.swift
+++ b/Sources/YOLO/VideoCapture.swift
@@ -4,12 +4,10 @@
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 //
-//  The VideoCapture component manages the camera and video processing pipeline for real-time
-//  object detection. It handles setting up the AVCaptureSession, managing camera devices,
-//  configuring camera properties like focus and exposure, and processing video frames for
-//  model inference. The class delivers capture frames to the predictor component for real-time
-//  analysis and returns results through delegate callbacks. It also supports camera controls
-//  such as switching between front and back cameras, zooming, and capturing still photos.
+//  VideoCapture wraps AVCaptureSession to drive real-time inference. It sets up the session, selects camera
+//  devices, configures focus and exposure, and forwards each video frame to a Predictor. Results are returned to
+//  callers through delegate callbacks. The class also handles switching between front and back cameras, zooming,
+//  and capturing still frames.
 
 import AVFoundation
 import CoreVideo

--- a/Sources/YOLO/YOLO.swift
+++ b/Sources/YOLO/YOLO.swift
@@ -4,12 +4,10 @@
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 //
-//  The YOLO class serves as the primary interface for loading and using YOLO machine learning models.
-//  It supports a variety of input formats including UIImage, CIImage, CGImage, and resource files.
-//  The class handles model loading, format conversion, and inference execution, offering a simple yet
-//  powerful API through Swift's callable object pattern. Users can load models from local bundles or
-//  file paths and perform inference with a single function call syntax, making integration into iOS
-//  applications straightforward.
+//  YOLO is the primary entry point for loading a model and running inference. It accepts UIImage, CIImage, CGImage,
+//  bundle resources, file paths, remote URLs, and SwiftUI images, and exposes them through `callAsFunction`
+//  overloads so callers can invoke a YOLO instance like a function. Models can be loaded from the app bundle, a
+//  filesystem path, or downloaded and cached from a remote URL.
 
 import Foundation
 import SwiftUI
@@ -17,9 +15,9 @@ import UIKit
 
 /// The primary interface for working with YOLO models, supporting multiple input types and inference methods.
 ///
-/// Model loading is asynchronous. Calling a `callAsFunction` overload before the init completion
-/// handler has fired returns an empty `YOLOResult`. Use `isLoaded` to check readiness, or perform
-/// inference from inside the completion handler.
+/// Model loading is asynchronous. Calling a `callAsFunction` overload before the init completion handler has fired
+/// returns an empty `YOLOResult`. Use `isLoaded` to check readiness, or perform inference from inside the completion
+/// handler.
 public final class YOLO: @unchecked Sendable {
   var predictor: Predictor?
   private var modelDownloader: YOLOModelDownloader?
@@ -36,7 +34,7 @@ public final class YOLO: @unchecked Sendable {
     (predictor as? BasePredictor)?.isModelLoaded ?? false
   }
 
-  /// Initialize YOLO with remote URL for automatic download and caching
+  /// Initializes YOLO from a remote model URL, downloading and caching it as needed.
   public init(url: URL, task: YOLOTask, completion: @escaping (Result<YOLO, Error>) -> Void) {
     modelDownloader = YOLOModelDownloader()
     modelDownloader?.download(from: url, task: task) { [weak self] result in
@@ -61,7 +59,7 @@ public final class YOLO: @unchecked Sendable {
     loadModel(from: modelURL, task: task, completion: completion)
   }
 
-  /// Load model from URL with task-specific predictor creation
+  /// Creates the task-specific predictor for the given model URL and applies any pending thresholds.
   private func loadModel(
     from modelURL: URL, task: YOLOTask, completion: ((Result<YOLO, Error>) -> Void)?
   ) {
@@ -86,15 +84,15 @@ public final class YOLO: @unchecked Sendable {
 
   // MARK: - Threshold Configuration Methods
 
-  /// Sets the maximum number of detection items to include in results.
-  /// - Parameter numItems: The maximum number of items to include (default is 30).
+  /// Sets the maximum number of detection items to include in results (default 30 inside the predictor).
+  /// - Parameter numItems: The maximum number of items to include per inference.
   public func setNumItemsThreshold(_ numItems: Int) {
     pendingNumItems = numItems
     (predictor as? BasePredictor)?.setNumItemsThreshold(numItems: numItems)
   }
 
-  /// Gets the current maximum number of detection items.
-  /// - Returns: The current threshold value, or nil if not applicable.
+  /// Returns the current maximum number of detection items.
+  /// - Returns: The active threshold, or `nil` if no value has been set and the model hasn't loaded yet.
   public func getNumItemsThreshold() -> Int? {
     (predictor as? BasePredictor)?.numItemsThreshold ?? pendingNumItems
   }
@@ -107,8 +105,8 @@ public final class YOLO: @unchecked Sendable {
     (predictor as? BasePredictor)?.setConfidenceThreshold(confidence: confidence)
   }
 
-  /// Gets the current confidence threshold.
-  /// - Returns: The current threshold value, or nil if not applicable.
+  /// Returns the current confidence threshold.
+  /// - Returns: The active threshold, or `nil` if no value has been set and the model hasn't loaded yet.
   public func getConfidenceThreshold() -> Double? {
     (predictor as? BasePredictor)?.confidenceThreshold ?? pendingConfidence
   }
@@ -121,8 +119,8 @@ public final class YOLO: @unchecked Sendable {
     (predictor as? BasePredictor)?.setIouThreshold(iou: iou)
   }
 
-  /// Gets the current IoU threshold.
-  /// - Returns: The current threshold value, or nil if not applicable.
+  /// Returns the current IoU threshold.
+  /// - Returns: The active threshold, or `nil` if no value has been set and the model hasn't loaded yet.
   public func getIouThreshold() -> Double? {
     (predictor as? BasePredictor)?.iouThreshold ?? pendingIou
   }

--- a/Sources/YOLO/YOLOCamera.swift
+++ b/Sources/YOLO/YOLOCamera.swift
@@ -4,12 +4,8 @@
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 //
-//  The YOLOCamera component provides a SwiftUI view for real-time object detection using device cameras.
-//  It wraps the underlying YOLOView component to provide a clean SwiftUI interface for camera feed processing,
-//  model inference, and result display. The component automatically handles camera setup, frame capture,
-//  model loading, and inference processing, making it simple to add real-time object detection capabilities
-//  to SwiftUI applications with minimal code. Results are exposed through a callback for custom handling
-//  of detection results.
+//  YOLOCamera is a SwiftUI wrapper around YOLOView that runs real-time inference on the device camera. It manages
+//  camera setup, frame capture, model loading, and inference, and forwards results through an optional callback.
 
 import AVFoundation
 import SwiftUI

--- a/Sources/YOLO/YOLOModelCache.swift
+++ b/Sources/YOLO/YOLOModelCache.swift
@@ -4,25 +4,25 @@
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 //
-//  The YOLOModelCache class manages the caching of downloaded YOLO models to improve performance
-//  and reduce network usage. It provides functionality to store, retrieve, and manage cached models
-//  in the device's documents directory, with URL-based cache key generation for unique identification.
+//  YOLOModelCache stores compiled YOLO models in `Library/Caches/YOLOModels/` so subsequent launches can skip the
+//  download and compilation. Each entry is keyed by the SHA-256 of the source URL (plus optional task) so the same
+//  archive can be cached separately per task.
 
 import CryptoKit
 import Foundation
 
-/// Manages caching of downloaded YOLO models in the documents directory.
+/// Manages caching of downloaded YOLO models in `Library/Caches/YOLOModels/`.
 public final class YOLOModelCache {
-  /// Shared singleton instance
+  /// Shared singleton instance.
   public static let shared = YOLOModelCache()
 
-  /// Cache directory URL
+  /// Root cache directory for compiled models.
   let cacheDirectory: URL
 
-  /// Lock for thread-safe file system access
+  /// Lock that serializes file-system access from concurrent callers.
   private let lock = NSLock()
 
-  /// Error types for cache operations
+  /// Errors that can be reported by cache operations.
   public enum CacheError: LocalizedError {
     case failedToCreateDirectory
     case failedToSaveModel
@@ -57,19 +57,19 @@ public final class YOLOModelCache {
     }
   }
 
-  /// Generate cache key from URL with optional task type
+  /// Returns the SHA-256 cache key for the given URL and optional task.
   public func cacheKey(for url: URL, task: YOLOTask? = nil) -> String {
     let urlString =
       task.map { url.absoluteString + "_" + String(describing: $0) } ?? url.absoluteString
     return Data(urlString.utf8).sha256()
   }
 
-  /// Check if model is cached
+  /// Returns `true` if a compiled model for the given URL (and optional task) is already cached.
   public func isCached(url: URL, task: YOLOTask? = nil) -> Bool {
     getCachedModelPath(url: url, task: task) != nil
   }
 
-  /// Get cached model path if available
+  /// Returns the cached model URL for the given source URL (and optional task), or `nil` if none is present.
   public func getCachedModelPath(url: URL, task: YOLOTask? = nil) -> URL? {
     lock.lock()
     defer { lock.unlock() }
@@ -92,7 +92,7 @@ public final class YOLOModelCache {
     return nil
   }
 
-  /// Clear all cached models
+  /// Removes every entry from the cache directory.
   public func clearCache() throws {
     let contents = try FileManager.default.contentsOfDirectory(
       at: cacheDirectory, includingPropertiesForKeys: nil)
@@ -101,7 +101,7 @@ public final class YOLOModelCache {
     }
   }
 
-  /// Get cache size in bytes
+  /// Returns the total cache size in bytes.
   public func getCacheSize() throws -> Int64 {
     let contents = try FileManager.default.contentsOfDirectory(
       at: cacheDirectory,
@@ -120,14 +120,14 @@ public final class YOLOModelCache {
     return size
   }
 
-  /// List all cached models
+  /// Returns the cache keys for every cached model.
   public func listCachedModels() throws -> [String] {
     let contents = try FileManager.default.contentsOfDirectory(
       at: cacheDirectory, includingPropertiesForKeys: nil)
     return contents.map { $0.deletingPathExtension().lastPathComponent }
   }
 
-  /// Calculate directory size recursively
+  /// Recursively sums the file sizes inside `url`.
   private func directorySize(at url: URL) throws -> Int64 {
     let enumerator = FileManager.default.enumerator(
       at: url,

--- a/Sources/YOLO/YOLOModelDownloader.swift
+++ b/Sources/YOLO/YOLOModelDownloader.swift
@@ -4,9 +4,9 @@
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 //
-//  The YOLOModelDownloader class handles the downloading, extraction, and processing of YOLO models
-//  from remote URLs. It supports progress tracking, ZIP file extraction with proper handling of
-//  directory structures, and automatic caching of downloaded models for offline use.
+//  YOLOModelDownloader downloads, extracts, and compiles YOLO models from remote URLs. It reports fractional
+//  progress, unpacks ZIP archives while skipping macOS metadata, and stores the compiled `.mlmodelc` in
+//  YOLOModelCache for offline reuse.
 
 import CoreML
 import Foundation
@@ -18,7 +18,7 @@ public final class YOLOModelDownloader: NSObject {
   public typealias ProgressHandler = (Double) -> Void
   public typealias CompletionHandler = (Result<URL, Error>) -> Void
 
-  /// Error types for download operations
+  /// Errors that can be reported during a download.
   public enum DownloadError: LocalizedError {
     case invalidURL, invalidZipFile, modelNotFoundInArchive
     case downloadFailed(Error)
@@ -98,7 +98,7 @@ public final class YOLOModelDownloader: NSObject {
     downloadTask?.resume()
   }
 
-  /// Cancel current download
+  /// Cancels the in-flight download, if any.
   public func cancelDownload() {
     downloadTask?.cancel()
   }
@@ -122,7 +122,7 @@ public final class YOLOModelDownloader: NSObject {
     completionHandler?(result)
   }
 
-  /// Process downloaded file
+  /// Extracts, locates, compiles, and caches the model from a freshly downloaded archive.
   private func processDownloadedFile(at location: URL, originalURL: URL) {
     // Use the stored originalURL if available (for task-aware downloads)
     let url = self.originalURL ?? originalURL
@@ -157,7 +157,7 @@ public final class YOLOModelDownloader: NSObject {
     }
   }
 
-  /// Find model file in extracted contents
+  /// Locates the model file (or mlpackage) inside the extracted archive.
   private func findModelPath(in extractedPath: URL, for url: URL) throws -> URL {
     let contents = try FileManager.default.contentsOfDirectory(
       at: extractedPath, includingPropertiesForKeys: [.isDirectoryKey])
@@ -178,7 +178,7 @@ public final class YOLOModelDownloader: NSObject {
     }
   }
 
-  /// Cache compiled model
+  /// Moves the compiled model into the shared cache and returns its final URL.
   private func cacheModel(_ compiledPath: URL, for url: URL) throws -> URL {
     let key = YOLOModelCache.shared.cacheKey(for: url, task: currentTask)
     let cachedPath = YOLOModelCache.shared.cacheDirectory.appendingPathComponent(key)
@@ -192,7 +192,7 @@ public final class YOLOModelDownloader: NSObject {
     return cachedPath
   }
 
-  /// Extract ZIP file while skipping macOS metadata
+  /// Extracts a ZIP archive into `destinationURL`, skipping macOS resource-fork metadata.
   private func unzipSkippingMacOSX(at sourceURL: URL, to destinationURL: URL) throws {
     let archive: Archive
     do {
@@ -219,7 +219,7 @@ public final class YOLOModelDownloader: NSObject {
     }
   }
 
-  /// Recursively find model file in directory
+  /// Recursively searches `directory` for an `.mlpackage`, `.mlmodel`, or `.mlmodelc` and returns the first match.
   private func findModelFile(in directory: URL) throws -> URL? {
     let contents = try FileManager.default.contentsOfDirectory(
       at: directory, includingPropertiesForKeys: [.isDirectoryKey])
@@ -245,7 +245,7 @@ public final class YOLOModelDownloader: NSObject {
     return nil
   }
 
-  /// Compile model if needed
+  /// Compiles `.mlmodel` / `.mlpackage` files via Core ML and returns the resulting `.mlmodelc` URL.
   private func compileModelIfNeeded(at modelURL: URL) throws -> URL {
     switch modelURL.pathExtension {
     case "mlmodel", "mlpackage":

--- a/Sources/YOLO/YOLOResult.swift
+++ b/Sources/YOLO/YOLOResult.swift
@@ -4,29 +4,23 @@
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 //
-//  The YOLOResult and related structures define the data models for storing and processing
-//  the output from YOLO model inference. This includes bounding boxes for object detection,
-//  masks for segmentation, probability distributions for classification, keypoints for pose estimation,
-//  and oriented bounding boxes for rotated object detection. These structures maintain the
-//  results in a consistent format across different tasks, making it easier to process and
-//  visualize the information in the application's UI components.
+//  YOLOResult and its supporting structs hold the output of a YOLO inference: bounding boxes for detection,
+//  instance and semantic masks for segmentation, top-k probabilities for classification, keypoints for pose, and
+//  oriented bounding boxes for OBB. The shared shape keeps result handling consistent across tasks.
 
 import CoreGraphics
 import Foundation
 import UIKit
 
-/// Represents the complete results from a YOLO model inference, containing task-specific outputs.
+/// The complete output of a single YOLO inference, with optional task-specific fields populated as needed.
 ///
-/// This structure consolidates all outputs from YOLO model inference across different task types.
-/// It can store bounding boxes for object detection, masks for segmentation, probability
-/// distributions for classification, keypoints for pose estimation, and oriented
-/// bounding boxes for rotated object detection. The structure also maintains performance
-/// metrics and visualization data.
+/// Holds bounding boxes, instance and semantic masks, classification probabilities, keypoints, oriented bounding
+/// boxes, an annotated preview image, and timing metrics.
 ///
-/// - Note: Not all fields will be populated for every task type. For example, object detection
-///   models will only populate the `boxes` array, while segmentation models will populate
-///   both `boxes` and `masks`.
-/// - Important: This structure is marked as `@unchecked Sendable` to support concurrent operations.
+/// - Note: Not every field is populated for every task — detection populates `boxes`, segmentation also populates
+///   `masks`, classification populates `probs`, pose populates `keypointsList`, and OBB populates `obb`.
+/// - Important: Marked `@unchecked Sendable` so results can cross actor boundaries; fields are written once during
+///   construction and treated as read-only thereafter.
 public struct YOLOResult: @unchecked Sendable {
   /// The original dimensions of the input image that was processed.
   public let orig_shape: CGSize
@@ -65,13 +59,10 @@ public struct YOLOResult: @unchecked Sendable {
   public static let empty = YOLOResult(orig_shape: .zero, boxes: [], speed: 0, names: [])
 }
 
-/// Represents a single bounding box detection from a YOLO model.
+/// A single bounding-box detection from a YOLO model.
 ///
-/// This structure contains the information for a single detected object,
-/// including its class, confidence score, and location in both normalized
-/// and image coordinates.
-///
-/// - Note: This structure is marked as `@unchecked Sendable` to support concurrent operations.
+/// Holds the class index and label, the confidence score, and the rectangle in both image-space (`xywh`) and
+/// normalized (`xywhn`) coordinates.
 public struct Box: @unchecked Sendable {
   /// The index of the class in the model's class list.
   public let index: Int
@@ -89,12 +80,9 @@ public struct Box: @unchecked Sendable {
   public let xywhn: CGRect
 }
 
-/// Represents segmentation mask data from a YOLO segmentation model.
+/// Instance-segmentation mask data from a YOLO segmentation model.
 ///
-/// This structure contains both the raw per-pixel mask data for each detected object
-/// and an optional pre-rendered combined mask as a CGImage for visualization.
-///
-/// - Note: This structure is marked as `@unchecked Sendable` to support concurrent operations.
+/// Holds raw per-instance probability masks plus an optional pre-rendered composite for display.
 public struct Masks: @unchecked Sendable {
   /// The raw mask data as a 3D array [instance][height][width] with float values.
   public let masks: [[[Float]]]
@@ -103,10 +91,10 @@ public struct Masks: @unchecked Sendable {
   public let combinedMask: CGImage?
 }
 
-/// Represents semantic segmentation mask data from a YOLO semantic model.
+/// Semantic-segmentation mask data from a YOLO semantic model.
 ///
-/// The class map stores one class index per output pixel after model letterbox padding
-/// has been removed. `maskImage` is a pre-rendered color overlay for visualization.
+/// `classMap` holds one class index per output pixel after letterbox padding has been removed. `maskImage` is a
+/// pre-rendered color overlay for display.
 public struct SemanticMask: @unchecked Sendable {
   /// Dense class IDs in row-major order with `width * height` elements.
   public let classMap: [Int]
@@ -121,12 +109,9 @@ public struct SemanticMask: @unchecked Sendable {
   public let maskImage: CGImage?
 }
 
-/// Represents classification probability results from a YOLO classification model.
+/// Classification probability results from a YOLO classification model.
 ///
-/// This structure contains the top predicted classes and their confidence scores,
-/// providing both the single highest confidence prediction and the top 5 predictions.
-///
-/// - Note: This structure is marked as `@unchecked Sendable` to support concurrent operations.
+/// Holds both the single highest-confidence prediction and the top-5 predictions with their scores.
 public struct Probs: @unchecked Sendable {
   /// The class label with the highest confidence score.
   public var top1: String
@@ -141,10 +126,10 @@ public struct Probs: @unchecked Sendable {
   public var top5Confs: [Float]
 }
 
-/// Represents keypoint detection results from a YOLO pose estimation model.
+/// Keypoint detection results from a YOLO pose estimation model.
 ///
-/// This structure contains the detected keypoints (e.g., body joints) for a human figure,
-/// storing both normalized and image-space coordinates along with confidence values.
+/// Holds the detected body joints for a single subject in both normalized (`xyn`) and image-space (`xy`)
+/// coordinates, along with a confidence score per keypoint.
 public struct Keypoints {
   /// The keypoint coordinates in normalized space (0.0 to 1.0).
   public let xyn: [(x: Float, y: Float)]
@@ -156,10 +141,9 @@ public struct Keypoints {
   public let conf: [Float]
 }
 
-/// Represents a single oriented bounding box detection result.
+/// A single oriented bounding-box detection.
 ///
-/// This structure contains the information for a single detected object with an oriented
-/// (rotated) bounding box, including its class, confidence score, and OBB parameters.
+/// Holds the rotated box, its confidence, and the detected class as both an index and a label.
 public struct OBBResult {
   /// The oriented bounding box parameters.
   public var box: OBB
@@ -174,11 +158,9 @@ public struct OBBResult {
   public var index: Int
 }
 
-/// Represents an oriented (rotated) bounding box.
+/// An oriented (rotated) bounding box stored as center, size, and rotation angle.
 ///
-/// This structure defines a bounding box with rotation, storing the center coordinates,
-/// width, height, and rotation angle. OBBs provide better fitting boundaries for objects
-/// that are not aligned with the image axes.
+/// OBBs fit objects that aren't axis-aligned more tightly than a standard `Box`.
 public struct OBB {
   /// The x-coordinate of the center of the box.
   public var cx: Float
@@ -195,14 +177,14 @@ public struct OBB {
   /// The rotation angle of the box in radians.
   public var angle: Float
 
-  /// Creates a new oriented bounding box with the specified parameters.
+  /// Creates an oriented bounding box.
   ///
   /// - Parameters:
-  ///   - cx: The x-coordinate of the center of the box.
-  ///   - cy: The y-coordinate of the center of the box.
-  ///   - w: The width of the box.
-  ///   - h: The height of the box.
-  ///   - angle: The rotation angle of the box in radians.
+  ///   - cx: Center x-coordinate.
+  ///   - cy: Center y-coordinate.
+  ///   - w: Box width.
+  ///   - h: Box height.
+  ///   - angle: Rotation angle in radians.
   public init(cx: Float, cy: Float, w: Float, h: Float, angle: Float) {
     self.cx = cx
     self.cy = cy
@@ -212,21 +194,18 @@ public struct OBB {
   }
 }
 
-/// A polygon represented as an array of points (x, y).
+/// A polygon represented as an array of `CGPoint` corners.
 ///
-/// This type is used to represent the corners of an oriented bounding box
-/// after conversion from the center/width/height/angle representation.
+/// Used to express OBB corners after converting from the center/size/angle form.
 public typealias Polygon = [CGPoint]
 
-/// Extension to provide additional functionality for oriented bounding boxes.
 extension OBB {
-  /// Converts the OBB to an array of 4 corner points (polygon).
+  /// Converts the OBB to its four corner points in normalized space.
   ///
-  /// This method transforms the center, width, height, and angle representation
-  /// of an oriented bounding box into the four corner points of the rectangle.
-  /// The corners are returned in clockwise or counter-clockwise order.
+  /// Use this overload for NMS/IoU work where the result must be scale-invariant. For rendering on a non-square
+  /// image, prefer `toPolygon(imageSize:)` to avoid aspect-ratio distortion.
   ///
-  /// - Returns: An array of four CGPoints representing the corners of the oriented bounding box.
+  /// - Returns: The four corners of the oriented bounding box, in clockwise order.
   public func toPolygon() -> Polygon {
     // Half extents
     let halfW = w / 2
@@ -263,11 +242,11 @@ extension OBB {
 
   /// Converts the OBB to pixel-space corner points.
   ///
-  /// OBB values are normalized to the input image after preprocessing padding has been
-  /// removed, so the stored angle can be applied directly in pixel space.
+  /// OBB values are normalized to the input image after preprocessing padding is removed, so the stored angle can
+  /// be applied directly in pixel space without aspect-ratio correction.
   ///
-  /// - Parameter imageSize: The target image/view size in pixels.
-  /// - Returns: An array of four CGPoints in pixel coordinates.
+  /// - Parameter imageSize: Target image or view size in pixels.
+  /// - Returns: The four corners of the oriented bounding box in pixel coordinates.
   public func toPolygon(imageSize: CGSize) -> Polygon {
     let cosA = CGFloat(cos(Double(angle)))
     let sinA = CGFloat(sin(Double(angle)))
@@ -290,12 +269,7 @@ extension OBB {
     }
   }
 
-  /// Calculates the area of the oriented bounding box.
-  ///
-  /// The area of an oriented bounding box is simply the product of its width and height,
-  /// regardless of the rotation angle.
-  ///
-  /// - Returns: The area of the bounding box in square pixels.
+  /// The area of the oriented bounding box (`w * h`, rotation-independent).
   public var area: CGFloat {
     return CGFloat(w * h)
   }

--- a/Sources/YOLO/YOLOTask.swift
+++ b/Sources/YOLO/YOLOTask.swift
@@ -4,52 +4,30 @@
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 //
-//  The YOLOTask enum defines the different types of computer vision tasks that the YOLO models can perform.
-//  Each task represents a distinct type of machine learning capability, from basic object detection to
-//  more advanced tasks like instance segmentation, pose estimation, oriented bounding box detection,
-//  and image classification. This enum is used throughout the application to configure the model loading
-//  and inference pipeline for the specific task selected by the user.
+//  YOLOTask enumerates the computer-vision tasks YOLO models can perform: object detection, instance segmentation,
+//  semantic segmentation, pose estimation, oriented bounding box detection, and image classification. The task
+//  selects which predictor implementation the SDK instantiates for a given model.
 
-/// Represents the different computer vision tasks supported by YOLO models.
+/// The computer-vision tasks supported by YOLO models.
 ///
-/// This enumeration defines the various computer vision tasks that can be performed
-/// by YOLO models, each requiring different model architectures and processing pipelines.
-/// The task type determines how the model processes input images and what kind of
-/// results it produces.
+/// Each case maps to a different predictor implementation and output shape. Pick the case that matches the model
+/// you are loading.
 public enum YOLOTask {
-  /// Standard object detection task that identifies and localizes objects with bounding boxes.
-  ///
-  /// Detection models produce rectangular bounding boxes around detected objects
-  /// along with class labels and confidence scores.
+  /// Object detection: rectangular bounding boxes with class labels and confidence scores.
   case detect
 
-  /// Instance segmentation task that creates pixel-level masks for detected objects.
-  ///
-  /// Segmentation models produce precise object outlines (masks) for each detected object,
-  /// providing more detailed boundaries than rectangular bounding boxes.
+  /// Instance segmentation: per-object pixel masks alongside bounding boxes.
   case segment
 
-  /// Semantic segmentation task that assigns a class label to each image pixel.
-  ///
-  /// Semantic segmentation models produce one dense class map for the full scene without
-  /// separating individual object instances.
+  /// Semantic segmentation: one dense class index per pixel, without separating object instances.
   case semantic
 
-  /// Human pose estimation task that identifies key points of human figures.
-  ///
-  /// Pose estimation models detect human figures and identify the positions of key body
-  /// joints and points, useful for tracking human movements and poses.
+  /// Pose estimation: per-person body keypoints (joints) with confidence scores.
   case pose
 
-  /// Oriented bounding box detection for objects at various angles.
-  ///
-  /// OBB models detect objects with rotated bounding boxes, providing better fitting
-  /// boundaries for objects that are not aligned with the image axes.
+  /// Oriented bounding box detection: rotated boxes that fit non-axis-aligned objects more tightly than `detect`.
   case obb
 
-  /// Image classification task that identifies the primary subject of an image.
-  ///
-  /// Classification models predict what an image contains without localizing objects,
-  /// returning class labels and confidence scores for the entire image.
+  /// Image classification: top-k class predictions for the full image, with no localization.
   case classify
 }

--- a/Sources/YOLO/YOLOView.swift
+++ b/Sources/YOLO/YOLOView.swift
@@ -4,12 +4,10 @@
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 //
-//  The YOLOView class is the primary UI component for displaying real-time YOLO model results.
-//  It handles camera setup, model loading, video frame processing, rendering of detection results,
-//  and user interactions such as pinch-to-zoom. The view can display bounding boxes, masks for segmentation,
-//  pose estimation keypoints, and oriented bounding boxes depending on the active task. It includes
-//  UI elements for controlling inference settings such as confidence threshold and IoU threshold,
-//  and provides functionality for capturing photos with detection results overlaid.
+//  YOLOView is the primary UIView for real-time YOLO inference. It owns the camera session, loads the model, runs
+//  the video frame pipeline, and renders detection overlays — bounding boxes, segmentation masks, pose skeletons,
+//  or oriented boxes depending on the active task. It also exposes UI controls for confidence/IoU/max-detections
+//  and supports pinch-to-zoom and photo capture with overlays burned in.
 
 import AVFoundation
 import UIKit
@@ -35,23 +33,22 @@ func aspectFillDisplayRect(for normalizedRect: CGRect, imageSize: CGSize, viewSi
   )
 }
 
-/// YOLOView Delegate Protocol - Provides performance metrics and YOLO results for each frame
+/// Delegate that receives per-frame performance metrics and YOLO inference results from a `YOLOView`.
 public protocol YOLOViewDelegate: AnyObject {
-  /// Called when performance metrics (FPS and inference time) are updated
+  /// Called when performance metrics (FPS and inference time) are updated.
   func yoloView(_: YOLOView, didUpdatePerformance fps: Double, inferenceTime: Double)
 
-  /// Called when detection results are available
+  /// Called when a new inference result is available.
   func yoloView(_: YOLOView, didReceiveResult result: YOLOResult)
-
 }
 
 private let defaultMaxDetectionItems = 100
 
-/// A UIView component that provides real-time object detection, segmentation, and pose estimation capabilities.
+/// A UIView that runs real-time YOLO inference and renders detection, segmentation, pose, or OBB overlays.
 @MainActor
 public final class YOLOView: UIView, VideoCaptureDelegate {
 
-  /// Delegate object - Receives performance metrics and YOLO detection results
+  /// Delegate receiving performance metrics and YOLO inference results for each frame.
   public weak var delegate: YOLOViewDelegate?
 
   public func onInferenceTime(speed: Double, fps: Double) {
@@ -162,7 +159,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     overlayLayer.frame = bounds
   }
 
-  /// Initialize YOLOView without a model (camera only)
+  /// Creates a YOLOView with no model attached; starts the camera preview only.
   public override init(frame: CGRect) {
     self.videoCapture = VideoCapture()
     self.task = .detect  // Default task
@@ -625,7 +622,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     self.addGestureRecognizer(UIPinchGestureRecognizer(target: self, action: #selector(pinch)))
   }
 
-  /// Configure a slider with common settings
+  /// Applies the shared slider styling and wires up `sliderChanged` as the value-changed handler.
   private func configureSlider(_ slider: UISlider, min: Float, max: Float, value: Float) {
     slider.minimumValue = min
     slider.maximumValue = max
@@ -635,7 +632,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     slider.addTarget(self, action: #selector(sliderChanged), for: .valueChanged)
   }
 
-  /// Setup toolbar with consistent styling
+  /// Configures the toolbar background and adds the play/pause/camera/share/info buttons as subviews.
   private func setupToolbar() {
     toolbar.backgroundColor = .black.withAlphaComponent(0.7)
     [playButton, pauseButton, switchCameraButton, shareButton, infoButton].forEach { button in
@@ -694,7 +691,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     videoCapture.frameSizeCaptured = false
   }
 
-  /// Layout views for landscape orientation
+  /// Lays out the controls and overlays for landscape orientation.
   private func layoutLandscape() {
     let width = bounds.width
     let height = bounds.height
@@ -748,7 +745,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     layoutLensControl(width: width, height: height)
   }
 
-  /// Layout views for portrait orientation
+  /// Lays out the controls and overlays for portrait orientation.
   private func layoutPortrait() {
     let width = bounds.width
     let height = bounds.height
@@ -801,7 +798,7 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     layoutLensControl(width: width, height: height)
   }
 
-  /// Layout toolbar buttons (shared between orientations)
+  /// Lays out toolbar buttons; shared between portrait and landscape layouts.
   private func layoutToolbarButtons(width: CGFloat, height: CGFloat) {
     let toolBarHeight: CGFloat = 66
     let buttonHeight: CGFloat = toolBarHeight * 0.75

--- a/Tests/YOLOTests/PlotTests.swift
+++ b/Tests/YOLOTests/PlotTests.swift
@@ -48,7 +48,7 @@ class PlotTests: XCTestCase {
 
     let clearColor = UIColor.clear
     let clearComponents = clearColor.toRGBComponents()
-    XCTAssertNotNil(clearComponents)  // Should still work
+    XCTAssertNotNil(clearComponents)  // Clear color still resolves to RGB components
   }
 
   func testDrawYOLODetections() {
@@ -137,7 +137,7 @@ class PlotTests: XCTestCase {
     let outputImage = drawYOLOClassifications(on: inputImage, result: result)
 
     XCTAssertNotNil(outputImage)
-    // Should return an image based on the original
+    // Falls back to the original image when probs are absent
     XCTAssertGreaterThan(outputImage.size.width, 0)
   }
 

--- a/Tests/YOLOTests/YOLOIntegrationTests.swift
+++ b/Tests/YOLOTests/YOLOIntegrationTests.swift
@@ -162,7 +162,7 @@ class YOLOIntegrationTests: XCTestCase {
     }
 
     XCTAssertGreaterThan(smoothedSpeed, 0)
-    XCTAssertLessThan(smoothedSpeed, 1.0)  // Should be reasonable inference time
+    XCTAssertLessThan(smoothedSpeed, 1.0)  // Smoothed inference time stays below 1s
   }
 
   func testCoordinateTransformations() {

--- a/Tests/YOLOTests/YOLOMainTests.swift
+++ b/Tests/YOLOTests/YOLOMainTests.swift
@@ -89,8 +89,6 @@ class YOLOMainTests: XCTestCase {
     XCTAssertTrue(true, "YOLO call interface test skipped - requires model loading")
   }
 
-  // MARK: - Helper Methods
-  // (removed createMockYOLO - not needed for simplified tests)
 }
 
 // MARK: - Mock Classes for Testing

--- a/YOLOiOSApp/YOLOiOSApp/ExternalDisplay/ExternalDisplayManager.swift
+++ b/YOLOiOSApp/YOLOiOSApp/ExternalDisplay/ExternalDisplayManager.swift
@@ -4,7 +4,7 @@ import CoreMedia
 import UIKit
 import YOLO
 
-/// Manager for external display communication
+/// Coordinates the optional external display: scene activation, mode preference, and pub/sub of updates.
 class ExternalDisplayManager {
   static let shared = ExternalDisplayManager()
   private static let dedicatedModeKey = "dedicated_external_display"
@@ -50,7 +50,7 @@ class ExternalDisplayManager {
     }
   }
 
-  /// Posts YOLO results for external display
+  /// Broadcasts a YOLO inference result so the external display can render it.
   func shareResults(_ results: YOLOResult) {
     NotificationCenter.default.post(
       name: .yoloResultsAvailable,
@@ -59,7 +59,7 @@ class ExternalDisplayManager {
     )
   }
 
-  /// Posts model change notification with task type and model name
+  /// Notifies the external display that the selected task or model has changed.
   func notifyModelChange(task: YOLOTask, modelName: String) {
     let taskString = String(describing: task).lowercased()
 

--- a/YOLOiOSApp/YOLOiOSApp/ExternalDisplay/ExternalSceneDelegate.swift
+++ b/YOLOiOSApp/YOLOiOSApp/ExternalDisplay/ExternalSceneDelegate.swift
@@ -21,7 +21,7 @@ class ExternalSceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     let externalScreen = windowScene.screen
 
-    // Select highest resolution
+    // Pick the highest-resolution mode the external display supports.
     if let bestMode = externalScreen.availableModes.max(by: {
       $0.size.width * $0.size.height < $1.size.width * $1.size.height
     }) {
@@ -30,7 +30,7 @@ class ExternalSceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     externalScreen.overscanCompensation = .scale
 
-    // Setup window and controller
+    // Create the window and root view controller for the external scene.
     window = UIWindow(windowScene: windowScene)
     window?.frame = externalScreen.bounds
 
@@ -42,7 +42,7 @@ class ExternalSceneDelegate: UIResponder, UIWindowSceneDelegate {
     window?.insetsLayoutMarginsFromSafeArea = false
     window?.makeKeyAndVisible()
 
-    // Notify connection
+    // Notify the main app that the external display is up.
     NotificationCenter.default.post(
       name: .externalDisplayConnected,
       object: nil,
@@ -51,7 +51,7 @@ class ExternalSceneDelegate: UIResponder, UIWindowSceneDelegate {
   }
 
   func sceneDidDisconnect(_ scene: UIScene) {
-    // Notify main app that external display is disconnected
+    // Notify the main app that the external display has gone away.
     NotificationCenter.default.post(name: .externalDisplayDisconnected, object: nil)
     window = nil
   }

--- a/YOLOiOSApp/YOLOiOSApp/ExternalDisplay/ExternalViewController.swift
+++ b/YOLOiOSApp/YOLOiOSApp/ExternalDisplay/ExternalViewController.swift
@@ -12,13 +12,13 @@ class ExternalViewController: UIViewController, YOLOViewDelegate {
   private var currentTask: YOLOTask = .detect
   private var currentModelName: String = "yolo26n"
 
-  // UI Elements with proper scaling
+  // Scaled UI overlays drawn on top of the YOLOView.
   private var labelName: UILabel!
   private var labelFPS: UILabel!
   private var segmentedControl: UISegmentedControl!
   private var logoImageView: UIImageView!
 
-  // Task info
+  // Task list shared with the iPhone controller for index lookup on task-change notifications.
   private let tasks: [(name: String, value: YOLOTask)] = [
     ("Detect", .detect),
     ("Segment", .segment),
@@ -43,11 +43,10 @@ class ExternalViewController: UIViewController, YOLOViewDelegate {
     let screenSize = view.bounds.size
     let scaleFactor = calculateScaleFactor(for: screenSize)
 
-    // Proportional font sizes
+    // Font sizes scale with display height.
     let baseFontSizeModelName = screenSize.height * 0.1
     let baseFontSizeFPS = screenSize.height * 0.04
 
-    // Model name label
     labelName = createLabel(
       text: currentModelName,
       fontSize: baseFontSizeModelName,
@@ -55,7 +54,6 @@ class ExternalViewController: UIViewController, YOLOViewDelegate {
     )
     view.addSubview(labelName)
 
-    // FPS label
     labelFPS = createLabel(
       text: "0.0 FPS - 0.0 ms",
       fontSize: baseFontSizeFPS,
@@ -63,11 +61,9 @@ class ExternalViewController: UIViewController, YOLOViewDelegate {
     )
     view.addSubview(labelFPS)
 
-    // Task segmented control
     segmentedControl = createSegmentedControl()
     view.addSubview(segmentedControl)
 
-    // Logo ImageView
     logoImageView = UIImageView(image: UIImage(named: "ultralytics_yolo_logotype"))
     logoImageView.contentMode = .scaleAspectFit
     logoImageView.alpha = 1.0
@@ -97,9 +93,8 @@ class ExternalViewController: UIViewController, YOLOViewDelegate {
     for (index, taskInfo) in tasks.enumerated() {
       control.insertSegment(withTitle: taskInfo.name, at: index, animated: false)
     }
-    control.selectedSegmentIndex = 0  // Default to Detect
+    control.selectedSegmentIndex = 0  // default to Detect
 
-    // Styling
     control.backgroundColor = UIColor(white: 0.2, alpha: 0.3)
     control.selectedSegmentTintColor = UIColor(white: 0.4, alpha: 0.8)
     control.layer.cornerRadius = 12
@@ -192,7 +187,7 @@ class ExternalViewController: UIViewController, YOLOViewDelegate {
   }
 
   private func setupYOLOView() {
-    // Create YOLOView without model initially - will be set when main app notifies
+    // Create the YOLOView without a model; the main app will supply one via .modelDidChange.
     yoloView = YOLOView(frame: view.bounds)
     yoloView?.delegate = self
     yoloView?.backgroundColor = .clear
@@ -209,7 +204,7 @@ class ExternalViewController: UIViewController, YOLOViewDelegate {
       yoloView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
     ])
 
-    // Re-add UI elements on top
+    // Re-add overlays so they sit above the YOLOView.
     [logoImageView, labelName, labelFPS].forEach {
       $0?.removeFromSuperview()
       if let view = $0 { self.view.addSubview(view) }
@@ -225,23 +220,19 @@ class ExternalViewController: UIViewController, YOLOViewDelegate {
   }
 
   private func setupNotifications() {
-    // Listen for model changes
+    // Mirror model, threshold, and task changes from the iPhone-side ViewController.
     NotificationCenter.default.addObserver(
       self,
       selector: #selector(handleModelChange(_:)),
       name: .modelDidChange,
       object: nil
     )
-
-    // Listen for threshold changes from iPhone
     NotificationCenter.default.addObserver(
       self,
       selector: #selector(handleThresholdChange(_:)),
       name: .thresholdDidChange,
       object: nil
     )
-
-    // Listen for task changes from iPhone
     NotificationCenter.default.addObserver(
       self,
       selector: #selector(handleTaskChange(_:)),
@@ -301,7 +292,7 @@ class ExternalViewController: UIViewController, YOLOViewDelegate {
       nameWithoutExtension = (nameWithoutExtension as NSString).deletingPathExtension
     }
 
-    // Use processString to properly format the model name (handles YOLO11n-seg -> YOLO11n Seg, etc.)
+    // Format for display (e.g. "yolo26n-seg" -> "YOLO26n Seg").
     labelName.text = processString(nameWithoutExtension)
   }
 
@@ -315,7 +306,7 @@ class ExternalViewController: UIViewController, YOLOViewDelegate {
       return
     }
 
-    // Use the new updateThresholds method to properly sync all threshold values
+    // Sync confidence, IoU, and max-items thresholds in a single call.
     yoloView.updateThresholds(conf: conf, iou: iou, numItems: maxItems)
   }
 
@@ -341,7 +332,7 @@ class ExternalViewController: UIViewController, YOLOViewDelegate {
     return true
   }
 
-  // Support all orientations for external display
+  // External displays can be rotated; allow all orientations.
   override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
     return .all
   }

--- a/YOLOiOSApp/YOLOiOSApp/ExternalDisplay/NotificationExtensions.swift
+++ b/YOLOiOSApp/YOLOiOSApp/ExternalDisplay/NotificationExtensions.swift
@@ -2,13 +2,12 @@
 
 import Foundation
 
-// Notification names for external display events
+// Notification names used to coordinate the iPhone and external-display scenes.
 extension Notification.Name {
   static let externalDisplayConnected = Notification.Name("ExternalDisplayConnected")
   static let externalDisplayDisconnected = Notification.Name("ExternalDisplayDisconnected")
   static let externalDisplayReady = Notification.Name("ExternalDisplayReady")
   static let modelDidChange = Notification.Name("ModelDidChange")
-  static let shareCameraSession = Notification.Name("ShareCameraSession")
   static let yoloResultsAvailable = Notification.Name("YOLOResultsAvailable")
   static let thresholdDidChange = Notification.Name("ThresholdDidChange")
   static let taskDidChange = Notification.Name("TaskDidChange")

--- a/YOLOiOSApp/YOLOiOSApp/ExternalDisplay/ViewController+ExternalDisplay.swift
+++ b/YOLOiOSApp/YOLOiOSApp/ExternalDisplay/ViewController+ExternalDisplay.swift
@@ -1,18 +1,14 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 // MARK: - OPTIONAL External Display Support
-// This extension provides optional external display functionality for the YOLO iOS app.
-// It enhances the user experience when connected to an external monitor or TV but is
-// NOT required for the core app functionality. The features remain dormant until
-// an external display is connected.
+// Optional extension that adds external monitor/TV support to the main ViewController. Dormant unless a display is
+// connected and dedicated mode is enabled in ExternalDisplayManager.
 //
-// Features handled in this extension:
-// - External display connection/disconnection detection
-// - UI adjustments for external display mode:
-//   * Hide switch camera and share buttons (not supported in external display mode)
-//   * Adjust model dropdown positioning to prevent overlap
-// - Model and threshold synchronization with external display
-// - Camera session management (stop iPhone camera when external display is active)
+// Responsibilities:
+// - Detect external display connection/disconnection
+// - Hide controls that don't apply in external-display mode (switch camera, share)
+// - Mirror model and threshold changes to the external scene
+// - Stop the iPhone camera while the external display is active
 
 import UIKit
 import YOLO

--- a/YOLOiOSApp/YOLOiOSApp/ModelDownloadManager.swift
+++ b/YOLOiOSApp/YOLOiOSApp/ModelDownloadManager.swift
@@ -1,26 +1,23 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-//  This file is part of the Ultralytics YOLO app, handling machine learning model management.
+//  This file is part of the Ultralytics YOLO app and manages the machine learning model lifecycle.
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 //
-//  The ModelDownloadManager and related classes provide a complete system for managing YOLO models.
-//  This includes downloading models from remote URLs, caching loaded models in memory, handling model
-//  extraction from ZIP archives, and managing the lifecycle of models on the device. The implementation
-//  includes progress tracking for downloads, prioritization of download tasks, and memory management
-//  for loaded models to ensure optimal performance on resource-constrained devices. These utilities
-//  allow the application to dynamically load models based on user selection while maintaining a responsive
-//  user experience.
+//  ModelCacheManager and ModelDownloadManager together handle the YOLO model lifecycle: downloading from remote URLs,
+//  extracting ZIP archives, compiling MLModels, caching loaded models in memory, and tracking what is on disk. The
+//  in-memory cache is bounded to keep memory in check on resource-constrained devices, while progress callbacks keep
+//  the UI responsive during downloads.
 
 import CoreML
 import Foundation
 import ZIPFoundation
 
-/// Shared documents directory accessor.
+/// URL of the app's Documents directory; used for storing compiled models and download archives.
 private let documentsDirectory = FileManager.default.urls(
   for: .documentDirectory, in: .userDomainMask)[0]
 
-/// A structure representing a YOLO model with metadata for display and loading.
+/// Metadata describing a selectable YOLO model entry (local bundle or downloadable remote).
 struct ModelEntry {
   let displayName: String
   let identifier: String
@@ -139,7 +136,7 @@ extension ModelDownloadManager: URLSessionDownloadDelegate {
       try FileManager.default.moveItem(at: location, to: zipURL)
       downloadTasks.removeValue(forKey: downloadTask)
 
-      // Extract to model-specific temporary directory to avoid conflicts
+      // Extract to a per-key temp directory to avoid collisions between concurrent downloads.
       let tempExtractionURL = documentsDirectory.appendingPathComponent("temp_\(key)")
       if FileManager.default.fileExists(atPath: tempExtractionURL.path) {
         try FileManager.default.removeItem(at: tempExtractionURL)
@@ -147,19 +144,19 @@ extension ModelDownloadManager: URLSessionDownloadDelegate {
 
       try unzipSkippingMacOSX(at: zipURL, to: tempExtractionURL)
 
-      // Find the model file in the extracted contents (search recursively)
+      // Recursively locate the model file inside the extracted contents.
       func findModelFile(in directory: URL) throws -> URL? {
         let contents = try FileManager.default.contentsOfDirectory(
           at: directory, includingPropertiesForKeys: [.isDirectoryKey])
 
-        // First, look for model files in current directory
+        // Prefer model files in the current directory before descending.
         for url in contents {
           if ["mlmodel", "mlpackage"].contains(url.pathExtension) {
             return url
           }
         }
 
-        // Then search subdirectories
+        // Otherwise search subdirectories.
         for url in contents {
           let resourceValues = try url.resourceValues(forKeys: [.isDirectoryKey])
           if resourceValues.isDirectory == true {
@@ -179,7 +176,7 @@ extension ModelDownloadManager: URLSessionDownloadDelegate {
       }
 
       loadModel(from: foundModelURL, key: key) { model in
-        // Clean up temp directory and zip file
+        // Clean up temp extraction directory and downloaded zip.
         try? FileManager.default.removeItem(at: tempExtractionURL)
         try? FileManager.default.removeItem(at: zipURL)
         self.completeTask(downloadTask, model: model, key: key)

--- a/YOLOiOSApp/YOLOiOSApp/ModelSelectionManager.swift
+++ b/YOLOiOSApp/YOLOiOSApp/ModelSelectionManager.swift
@@ -115,8 +115,7 @@ struct ModelSelectionManager {
         let fullName = (model.name as NSString).deletingPathExtension
         let displayTitle = removeTaskSuffix(from: fullName)
 
-        // Check if model is downloaded using ModelCacheManager for remote models
-        // Use the model name without extension as the key (e.g., "yolo26n", "yolo26m-seg")
+        // For remote models, check the on-disk cache. The key is the model name without extension (e.g. "yolo26n").
         let modelKey = (model.name as NSString).deletingPathExtension
         let isDownloaded =
           model.isLocal
@@ -159,8 +158,7 @@ struct ModelSelectionManager {
       guard index < control.numberOfSegments else { break }
 
       if let model = standardModels[size] {
-        // Check if model is downloaded using ModelCacheManager for remote models
-        // Use the model name without extension as the key (e.g., "yolo26n", "yolo26m-seg")
+        // For remote models, check the on-disk cache. The key is the model name without extension (e.g. "yolo26n").
         let modelKey = (model.name as NSString).deletingPathExtension
         let isDownloaded =
           model.isLocal

--- a/YOLOiOSApp/YOLOiOSApp/RemoteModels.swift
+++ b/YOLOiOSApp/YOLOiOSApp/RemoteModels.swift
@@ -1,19 +1,16 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-//  This file is part of the Ultralytics YOLO app, defining remotely available YOLO models.
+//  This file is part of the Ultralytics YOLO app and defines the registry of downloadable YOLO models.
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 //
-//  The RemoteModels file defines a registry of downloadable YOLO models available for each task type.
-//  It provides a structured mapping between task categories (detection, segmentation, semantic segmentation, classification, etc.)
-//  and the available models with their remote download URLs. These models are presented to users in the
-//  application interface, allowing them to download and use additional models beyond those bundled with
-//  the application. The dictionary structure enables easy filtering of models by task type and provides
-//  all necessary information for the ModelDownloadManager to retrieve and install the models.
+//  remoteModelsInfo maps task names (detection, segmentation, semantic segmentation, classification, pose, OBB) to the
+//  YOLO models available for download from the GitHub release. Entries listed here that are not already bundled locally
+//  appear as downloadable options in the UI; ModelDownloadManager fetches and installs them on demand.
 
 import Foundation
 
-/// A dictionary mapping task names to available remote models with their download URLs.
+/// Maps task names to the YOLO models available for download, with their archive URLs.
 public let remoteModelsInfo: [String: [(modelName: String, downloadURL: URL)]] = {
   let base = "https://github.com/ultralytics/yolo-ios-app/releases/download/v8.3.0"
   let sizes = ["n", "s", "m", "l", "x"]

--- a/YOLOiOSApp/YOLOiOSApp/ViewController.swift
+++ b/YOLOiOSApp/YOLOiOSApp/ViewController.swift
@@ -1,15 +1,15 @@
 // Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-//  This file is part of the Ultralytics YOLO app, providing the main user interface for model selection and visualization.
+//  This file is part of the Ultralytics YOLO app and provides the main user interface for model selection and
+//  visualization.
 //  Licensed under AGPL-3.0. For commercial use, refer to Ultralytics licensing: https://ultralytics.com/license
 //  Access the source code: https://github.com/ultralytics/yolo-ios-app
 //
-//  The ViewController serves as the primary interface for users to interact with YOLO models.
-//  It provides the ability to select different models, tasks (detection, segmentation, semantic segmentation, classification, etc.),
-//  and visualize results in real-time. The controller manages the loading of local and remote models,
-//  handles UI updates during model loading and inference, and provides functionality for capturing
-//  and sharing detection results. Advanced features include model download progress
-//  tracking, and adaptive UI layout for different device orientations.
+//  The ViewController is the primary interface for users to interact with YOLO models. Users can select different
+//  models and tasks (detection, segmentation, semantic segmentation, classification, pose, OBB) and visualize results
+//  in real-time. The controller manages loading of local and remote models, updates UI state during loading and
+//  inference, and handles capturing and sharing detection results. It also tracks model download progress and adapts
+//  the layout to different device orientations.
 
 import AVFoundation
 import AudioToolbox
@@ -22,8 +22,7 @@ import YOLO
 class ViewController: UIViewController, YOLOViewDelegate {
 
   // MARK: - External Display Support (Optional)
-  // NOTE: The following external display features remain dormant until connected.
-  // See ExternalDisplay/ directory for implementation details.
+  // External display features remain dormant until a display is connected. See ExternalDisplay/ for details.
 
   @IBOutlet weak var yoloView: YOLOView!
   @IBOutlet weak var View0: UIView!
@@ -37,7 +36,7 @@ class ViewController: UIViewController, YOLOViewDelegate {
 
   let selection = UISelectionFeedbackGenerator()
 
-  // Store current loading entry for external display notification (Optional feature)
+  // Tracks the currently loading model for external display notification.
   var currentLoadingEntry: ModelEntry?
 
   private let downloadProgressView = UIProgressView(progressViewStyle: .default)
@@ -97,20 +96,13 @@ class ViewController: UIViewController, YOLOViewDelegate {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    // MARK: External Display Setup (Optional)
-    // NOTE: The following external display setup is OPTIONAL and not required for core app functionality.
-    // This code enhances the app for external monitor/TV connections and remains dormant when not in use.
-    // See ExternalDisplay/ directory and README for more information.
-
-    // Setup external display notifications
+    // Optional external display setup — dormant unless a monitor/TV is connected. See ExternalDisplay/ for details.
     setupExternalDisplayNotifications()
-
-    // If external display is already connected, ensure YOLOView doesn't interfere
     if hasExternalScreen() {
       yoloView.isHidden = true
     }
 
-    // Setup segmented control and load models
+    // Populate the task segmented control and discover bundled models per task.
     segmentedControl.removeAllSegments()
     tasks.enumerated().forEach { index, task in
       segmentedControl.insertSegment(withTitle: task.shortName, at: index, animated: false)
@@ -124,10 +116,10 @@ class ViewController: UIViewController, YOLOViewDelegate {
     segmentedControl.selectedSegmentIndex = defaultTaskIndex
     currentTask = tasks[defaultTaskIndex].name
 
-    // Always load models initially - external display handling will stop camera if needed
+    // Always load models initially; external display handling will stop the camera if needed.
     reloadModelEntriesAndLoadFirst(for: currentTask)
 
-    // Setup gestures and delegates
+    // Wire up gestures and delegates.
     logoImage.isUserInteractionEnabled = true
     logoImage.addGestureRecognizer(
       UITapGestureRecognizer(target: self, action: #selector(logoButton)))
@@ -135,11 +127,11 @@ class ViewController: UIViewController, YOLOViewDelegate {
     yoloView.delegate = self
     [yoloView.labelName, yoloView.labelFPS].forEach { $0?.isHidden = true }
 
-    // Add target to sliders to monitor changes
+    // Observe slider changes to forward thresholds to an external display.
     yoloView.sliderConf.addTarget(self, action: #selector(sliderValueChanged), for: .valueChanged)
     yoloView.sliderIoU.addTarget(self, action: #selector(sliderValueChanged), for: .valueChanged)
 
-    // Setup labels and version
+    // Style labels and stamp the app version.
     [labelName, labelFPS, labelVersion].forEach {
       $0?.textColor = .white
       $0?.overrideUserInterfaceStyle = .dark
@@ -150,7 +142,7 @@ class ViewController: UIViewController, YOLOViewDelegate {
       labelVersion.text = "v\(version) (\(build))"
     }
 
-    // Setup progress views
+    // Install the download progress views.
     [downloadProgressView, downloadProgressLabel].forEach {
       $0.isHidden = true
       $0.translatesAutoresizingMaskIntoConstraints = false
@@ -272,10 +264,8 @@ class ViewController: UIViewController, YOLOViewDelegate {
     }
     isLoadingModel = true
 
-    // Check if external display is connected
+    // Skip the local YOLOView reset when an external display owns the camera.
     let hasExternalDisplay = hasExternalScreen()
-
-    // Only reset YOLOView if no external display is connected
     if !hasExternalDisplay {
       yoloView.resetLayers()
       yoloView.setInferenceFlag(ok: false)
@@ -283,8 +273,6 @@ class ViewController: UIViewController, YOLOViewDelegate {
 
     setLoadingState(true, showOverlay: true)
     resetDownloadProgress()
-
-    // Store current entry for external display notification
     currentLoadingEntry = entry
 
     let yoloTask = tasks.first(where: { $0.name == task })?.yoloTask ?? .detect
@@ -308,10 +296,8 @@ class ViewController: UIViewController, YOLOViewDelegate {
           self.downloadProgressLabel.isHidden = false
           self.downloadProgressLabel.text = "Loading \(entry.displayName)"
 
-          // Check if external display is connected
-          let hasExternalDisplay = self.hasExternalScreen()
-
-          if hasExternalDisplay {
+          // External display path: notify it instead of loading into the local YOLOView.
+          if self.hasExternalScreen() {
             self.finishLoadingModel(success: true, modelName: entry.displayName)
           } else {
             self.yoloView.setModel(modelPathOrName: modelURL.path, task: yoloTask) {
@@ -330,7 +316,7 @@ class ViewController: UIViewController, YOLOViewDelegate {
         }
       }
     } else {
-      let key = entry.identifier  // "yolov8n", "yolov8m-seg", etc.
+      let key = entry.identifier  // e.g. "yolo26n", "yolo26m-seg"
 
       if ModelCacheManager.shared.isModelDownloaded(key: key) {
         loadCachedModelAndSetToYOLOView(
@@ -345,10 +331,10 @@ class ViewController: UIViewController, YOLOViewDelegate {
         self.downloadProgressView.isHidden = false
         self.downloadProgressLabel.isHidden = false
 
-        // Set initial downloading message with proper model name
+        // Show the initial download message with a properly formatted model name.
         self.downloadProgressLabel.text = "Downloading \(processString(entry.displayName))"
 
-        let localZipFileName = remoteURL.lastPathComponent  // ex. "yolov8n.mlpackage.zip"
+        let localZipFileName = remoteURL.lastPathComponent  // e.g. "yolo26n.mlpackage.zip"
 
         ModelCacheManager.shared.loadModel(
           from: localZipFileName,
@@ -381,10 +367,8 @@ class ViewController: UIViewController, YOLOViewDelegate {
       self.downloadProgressLabel.isHidden = false
       self.downloadProgressLabel.text = "Loading \(displayName)"
 
-      // Check if external display is connected
-      let hasExternalDisplay = self.hasExternalScreen()
-
-      if hasExternalDisplay {
+      // External display path: notify it instead of loading into the local YOLOView.
+      if self.hasExternalScreen() {
         self.finishLoadingModel(success: true, modelName: displayName)
       } else {
         self.yoloView.setModel(modelPathOrName: localModelURL.path, task: yoloTask) {
@@ -464,7 +448,7 @@ class ViewController: UIViewController, YOLOViewDelegate {
         }
       }
 
-      // Only set inference flag on YOLOView if no external display
+      // Only toggle the local YOLOView inference flag when no external display is active.
       if !hasExternalDisplay {
         self.yoloView.setInferenceFlag(ok: success)
       }
@@ -496,7 +480,7 @@ class ViewController: UIViewController, YOLOViewDelegate {
 
     currentTask = newTask
 
-    // Notify external display of task change immediately (Optional external display feature)
+    // Notify the external display (if any) of the task change before reloading models.
     NotificationCenter.default.post(
       name: .taskDidChange,
       object: nil,
@@ -586,7 +570,7 @@ class ViewController: UIViewController, YOLOViewDelegate {
   }
 
   @objc func sliderValueChanged(_ sender: UISlider) {
-    // Send threshold values to external display (Optional external display feature)
+    // Forward threshold values to the external display (no-op if none is connected).
     let conf = Double(round(100 * yoloView.sliderConf.value)) / 100
     let iou = Double(round(100 * yoloView.sliderIoU.value)) / 100
     let maxItems = Int(yoloView.sliderNumItems.value)


### PR DESCRIPTION
## Summary

- Reflow all `//` and `///` comments across the SDK, host app, examples, and tests to ≤120-char width — joining too-narrow paragraphs and breaking over-length lines.
- Copy edit pass: tighten file headers and method docs, drop marketing prose ("leverages", "facilitates", "designed to"), and retarget `Sources/YOLO/` headers from "the YOLO app" to "the YOLO SDK".
- Fix several doc/code mismatches found during the pass:
  - `NonMaxSuppression.swift` header claimed "intersection over minimum area" → standard IoU.
  - `Segmenter.parseSegmentationRequest` tuple doc said `(pred, masks, detectedObjects)` → actual return is `(masks, detectedObjects)`.
  - `YOLOModelCache.swift` docs said "documents directory" → actually `Library/Caches/YOLOModels/`.
  - ExampleApps `ViewController`s: multiple inline comments said "segmentation model" while the code is `task: .detect`.
  - `YOLOSingleImageUIKitUITests.swift`: removed stale camera/photo permissions claim (single-image app has no camera).
- Small code cleanups:
  - Drop unused `Notification.Name.shareCameraSession` (declared, never observed/posted).
  - Inline single-use `hasExternalDisplay` locals.
  - Replace stale `yolov8` example strings with `yolo26` in ViewControllers.
  - Add missing file header to `SemanticSegmenter.swift` for consistency.

**53 files changed · +455 / −630** (net 175 fewer lines)

## Follow-ups flagged but not fixed (separate PRs)

- `Logger.swift`: `YOLOLog.info` defined but never called — dead API.
- `BasePredictor.swift`: `t1` timing includes catch-handler time on failure paths.
- `ObjectDetector.swift`: `predictOnImage` uses `Date()` for `elapsed` while the realtime path uses `CACurrentMediaTime()` — inconsistent units fed into `YOLOResult.speed`.
- `YOLO.swift` vs `YOLOView.swift`: default max detections inconsistent (30 vs 100).
- `YOLOMainTests.swift`: 7 `XCTAssertTrue(true, "...skipped")` placeholder tests — dead coverage; could use bundled `Resources/yolo26n.mlpackage`.
- `ExternalViewController.swift`: `segmentedControl` permanently `isHidden = true` yet code still updates its `selectedSegmentIndex`. Vestigial.
- `ModelCacheManager.addModelToCache` doesn't update `accessOrder` for cache hits → LRU drifts (header copy now says "bounded", not strict LRU).
- Hard-coded `asyncAfter(0.3/0.5/1.5s)` sleeps in external-display setup are timing-fragile.
- ZIPFoundation pinned at `0.9.20` (Apr 2024).

## Test plan

- [ ] CI: Swift build + tests pass on iOS simulator (xcodebuild matrix in `ci.yml`)
- [ ] Spot-check rendered docs for `Sources/YOLO/YOLO.swift`, `YOLOView.swift`, `YOLOResult.swift` in Xcode quick-help
- [ ] Visually verify YOLOiOSApp still launches and shows detections (no executable behavior should have changed beyond the listed cleanups)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🧹 This PR is primarily a documentation and code-comment cleanup across the iOS app and SDK, with clearer examples, updated task descriptions, and more consistent messaging around YOLO26-based defaults.

### 📊 Key Changes
- ✍️ Rewrote and shortened comments/docstrings across the repo to make the codebase easier to understand and maintain.
- 🎯 Updated example app descriptions in both SwiftUI and UIKit to reflect that the sample apps now use **detection models by default**, while still noting support for segmentation, classification, pose, and OBB tasks.
- 📚 Improved SDK API documentation for core components like `YOLO`, `YOLOView`, `YOLOCamera`, `BasePredictor`, `ObjectDetector`, `Segmenter`, `Classifier`, `PoseEstimator`, `ObbDetector`, and result types.
- 🧠 Clarified support for modern model/output formats, especially around **YOLO26** detection and OBB workflows, including NMS-free and end-to-end output handling.
- 🖼️ Refined explanations for visualization, thresholds, model loading, caching, downloading, and external display support.
- 🧪 Cleaned up test comments and notes to better match actual model/task expectations.
- 🛠️ Included a few minor wording/consistency fixes, such as package/tooling comments and removal of an unused external display notification constant.

### 🎯 Purpose & Impact
- ✅ Makes the project much more approachable for new developers exploring the iOS examples or SDK internals.
- 🚀 Helps users better understand which tasks and model types are supported, especially with **YOLO26** as the current recommended model family.
- 🔍 Reduces confusion caused by outdated or overly long comments, particularly where older segmentation/OBB defaults were previously implied.
- 🧩 Improves maintainability for contributors by aligning documentation with current behavior and architecture.
- 📱 No major runtime feature changes are introduced here, so impact is mostly on **clarity, onboarding, and developer experience** rather than app behavior.