### PR TITLE
Clarify official Core ML asset exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,26 +90,31 @@ var body: some View {
 
 Official models are GitHub release assets, not large files committed to the repositories. The iOS app, Swift package examples, and Flutter package download official models automatically on first use and cache them locally.
 
-| Consumer                        | Runtime format                | Release asset source                                                                             | Direct URL pattern                                                                           |
-| ------------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
-| YOLO iOS app                    | Core ML int8 `.mlpackage.zip` | [yolo-ios-app `v8.3.0`](https://github.com/ultralytics/yolo-ios-app/releases/tag/v8.3.0)         | `https://github.com/ultralytics/yolo-ios-app/releases/download/v8.3.0/<model>.mlpackage.zip` |
-| YOLO Swift package URL examples | Core ML int8 `.mlpackage.zip` | [yolo-ios-app `v8.3.0`](https://github.com/ultralytics/yolo-ios-app/releases/tag/v8.3.0)         | `https://github.com/ultralytics/yolo-ios-app/releases/download/v8.3.0/<model>.mlpackage.zip` |
-| YOLO Flutter on iOS/macOS       | Core ML int8 `.mlpackage.zip` | [yolo-ios-app `v8.3.0`](https://github.com/ultralytics/yolo-ios-app/releases/tag/v8.3.0)         | `https://github.com/ultralytics/yolo-ios-app/releases/download/v8.3.0/<model>.mlpackage.zip` |
-| YOLO Flutter on Android         | TFLite int8 `.tflite`         | [yolo-flutter-app `v0.3.5`](https://github.com/ultralytics/yolo-flutter-app/releases/tag/v0.3.5) | `https://github.com/ultralytics/yolo-flutter-app/releases/download/v0.3.5/<model>.tflite`    |
+| Runtime asset | Used by | Release |
+| --- | --- | --- |
+| Core ML int8 `.mlpackage.zip` | iOS app, Swift package, Flutter on iOS/macOS | [yolo-ios-app `v8.3.0`](https://github.com/ultralytics/yolo-ios-app/releases/tag/v8.3.0) |
+| TFLite int8 `.tflite` | Flutter on Android | [yolo-flutter-app `v0.3.5`](https://github.com/ultralytics/yolo-flutter-app/releases/tag/v0.3.5) |
 
-The iOS app registry is [`RemoteModels.swift`](YOLOiOSApp/YOLOiOSApp/RemoteModels.swift). It enumerates YOLO26 `n/s/m/l/x` assets for detect, segment, semantic, classify, pose, and OBB and points each model ID at the `v8.3.0` Core ML release. The Flutter resolver uses this same Core ML release on Apple platforms and the Flutter `v0.3.5` release for Android TFLite.
+URL patterns:
 
-| Property                | Core ML official assets                              | TFLite official assets                         |
-| ----------------------- | ---------------------------------------------------- | ---------------------------------------------- |
-| Model family            | YOLO26 `n/s/m/l/x`                                   | YOLO26 `n/s/m/l/x`                             |
-| Tasks                   | detect, segment, semantic, classify, pose, OBB       | detect, segment, semantic, classify, pose, OBB |
-| Format                  | `.mlpackage.zip`                                     | `.tflite`                                      |
-| Quantization            | int8 Core ML export                                  | int8 TFLite export                             |
-| Export size             | classify: `224`; OBB: `1024`; all other tasks: `640` | classify: `224`; all other tasks: `640`        |
-| End-to-end / NMS export | `nms=False`                                          | `nms=False`                                    |
-| Calibration data        | Core ML exporter default calibration                 | `data=coco128.yaml`                            |
-| Postprocessing          | Swift package / iOS app postprocessing               | Flutter native Android postprocessing          |
-| Hosted release          | `ultralytics/yolo-ios-app` `v8.3.0`                  | `ultralytics/yolo-flutter-app` `v0.3.5`        |
+- Core ML: `https://github.com/ultralytics/yolo-ios-app/releases/download/v8.3.0/<model>.mlpackage.zip`
+- TFLite: `https://github.com/ultralytics/yolo-flutter-app/releases/download/v0.3.5/<model>.tflite`
+
+The iOS app registry is [`RemoteModels.swift`](YOLOiOSApp/YOLOiOSApp/RemoteModels.swift). It enumerates YOLO26 `n/s/m/l/x` assets for detect, segment, semantic, classify, pose, and OBB and points each model ID at the `v8.3.0` Core ML release. The Core ML column below is owned by this repo; the TFLite column summarizes the Flutter repo's Android export script and release assets.
+
+| Property | Core ML | TFLite |
+| --- | --- | --- |
+| Model IDs | `yolo26{n,s,m,l,x}` | `yolo26{n,s,m,l,x}` |
+| Tasks | detect, seg, sem, cls, pose, obb | detect, seg, sem, cls, pose, obb |
+| Format | `.mlpackage.zip` | `.tflite` |
+| `int8` | `True` | `True` |
+| `imgsz` | `224` cls; `1024` OBB; `640` others | `224` cls; `640` others |
+| `nms` | `False` | `False` |
+| `end2end` | `True` | `False` |
+| Calibration | exporter default | `data=coco128.yaml` |
+| Postprocessing | Swift/Core ML | Android native |
+
+Core ML assets use `nms=False` and `end2end=True`: `nms=False` suppresses the Core ML NMS pipeline, and `end2end=True` supplies the YOLO26 decoded output contract consumed by the Swift decoders. The TFLite export script passes both `nms=False` and `end2end=False`; `end2end=False` disables the YOLO26 end-to-end head for the Android LiteRT conversion path.
 
 ### Core ML Release Workflow
 
@@ -131,7 +136,7 @@ uv run python scripts/export-models.py --sizes n --copy-to-app
 uv run python scripts/export-models.py --upload --repo ultralytics/yolo-ios-app --tag v8.3.0
 ```
 
-The script exports from checkpoints named `yolo26<size><suffix>.pt`, for example `yolo26n.pt`, `yolo26s-seg.pt`, `yolo26m-sem.pt`, `yolo26l-pose.pt`, and `yolo26x-obb.pt`. YOLO26 is NMS-free in this SDK, so official Core ML assets are exported with `nms=False`; Swift-side postprocessing handles detect, segment, pose, and OBB outputs.
+The script exports from checkpoints named `yolo26<size><suffix>.pt`, for example `yolo26n.pt`, `yolo26s-seg.pt`, `yolo26m-sem.pt`, `yolo26l-pose.pt`, and `yolo26x-obb.pt`. YOLO26 is NMS-free in this SDK, so official Core ML assets are exported with `nms=False` and `end2end=True`; Swift-side postprocessing handles detect, segment, pose, and OBB outputs.
 
 ### Android TFLite Counterparts
 

--- a/README.md
+++ b/README.md
@@ -90,10 +90,10 @@ var body: some View {
 
 Official models are GitHub release assets, not large files committed to the repositories. The iOS app, Swift package examples, and Flutter package download official models automatically on first use and cache them locally.
 
-| Runtime asset | Used by | Release |
-| --- | --- | --- |
-| Core ML int8 `.mlpackage.zip` | iOS app, Swift package, Flutter on iOS/macOS | [yolo-ios-app `v8.3.0`](https://github.com/ultralytics/yolo-ios-app/releases/tag/v8.3.0) |
-| TFLite int8 `.tflite` | Flutter on Android | [yolo-flutter-app `v0.3.5`](https://github.com/ultralytics/yolo-flutter-app/releases/tag/v0.3.5) |
+| Runtime asset                 | Used by                                      | Release                                                                                          |
+| ----------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| Core ML int8 `.mlpackage.zip` | iOS app, Swift package, Flutter on iOS/macOS | [yolo-ios-app `v8.3.0`](https://github.com/ultralytics/yolo-ios-app/releases/tag/v8.3.0)         |
+| TFLite int8 `.tflite`         | Flutter on Android                           | [yolo-flutter-app `v0.3.5`](https://github.com/ultralytics/yolo-flutter-app/releases/tag/v0.3.5) |
 
 URL patterns:
 
@@ -102,17 +102,17 @@ URL patterns:
 
 The iOS app registry is [`RemoteModels.swift`](YOLOiOSApp/YOLOiOSApp/RemoteModels.swift). It enumerates YOLO26 `n/s/m/l/x` assets for detect, segment, semantic, classify, pose, and OBB and points each model ID at the `v8.3.0` Core ML release. The Core ML column below is owned by this repo; the TFLite column summarizes the Flutter repo's Android export script and release assets.
 
-| Property | Core ML | TFLite |
-| --- | --- | --- |
-| Model IDs | `yolo26{n,s,m,l,x}` | `yolo26{n,s,m,l,x}` |
-| Tasks | detect, seg, sem, cls, pose, obb | detect, seg, sem, cls, pose, obb |
-| Format | `.mlpackage.zip` | `.tflite` |
-| `int8` | `True` | `True` |
-| `imgsz` | `224` cls; `1024` OBB; `640` others | `224` cls; `640` others |
-| `nms` | `False` | `False` |
-| `end2end` | `True` | `False` |
-| Calibration | exporter default | `data=coco128.yaml` |
-| Postprocessing | Swift/Core ML | Android native |
+| Property       | Core ML                             | TFLite                           |
+| -------------- | ----------------------------------- | -------------------------------- |
+| Model IDs      | `yolo26{n,s,m,l,x}`                 | `yolo26{n,s,m,l,x}`              |
+| Tasks          | detect, seg, sem, cls, pose, obb    | detect, seg, sem, cls, pose, obb |
+| Format         | `.mlpackage.zip`                    | `.tflite`                        |
+| `int8`         | `True`                              | `True`                           |
+| `imgsz`        | `224` cls; `1024` OBB; `640` others | `224` cls; `640` others          |
+| `nms`          | `False`                             | `False`                          |
+| `end2end`      | `True`                              | `False`                          |
+| Calibration    | exporter default                    | `data=coco128.yaml`              |
+| Postprocessing | Swift/Core ML                       | Android native                   |
 
 Core ML assets use `nms=False` and `end2end=True`: `nms=False` suppresses the Core ML NMS pipeline, and `end2end=True` supplies the YOLO26 decoded output contract consumed by the Swift decoders. The TFLite export script passes both `nms=False` and `end2end=False`; `end2end=False` disables the YOLO26 end-to-end head for the Android LiteRT conversion path.
 

--- a/Sources/YOLO/README.md
+++ b/Sources/YOLO/README.md
@@ -240,10 +240,10 @@ You can use the official hosted assets, export the official matrix yourself, or 
 
 Official Core ML assets are hosted in [yolo-ios-app `v8.3.0`](https://github.com/ultralytics/yolo-ios-app/releases/tag/v8.3.0). They are int8 `.mlpackage.zip` archives named by model ID, for example `yolo26n.mlpackage.zip`, `yolo26n-seg.mlpackage.zip`, and `yolo26x-obb.mlpackage.zip`.
 
-| Runtime asset | Used by | Release |
-| --- | --- | --- |
-| Core ML int8 `.mlpackage.zip` | iOS app, Swift package, Flutter on iOS/macOS | [yolo-ios-app `v8.3.0`](https://github.com/ultralytics/yolo-ios-app/releases/tag/v8.3.0) |
-| TFLite int8 `.tflite` | Flutter on Android | [yolo-flutter-app `v0.3.5`](https://github.com/ultralytics/yolo-flutter-app/releases/tag/v0.3.5) |
+| Runtime asset                 | Used by                                      | Release                                                                                          |
+| ----------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| Core ML int8 `.mlpackage.zip` | iOS app, Swift package, Flutter on iOS/macOS | [yolo-ios-app `v8.3.0`](https://github.com/ultralytics/yolo-ios-app/releases/tag/v8.3.0)         |
+| TFLite int8 `.tflite`         | Flutter on Android                           | [yolo-flutter-app `v0.3.5`](https://github.com/ultralytics/yolo-flutter-app/releases/tag/v0.3.5) |
 
 URL patterns:
 

--- a/Sources/YOLO/README.md
+++ b/Sources/YOLO/README.md
@@ -240,25 +240,19 @@ You can use the official hosted assets, export the official matrix yourself, or 
 
 Official Core ML assets are hosted in [yolo-ios-app `v8.3.0`](https://github.com/ultralytics/yolo-ios-app/releases/tag/v8.3.0). They are int8 `.mlpackage.zip` archives named by model ID, for example `yolo26n.mlpackage.zip`, `yolo26n-seg.mlpackage.zip`, and `yolo26x-obb.mlpackage.zip`.
 
-| Consumer                       | Runtime format                | Release asset source                                                                             | Direct URL pattern                                                                           |
-| ------------------------------ | ----------------------------- | ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
-| YOLO iOS app and Swift package | Core ML int8 `.mlpackage.zip` | [yolo-ios-app `v8.3.0`](https://github.com/ultralytics/yolo-ios-app/releases/tag/v8.3.0)         | `https://github.com/ultralytics/yolo-ios-app/releases/download/v8.3.0/<model>.mlpackage.zip` |
-| YOLO Flutter on iOS/macOS      | Core ML int8 `.mlpackage.zip` | [yolo-ios-app `v8.3.0`](https://github.com/ultralytics/yolo-ios-app/releases/tag/v8.3.0)         | `https://github.com/ultralytics/yolo-ios-app/releases/download/v8.3.0/<model>.mlpackage.zip` |
-| YOLO Flutter on Android        | TFLite int8 `.tflite`         | [yolo-flutter-app `v0.3.5`](https://github.com/ultralytics/yolo-flutter-app/releases/tag/v0.3.5) | `https://github.com/ultralytics/yolo-flutter-app/releases/download/v0.3.5/<model>.tflite`    |
+| Runtime asset | Used by | Release |
+| --- | --- | --- |
+| Core ML int8 `.mlpackage.zip` | iOS app, Swift package, Flutter on iOS/macOS | [yolo-ios-app `v8.3.0`](https://github.com/ultralytics/yolo-ios-app/releases/tag/v8.3.0) |
+| TFLite int8 `.tflite` | Flutter on Android | [yolo-flutter-app `v0.3.5`](https://github.com/ultralytics/yolo-flutter-app/releases/tag/v0.3.5) |
+
+URL patterns:
+
+- Core ML: `https://github.com/ultralytics/yolo-ios-app/releases/download/v8.3.0/<model>.mlpackage.zip`
+- TFLite: `https://github.com/ultralytics/yolo-flutter-app/releases/download/v0.3.5/<model>.tflite`
 
 The package can load a Core ML release URL directly; it downloads once and caches the compiled model locally. If you download manually, unzip the `.mlpackage.zip` asset and add the `.mlpackage` to your app target's "Copy Bundle Resources" build phase.
 
-| Property                | Core ML official assets                              | TFLite official assets                         |
-| ----------------------- | ---------------------------------------------------- | ---------------------------------------------- |
-| Model family            | YOLO26 `n/s/m/l/x`                                   | YOLO26 `n/s/m/l/x`                             |
-| Tasks                   | detect, segment, semantic, classify, pose, OBB       | detect, segment, semantic, classify, pose, OBB |
-| Format                  | `.mlpackage.zip`                                     | `.tflite`                                      |
-| Quantization            | int8 Core ML export                                  | int8 TFLite export                             |
-| Export size             | classify: `224`; OBB: `1024`; all other tasks: `640` | classify: `224`; all other tasks: `640`        |
-| End-to-end / NMS export | `nms=False`                                          | `nms=False`                                    |
-| Calibration data        | Core ML exporter default calibration                 | `data=coco128.yaml`                            |
-| Postprocessing          | Swift package / iOS app postprocessing               | Flutter native Android postprocessing          |
-| Hosted release          | `ultralytics/yolo-ios-app` `v8.3.0`                  | `ultralytics/yolo-flutter-app` `v0.3.5`        |
+The [repository root README](../../README.md#-official-model-assets) is the authoritative reference for official model properties, including `imgsz`, `int8`, `nms`, `end2end`, calibration, postprocessing, and release hosting.
 
 ### Reproduce The Official Core ML Assets
 
@@ -272,7 +266,7 @@ uv run python scripts/export-models.py
 
 Use `--copy-to-app` to copy exported packages into `YOLOiOSApp/Models/<Task>/` for local app testing, and `--upload --repo ultralytics/yolo-ios-app --tag v8.3.0` to publish the generated zip archives to the canonical release.
 
-YOLO26 is NMS-free in this SDK: official Core ML assets are exported with `nms=False`, and the Swift package applies postprocessing internally. Legacy YOLO11 models exported with Core ML NMS (`nms=True`) remain supported; the predictor detects the model's `nms` metadata flag at load time and dispatches to the correct path.
+YOLO26 is NMS-free in this SDK: official Core ML assets are exported with `nms=False` and `end2end=True`, and the Swift package applies postprocessing internally. Legacy YOLO11 models exported with Core ML NMS (`nms=True`) remain supported; the predictor detects the model's `nms` metadata flag at load time and dispatches to the correct path.
 
 ## 🤝 Contributing
 

--- a/scripts/export-models.py
+++ b/scripts/export-models.py
@@ -113,6 +113,7 @@ def main() -> None:
                     format="coreml",
                     int8=True,
                     nms=False,
+                    end2end=True,
                     imgsz=task.imgsz,
                 )
             )


### PR DESCRIPTION
## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR updates the YOLO iOS app docs and export script to clarify official model asset sources and ensure Core ML YOLO26 models are exported with `end2end=True` for the Swift decoding pipeline.

### 📊 Key Changes
- 📚 Simplified and reorganized documentation in both `README.md` files:
  - Replaced a detailed consumer-by-consumer asset table with a cleaner runtime-based summary.
  - Clearly separated Core ML assets for Apple platforms and TFLite assets for Android.
  - Added explicit URL patterns for official hosted model downloads.
- 🧾 Made the root README the main source of truth for official model properties like:
  - supported YOLO26 model IDs and tasks
  - image sizes
  - int8 quantization
  - `nms` and `end2end` settings
  - calibration and postprocessing details
- ⚙️ Updated `scripts/export-models.py` to export Core ML models with:
  - `nms=False`
  - `end2end=True`
- 🔍 Clarified the Core ML vs. TFLite behavior:
  - Core ML uses `end2end=True` for Swift-side decoding
  - TFLite keeps `end2end=False` for the Android LiteRT conversion path
- ♻️ Updated documentation to reflect that YOLO26 Core ML assets are now officially exported with both `nms=False` and `end2end=True`.

### 🎯 Purpose & Impact
- ✅ Improves documentation clarity, making it easier for developers to understand where official models come from and how they differ across platforms.
- 🚀 Aligns the export script with the intended Swift inference pipeline, reducing confusion and helping ensure exported Core ML models work correctly in the iOS app and Swift package.
- 🍎 Makes the Apple model format expectations more explicit, especially for YOLO26’s decoded end-to-end output contract.
- 🤝 Helps maintain consistency between release assets, export tooling, and docs, which should make reproduction, debugging, and onboarding easier for contributors and users.
- 📱 For end users, this likely means more reliable official Core ML model behavior in the iOS app and related Apple integrations.