### PR TITLE
Clarify bundled nano model documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ This repository provides a comprehensive solution for running YOLO models on App
 
 ### [**Ultralytics YOLO iOS App (Main App)**](https://github.com/ultralytics/yolo-ios-app/tree/main/YOLOiOSApp)
 
-The primary iOS application allows easy real-time YOLO inference using your device's camera or image library. Official Ultralytics models are downloaded on demand, and you can also test your custom [Core ML](https://developer.apple.com/documentation/coreml) models by adding them to the app project.
+The primary iOS application allows easy real-time YOLO inference using your device's camera or image library. The shipped app bundles all six official nano Core ML models, larger variants download on demand, and you can also test your custom [Core ML](https://developer.apple.com/documentation/coreml) models by adding them to the app project.
 
 ### [**Swift Package (YOLO Library)**](https://github.com/ultralytics/yolo-ios-app/tree/main/Sources/YOLO)
 
@@ -88,7 +88,7 @@ var body: some View {
 
 ## 📦 Official Model Assets
 
-Official models are GitHub release assets, not large files committed to the repositories. The iOS app, Swift package examples, and Flutter package download official models automatically on first use and cache them locally.
+Official models are GitHub release assets, not large files committed to the repositories. The main iOS app downloads the six nano Core ML assets at build time and bundles them into the app; larger app models, Swift package examples, and Flutter package assets download official models on first use and cache them locally.
 
 The main YOLOiOSApp **bundles all six nano models** (one per task: detect, segment, semantic, classify, pose, OBB) into the shipped app, including App Store/archive builds. They are downloaded at build time from the GitHub release assets by a **Download YOLO Models** Xcode build phase that runs [`scripts/download-models.sh`](scripts/download-models.sh) — the `.mlpackage` files are **never committed to the repo** (`*.mlpackage` is gitignored). The step is idempotent and is skipped on GitHub Actions CI, which runs the same script in its own step.
 
@@ -146,7 +146,7 @@ The Android assets used by the Flutter package are maintained in the Flutter rep
 
 ## 🛠️ Quickstart Guide
 
-New to YOLO on mobile or want to quickly test your custom model? Start with the main YOLOiOSApp. Official models are downloaded on demand.
+New to YOLO on mobile or want to quickly test your custom model? Start with the main YOLOiOSApp. The six nano task models are bundled at build time, so the app can run offline after installation; larger model sizes download on demand.
 
 - [**Ultralytics YOLO iOS App (Main App)**](https://github.com/ultralytics/yolo-ios-app/tree/main/YOLOiOSApp): The easiest way to experience YOLO inference on iOS.
 
@@ -167,15 +167,13 @@ This repository includes comprehensive [unit tests](https://en.wikipedia.org/wik
 
 ### Running Tests
 
-Tests require Core ML model files (`.mlpackage`), which are not included in the repository due to their size. To run the tests with model validation:
+Tests require Core ML model files (`.mlpackage`), which are not committed to the repository due to their size. To run the package tests with model validation, first run the same downloader used by CI and the app build phase:
 
-1.  Set `SKIP_MODEL_TESTS = false` in the relevant test files.
-2.  Download the required models from the [YOLO iOS App releases](https://github.com/ultralytics/yolo-ios-app/releases) or train your own using tools like [Ultralytics Platform](https://platform.ultralytics.com).
-3.  Convert the models to Core ML format using the [Ultralytics Python library's export function](https://docs.ultralytics.com/modes/export/).
-4.  Add the exported `.mlpackage` files to your [Xcode](https://developer.apple.com/xcode/) project, ensuring they are included in the test targets.
-5.  Run the tests using Xcode's Test Navigator (Cmd+U).
+```bash
+bash scripts/download-models.sh
+```
 
-If you don't have the model files, you can still run tests by keeping `SKIP_MODEL_TESTS = true`. This will skip tests that require loading and running a model.
+This downloads the six nano Core ML packages into `Tests/YOLOTests/Resources/` and copies them into `YOLOiOSApp/Models/<Task>/` for the main app bundle. You can also export or replace these packages with custom Core ML models using the [Ultralytics Python library's export function](https://docs.ultralytics.com/modes/export/). If a specific test target supports `SKIP_MODEL_TESTS`, keeping it set to `true` skips tests that require loading and running a model.
 
 ### Test Coverage
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -108,15 +108,13 @@ var body: some View {
 
 ### 运行测试
 
-测试依赖 Core ML 模型文件（`.mlpackage`），但由于文件体积较大，仓库中不包含这些模型。若要执行带模型校验的测试，请按以下步骤操作：
+测试依赖 Core ML 模型文件（`.mlpackage`），但由于文件体积较大，仓库中不会提交这些模型。若要执行带模型校验的测试，请先在仓库根目录运行与 CI 和应用构建阶段相同的下载脚本：
 
-1. 在相关测试文件中将 `SKIP_MODEL_TESTS = false`。
-2. 从 [YOLO iOS App 发布页](https://github.com/ultralytics/yolo-ios-app/releases)下载所需模型，或通过 [Ultralytics Platform](https://platform.ultralytics.com) 训练你自己的模型。
-3. 使用 [Ultralytics Python 库的导出功能](https://docs.ultralytics.com/modes/export/) 将模型转换为 Core ML 格式。
-4. 将导出的 `.mlpackage` 文件添加到你的 [Xcode](https://developer.apple.com/xcode/) 项目中，并确保它们已加入对应的测试 target。
-5. 通过 Xcode 的 Test Navigator（Cmd+U）运行测试。
+```bash
+bash scripts/download-models.sh
+```
 
-如果你没有这些模型文件，也可以保持 `SKIP_MODEL_TESTS = true`。这样会跳过需要加载和运行模型的测试。
+该脚本会将六个 nano Core ML package 下载到 `Tests/YOLOTests/Resources/`，并复制到 `YOLOiOSApp/Models/<Task>/`，供主应用在构建时打包进应用。你也可以使用 [Ultralytics Python 库的导出功能](https://docs.ultralytics.com/modes/export/) 导出或替换为自定义 Core ML 模型。如果某个测试 target 支持 `SKIP_MODEL_TESTS`，保持为 `true` 会跳过需要加载和运行模型的测试。
 
 ### 测试覆盖范围
 

--- a/Tests/YOLOTests/README.md
+++ b/Tests/YOLOTests/README.md
@@ -2,13 +2,23 @@
 
 # YOLO Test Guide
 
-Welcome to the testing guide for the Ultralytics YOLO iOS application. This directory contains comprehensive tests designed to ensure the robustness and correctness of the [Ultralytics YOLO](https://docs.ultralytics.com/) framework integration within the iOS environment. To execute these tests successfully, you'll need to download and correctly place the required model files first.
+Welcome to the testing guide for the Ultralytics YOLO iOS application. This directory contains comprehensive tests designed to ensure the robustness and correctness of the [Ultralytics YOLO](https://docs.ultralytics.com/) framework integration within the iOS environment. To execute model-backed tests successfully, run the repository model downloader first; it fetches the same six nano Core ML assets that the main app bundles at build time.
 
 ## 🧪 Preparation Before Testing
 
 Follow these steps to set up your testing environment.
 
-### 1. Check the Test Resource Directory
+### 1. Download the Required Nano Models
+
+From the repository root, run:
+
+```bash
+bash scripts/download-models.sh
+```
+
+The script downloads the six nano `.mlpackage` files into `Tests/YOLOTests/Resources/` and copies them into `YOLOiOSApp/Models/<Task>/` so the main app bundle uses the same assets. The `.mlpackage` directories are intentionally gitignored and are not committed to the repository.
+
+### 2. Check the Test Resource Directory
 
 Verify that the following directory exists within your project structure:
 
@@ -22,7 +32,7 @@ If this directory is missing, create it using the terminal:
 mkdir -p Tests/YOLOTests/Resources/
 ```
 
-### 2. Obtain the Required Model Files
+### 3. Confirm the Required Model Files
 
 The tests require specific [Core ML](https://developer.apple.com/documentation/coreml) model files (`.mlpackage`). Ensure you have the following files ready:
 
@@ -33,9 +43,9 @@ The tests require specific [Core ML](https://developer.apple.com/documentation/c
 - `yolo26n-pose.mlpackage`: Model for [pose estimation](https://docs.ultralytics.com/tasks/pose/).
 - `yolo26n-obb.mlpackage`: Model for [oriented bounding box (OBB)](https://docs.ultralytics.com/tasks/obb/) detection.
 
-### 3. Methods to Acquire Model Files
+### 4. Alternative Manual Acquisition
 
-You can obtain the necessary `.mlpackage` files using one of the following methods:
+The automated downloader is the recommended path. You can also obtain compatible `.mlpackage` files using one of the following manual methods:
 
 #### Method 1: Download and Convert Official Models
 
@@ -73,9 +83,9 @@ export_and_zip_yolo_models()
 
 Download pre-exported Core ML models from the [YOLO iOS App releases page](https://github.com/ultralytics/yolo-ios-app/releases). If you download zipped `.mlpackage` assets, unzip them before placing the model packages in `Tests/YOLOTests/Resources/`.
 
-### 4. Place the Model Files
+### 5. Place Manually Acquired Model Files
 
-After obtaining or exporting the `.mlpackage` files, move or copy them into the designated resource directory:
+If you do not use `scripts/download-models.sh`, move or copy the manually acquired `.mlpackage` files into the designated resource directory:
 
 ```
 Tests/YOLOTests/Resources/

--- a/Tests/YOLOTests/Resources/README.md
+++ b/Tests/YOLOTests/Resources/README.md
@@ -15,7 +15,7 @@ To execute the test suite successfully, ensure the following [Core ML](https://d
 - `yolo26n-pose.mlpackage` - [Pose estimation](https://docs.ultralytics.com/tasks/pose/) model
 - `yolo26n-obb.mlpackage` - [Oriented bounding box](https://docs.ultralytics.com/tasks/obb/) model
 
-**Note**: Due to their significant file sizes, these model files are not included directly in the source code repository. While the necessary directory structure is provided, you must manually add the actual `.mlpackage` files.
+**Note**: Due to their significant file sizes, these model files are not committed directly to the source code repository. Run `bash scripts/download-models.sh` from the repository root to populate this directory automatically; manually add `.mlpackage` files only when using custom or locally exported models.
 
 ## 📁 Directory Structure
 
@@ -47,7 +47,7 @@ bash scripts/download-models.sh
 This script will:
 
 - Download all nano-sized YOLO26 models to this test resources directory
-- Copy the models to the appropriate app model directories for use in the iOS app
+- Copy the models to the appropriate app model directories so the main iOS app bundles them at build time
 - Verify model integrity after download
 
 ### Manual Setup

--- a/YOLOiOSApp/README.md
+++ b/YOLOiOSApp/README.md
@@ -64,7 +64,7 @@ Ensure you have the following before you begin:
 
     In Xcode, navigate to the project's target settings. Under the "Signing & Capabilities" tab, select your Apple Developer account to sign the app.
 
-3.  **Add YOLO26 Models:**
+3.  **Bundled and Optional YOLO26 Models:**
     The app ships with all six nano models (one per task: detect, segment, semantic, classify, pose, OBB). They are downloaded from the [yolo-ios-app `v8.3.0`](https://github.com/ultralytics/yolo-ios-app/releases/tag/v8.3.0) release assets at build time by a **Download YOLO Models** Xcode build phase that runs [`scripts/download-models.sh`](../scripts/download-models.sh), and are **never committed to the repo** (`*.mlpackage` is gitignored). Larger sizes (`s/m/l/x`) download on demand on first use and are cached on device; the URL registry is [`RemoteModels.swift`](RemoteModels.swift).
 
     You can also prepare local model files for development or tests:
@@ -90,7 +90,7 @@ The Ultralytics YOLO iOS App offers an intuitive user experience:
 
 - **Real-Time Inference:** Launch the app and point your device's camera at objects. The app will perform real-time [object detection](https://docs.ultralytics.com/tasks/detect/), [instance segmentation](https://docs.ultralytics.com/tasks/segment/), [semantic segmentation](https://docs.ultralytics.com/tasks/semantic/), [image classification](https://docs.ultralytics.com/tasks/classify/), [pose estimation](https://docs.ultralytics.com/tasks/pose/), or [oriented bounding box detection](https://docs.ultralytics.com/tasks/obb/) depending on the selected task and model.
 - **Flexible Task Selection:** Easily switch between different computer vision tasks supported by the loaded models using the app's interface.
-- **Multiple AI Models:** Choose from a range of downloadable Ultralytics YOLO26 models, from the lightweight YOLO26n ('nano') optimized for edge devices to the powerful YOLO26x ('x-large') for maximum accuracy. You can also deploy and use custom models trained on your own data after exporting them to the Core ML format.
+- **Multiple AI Models:** Use the bundled YOLO26n ('nano') model for each supported task immediately after build, then download larger `s/m/l/x` variants on demand for higher accuracy. You can also deploy and use custom models trained on your own data after exporting them to the Core ML format.
 
 ### 📺 External Display Support (Optional)
 
@@ -127,11 +127,11 @@ The YOLO iOS App includes a suite of unit and integration tests to ensure functi
 The test suite is designed to run with or without the actual Core ML model files:
 
 - **Without Models:** Set `SKIP_MODEL_TESTS = true` in the test target's build settings (under `Build Settings` > `User-Defined`). This allows running tests that don't require model inference, such as UI tests or utility function tests.
-- **With Models:** Set `SKIP_MODEL_TESTS = false` and ensure the required model files are added to the project in their respective directories as described below. This enables the full test suite, including tests that perform actual model inference.
+- **With Models:** Set `SKIP_MODEL_TESTS = false` and run `bash scripts/download-models.sh` from the repository root, or build the main app target so the **Download YOLO Models** build phase prepares the app models. This enables the full test suite, including tests that perform actual model inference.
 
 ### Required Models for Full Testing
 
-To execute the complete test suite (with `SKIP_MODEL_TESTS = false`), include the following **INT8 quantized Core ML models** in your project:
+To execute the complete test suite (with `SKIP_MODEL_TESTS = false`), include the following **INT8 quantized Core ML models** in your project. The repository does not commit these `.mlpackage` directories; `scripts/download-models.sh` downloads them into the test resources and copies them into the app's `Models/<Task>/` directories.
 
 - **Detection:** `yolo26n.mlpackage` (place in `Models/Detect`)
 - **Instance Segmentation:** `yolo26n-seg.mlpackage` (place in `Models/Segment`)


### PR DESCRIPTION
## Summary
- update root English and Chinese docs to say the main YOLOiOSApp bundles all six nano Core ML models at build time
- clarify larger app models still download on demand and model packages are not committed
- update app and test docs to use scripts/download-models.sh as the recommended setup path

## Validation
- git diff --check
- rg stale zero-model/download-on-demand wording across touched docs

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📦 This PR updates the documentation to clarify that the iOS app now bundles all six official YOLO26 nano Core ML models at build time, while larger models still download on demand.

### 📊 Key Changes
- 📝 Updated the main `README.md` to explain that the shipped app includes six bundled YOLO26 nano models for all supported tasks: detect, segment, semantic, classify, pose, and OBB.
- 📥 Clarified model delivery behavior:
  - Nano models are downloaded during build and packaged into the app.
  - Larger `s/m/l/x` models are still downloaded on first use and cached locally.
- 🧪 Simplified test setup instructions across multiple docs:
  - Users are now told to run `bash scripts/download-models.sh`
  - The script downloads test models into `Tests/YOLOTests/Resources/`
  - It also copies models into `YOLOiOSApp/Models/<Task>/` for app bundling
- 📚 Updated both English and Chinese documentation to keep setup guidance consistent.
- 🛠 Improved test documentation to emphasize the automated downloader as the recommended path, while still allowing manual or custom Core ML model replacement.

### 🎯 Purpose & Impact
- 🚀 Makes the app experience clearer: users can understand that core nano models are available immediately after install, including offline use.
- 🙌 Reduces confusion for developers by replacing manual test/model setup steps with one standard script.
- ✅ Improves consistency between app builds, CI, and local testing since all now rely on the same model download workflow.
- 📱 Better communicates the app’s out-of-the-box functionality: the default nano models are ready to use, while larger models remain optional for higher accuracy.
- 🌍 Helps a broader audience with clearer, more maintainable docs in both English and Chinese.