### PR TITLE
Fix testflight publish when no Package.resolved exists

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -145,11 +145,17 @@ jobs:
           FIRST_COMMIT=$(git rev-list --max-parents=0 HEAD)
           git reset --soft $FIRST_COMMIT
 
-          # Resolve dependencies and add to commit
+          # Resolve dependencies and include the SPM pin file when present. With no remote package
+          # dependencies, SPM does not emit a Package.resolved, so only force-add it if it exists.
           cd YOLOiOSApp
           xcodebuild -resolvePackageDependencies -project YOLOiOSApp.xcodeproj -scheme YOLOiOSApp
           cd ..
-          git add -f YOLOiOSApp/YOLOiOSApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+          RESOLVED="YOLOiOSApp/YOLOiOSApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved"
+          if [ -f "$RESOLVED" ]; then
+            git add -f "$RESOLVED"
+          else
+            echo "No Package.resolved (project has no remote SPM dependencies) — skipping"
+          fi
 
           # Single commit with version info
           MARKETING_VERSION="${{ needs.check.outputs.marketing_version }}"


### PR DESCRIPTION
## Problem

The **Publish iOS App** workflow failed on `main` after #252 ([run #107](https://github.com/ultralytics/yolo-ios-app/actions)):

```
fatal: pathspec 'YOLOiOSApp/.../swiftpm/Package.resolved' did not match any files
Error: Process completed with exit code 128.
```

## Cause

Removing the ZIPFoundation dependency left the app project with **zero remote SPM dependencies**. `Package.resolved` only pins *remote* packages, so `xcodebuild -resolvePackageDependencies` no longer emits one (the resolve log now reads `Resolved source packages: YOLO` — the local package only). The testflight step then `git add -f`'d a path that doesn't exist.

## Fix

Guard the add — only force-add `Package.resolved` when it exists, otherwise log and skip. The squashed testflight commit still contains the full source tree, and Xcode Cloud builds fine without a pin file when there are no remote packages to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR makes the iOS app publish workflow more robust by only adding Swift Package Manager’s `Package.resolved` file when it actually exists.

### 📊 Key Changes
- Updated `.github/workflows/publish.yml` in the `ultralytics/yolo-ios-app` repository.
- Improved the publish step that resolves Swift package dependencies during release preparation.
- Replaced the unconditional `git add` of `Package.resolved` with a file existence check.
- Added a clear log message when `Package.resolved` is not generated because the project has no remote SPM dependencies.

### 🎯 Purpose & Impact
- ✅ Prevents publish workflow failures caused by trying to add a non-existent `Package.resolved` file.
- 🚀 Makes releases more reliable for projects that do not use remote Swift Package Manager dependencies.
- 🧹 Keeps the workflow behavior clean and intentional by only committing dependency pin files when they are present.
- 👨‍💻 Reduces maintenance friction and confusion for developers by documenting the expected no-file case in the workflow output.