### PR TITLE
Fix segment masks outside detection boxes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,7 @@ jobs:
           files: ./info.lcov
           slug: ultralytics/yolo-ios-app
           fail_ci_if_error: false
+          handle_no_reports_found: true
 
   periphery:
     runs-on: macos-26

--- a/Sources/YOLO/BasePredictor.swift
+++ b/Sources/YOLO/BasePredictor.swift
@@ -203,18 +203,7 @@ public class BasePredictor: Predictor, @unchecked Sendable {
           iouThreshold: iou, confidenceThreshold: predictor.confidenceThreshold)
         predictor.detector = coreMLModel
         predictor.visionRequest = {
-          let request = VNCoreMLRequest(
-            model: coreMLModel,
-            completionHandler: {
-              [weak predictor] request, error in
-              guard let predictor = predictor else {
-                // The predictor was deallocated — do nothing
-                return
-              }
-              if isRealTime {
-                predictor.processObservations(for: request, error)
-              }
-            })
+          let request = VNCoreMLRequest(model: coreMLModel)
           request.imageCropAndScaleOption = predictor.imageCropAndScaleOption
           return request
         }()
@@ -267,11 +256,14 @@ public class BasePredictor: Predictor, @unchecked Sendable {
       do {
         if let request = visionRequest {
           try handler.perform([request])
+          processObservations(for: request, nil)
+        } else {
+          isUpdating = false
         }
       } catch {
         YOLOLog.error("Vision request failed: \(error)")
+        isUpdating = false
       }
-      t1 = CACurrentMediaTime() - t0  // inference dt
 
       currentBuffer = nil
     }
@@ -476,14 +468,18 @@ public class BasePredictor: Predictor, @unchecked Sendable {
   ///
   /// Call this once per processed frame after `t1` is set. Uses an EMA with `emaAlpha` weight on new samples and skips
   /// obvious outliers above `maxValidDt`.
-  func updateTime() {
+  func updateTime(notify: Bool = true) {
     let alpha = Self.emaAlpha
+    let now = CACurrentMediaTime()
+    self.t1 = now - self.t0
     if self.t1 < Self.maxValidDt {  // valid dt
       self.t2 = self.t1 * alpha + self.t2 * (1 - alpha)  // smoothed inference time
     }
-    self.t4 = (CACurrentMediaTime() - self.t3) * alpha + self.t4 * (1 - alpha)  // smoothed FPS dt
-    self.t3 = CACurrentMediaTime()
+    self.t4 = (now - self.t3) * alpha + self.t4 * (1 - alpha)  // smoothed FPS dt
+    self.t3 = now
 
-    self.currentOnInferenceTimeListener?.on(inferenceTime: self.t2 * 1000, fpsRate: 1 / self.t4)
+    if notify {
+      self.currentOnInferenceTimeListener?.on(inferenceTime: self.t2 * 1000, fpsRate: 1 / self.t4)
+    }
   }
 }

--- a/Sources/YOLO/BasePredictor.swift
+++ b/Sources/YOLO/BasePredictor.swift
@@ -40,9 +40,6 @@ public class BasePredictor: Predictor, @unchecked Sendable {
   /// Whether the model requires NMS post-processing (false for YOLO26 nms-free models).
   public private(set) var requiresNMS: Bool = true
 
-  /// The current pixel buffer being processed (used for camera frame processing).
-  var currentBuffer: CVPixelBuffer?
-
   /// The current listener to receive prediction results.
   weak var currentOnResultsListener: ResultsListener?
 
@@ -237,36 +234,54 @@ public class BasePredictor: Predictor, @unchecked Sendable {
     sampleBuffer: CMSampleBuffer, onResultsListener: ResultsListener?,
     onInferenceTime: InferenceTimeListener?
   ) {
-    if currentBuffer == nil, let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) {
-      currentBuffer = pixelBuffer
-      inputSize = CGSize(
-        width: CVPixelBufferGetWidth(pixelBuffer), height: CVPixelBufferGetHeight(pixelBuffer))
-      currentOnResultsListener = onResultsListener
-      currentOnInferenceTimeListener = onInferenceTime
-
-      /// - Tag: MappingOrientation
-      // The frame is always oriented based on the camera sensor, so in most cases Vision needs to rotate it for the
-      // model to work as expected.
-      let imageOrientation: CGImagePropertyOrientation = .up
-
-      // Invoke a VNRequestHandler with that image
-      let handler = VNImageRequestHandler(
-        cvPixelBuffer: pixelBuffer, orientation: imageOrientation, options: [:])
-      t0 = CACurrentMediaTime()  // inference start
-      do {
-        if let request = visionRequest {
-          try handler.perform([request])
-          processObservations(for: request, nil)
-        } else {
-          isUpdating = false
-        }
-      } catch {
-        YOLOLog.error("Vision request failed: \(error)")
-        isUpdating = false
-      }
-
-      currentBuffer = nil
+    guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
+    currentOnResultsListener = onResultsListener
+    currentOnInferenceTimeListener = onInferenceTime
+    guard let request = visionRequest else {
+      isUpdating = false
+      return
     }
+    let handler = makeRequestHandler(for: pixelBuffer)
+    guard perform(request, with: handler, errorMessage: "Vision request failed") else {
+      isUpdating = false
+      return
+    }
+    processObservations(for: request, nil)
+  }
+
+  func makeRequestHandler(for image: CIImage) -> VNImageRequestHandler {
+    inputSize = image.extent.size
+    t0 = CACurrentMediaTime()
+    return VNImageRequestHandler(ciImage: image, options: [:])
+  }
+
+  func makeRequestHandler(for pixelBuffer: CVPixelBuffer) -> VNImageRequestHandler {
+    inputSize = CGSize(
+      width: CVPixelBufferGetWidth(pixelBuffer), height: CVPixelBufferGetHeight(pixelBuffer))
+    t0 = CACurrentMediaTime()
+    return VNImageRequestHandler(
+      cvPixelBuffer: pixelBuffer, orientation: cameraFrameOrientation, options: [:])
+  }
+
+  /// The camera output is already configured into the app's inference orientation.
+  var cameraFrameOrientation: CGImagePropertyOrientation { .up }
+
+  func perform(_ request: VNRequest, with handler: VNImageRequestHandler, errorMessage: String)
+    -> Bool
+  {
+    do {
+      try handler.perform([request])
+      return true
+    } catch {
+      YOLOLog.error("\(errorMessage): \(error)")
+      return false
+    }
+  }
+
+  @discardableResult
+  func finishTiming(notify: Bool = true) -> Double {
+    updateTime(notify: notify)
+    return self.t1
   }
 
   /// The confidence threshold for filtering detection results (default: 0.25).

--- a/Sources/YOLO/Classifier.swift
+++ b/Sources/YOLO/Classifier.swift
@@ -28,26 +28,20 @@ public final class Classifier: BasePredictor, @unchecked Sendable {
   }
 
   public override func predictOnImage(image: CIImage) -> YOLOResult {
-    let requestHandler = VNImageRequestHandler(ciImage: image, options: [:])
     guard let request = visionRequest else {
       return YOLOResult(orig_shape: inputSize, boxes: [], speed: 0, names: labels)
     }
 
-    self.inputSize = CGSize(width: image.extent.width, height: image.extent.height)
     var probs = Probs(top1: "", top5: [], top1Conf: 0, top5Confs: [])
-    self.t0 = CACurrentMediaTime()
-    do {
-      try requestHandler.perform([request])
+    let requestHandler = makeRequestHandler(for: image)
+    if perform(request, with: requestHandler, errorMessage: "Classifier inference failed") {
       probs = extractProbs(from: request)
-    } catch {
-      YOLOLog.error("Classifier inference failed: \(error)")
     }
 
     var result = YOLOResult(
-      orig_shape: inputSize, boxes: [], probs: probs, speed: self.t1, names: labels)
+      orig_shape: inputSize, boxes: [], probs: probs, speed: 0, names: labels)
     result.annotatedImage = drawYOLOClassifications(on: image, result: result)
-    updateTime(notify: false)
-    result.speed = self.t1
+    result.speed = finishTiming(notify: false)
     return result
   }
 

--- a/Sources/YOLO/Classifier.swift
+++ b/Sources/YOLO/Classifier.swift
@@ -35,6 +35,7 @@ public final class Classifier: BasePredictor, @unchecked Sendable {
 
     self.inputSize = CGSize(width: image.extent.width, height: image.extent.height)
     var probs = Probs(top1: "", top5: [], top1Conf: 0, top5Confs: [])
+    self.t0 = CACurrentMediaTime()
     do {
       try requestHandler.perform([request])
       probs = extractProbs(from: request)
@@ -43,8 +44,10 @@ public final class Classifier: BasePredictor, @unchecked Sendable {
     }
 
     var result = YOLOResult(
-      orig_shape: inputSize, boxes: [], probs: probs, speed: t1, names: labels)
+      orig_shape: inputSize, boxes: [], probs: probs, speed: self.t1, names: labels)
     result.annotatedImage = drawYOLOClassifications(on: image, result: result)
+    updateTime(notify: false)
+    result.speed = self.t1
     return result
   }
 

--- a/Sources/YOLO/ObbDetector.swift
+++ b/Sources/YOLO/ObbDetector.swift
@@ -19,7 +19,10 @@ import Vision
 public final class ObbDetector: BasePredictor, @unchecked Sendable {
 
   override func processObservations(for request: VNRequest, _ error: Error?) {
-    guard let prediction = firstFeatureArray(request) else { return }
+    guard let prediction = firstFeatureArray(request) else {
+      self.isUpdating = false
+      return
+    }
     let obbResults = buildResults(from: prediction)
     self.updateTime()
     self.currentOnResultsListener?.on(
@@ -34,6 +37,7 @@ public final class ObbDetector: BasePredictor, @unchecked Sendable {
       return YOLOResult(orig_shape: inputSize, boxes: [], speed: 0, names: labels)
     }
     self.inputSize = CGSize(width: image.extent.width, height: image.extent.height)
+    self.t0 = CACurrentMediaTime()
 
     do {
       try requestHandler.perform([request])
@@ -41,11 +45,12 @@ public final class ObbDetector: BasePredictor, @unchecked Sendable {
         return YOLOResult(orig_shape: inputSize, boxes: [], speed: 0, names: labels)
       }
       let obbResults = buildResults(from: prediction)
-      updateTime()
+      let annotatedImage = drawOBBsOnCIImage(ciImage: image, obbDetections: obbResults)
+      updateTime(notify: false)
       return YOLOResult(
         orig_shape: inputSize, boxes: [], obb: obbResults,
-        annotatedImage: drawOBBsOnCIImage(ciImage: image, obbDetections: obbResults),
-        speed: self.t2, fps: 1 / self.t4, names: labels)
+        annotatedImage: annotatedImage,
+        speed: self.t1, names: labels)
     } catch {
       YOLOLog.error("OBB detection failed: \(error)")
     }

--- a/Sources/YOLO/ObbDetector.swift
+++ b/Sources/YOLO/ObbDetector.swift
@@ -32,29 +32,23 @@ public final class ObbDetector: BasePredictor, @unchecked Sendable {
   }
 
   public override func predictOnImage(image: CIImage) -> YOLOResult {
-    let requestHandler = VNImageRequestHandler(ciImage: image, options: [:])
     guard let request = visionRequest else {
       return YOLOResult(orig_shape: inputSize, boxes: [], speed: 0, names: labels)
     }
-    self.inputSize = CGSize(width: image.extent.width, height: image.extent.height)
-    self.t0 = CACurrentMediaTime()
+    let requestHandler = makeRequestHandler(for: image)
 
-    do {
-      try requestHandler.perform([request])
-      guard let prediction = firstFeatureArray(request) else {
-        return YOLOResult(orig_shape: inputSize, boxes: [], speed: 0, names: labels)
-      }
-      let obbResults = buildResults(from: prediction)
-      let annotatedImage = drawOBBsOnCIImage(ciImage: image, obbDetections: obbResults)
-      updateTime(notify: false)
+    guard perform(request, with: requestHandler, errorMessage: "OBB detection failed"),
+      let prediction = firstFeatureArray(request)
+    else {
       return YOLOResult(
-        orig_shape: inputSize, boxes: [], obb: obbResults,
-        annotatedImage: annotatedImage,
-        speed: self.t1, names: labels)
-    } catch {
-      YOLOLog.error("OBB detection failed: \(error)")
+        orig_shape: inputSize, boxes: [], speed: finishTiming(notify: false), names: labels)
     }
-    return YOLOResult(orig_shape: inputSize, boxes: [], speed: 0, names: labels)
+    let obbResults = buildResults(from: prediction)
+    let annotatedImage = drawOBBsOnCIImage(ciImage: image, obbDetections: obbResults)
+    return YOLOResult(
+      orig_shape: inputSize, boxes: [], obb: obbResults,
+      annotatedImage: annotatedImage,
+      speed: finishTiming(notify: false), names: labels)
   }
 
   private func firstFeatureArray(_ request: VNRequest) -> MLMultiArray? {

--- a/Sources/YOLO/ObjectDetector.swift
+++ b/Sources/YOLO/ObjectDetector.swift
@@ -90,7 +90,7 @@ public final class ObjectDetector: BasePredictor, @unchecked Sendable {
     let imageWidth = image.extent.width
     let imageHeight = image.extent.height
     self.inputSize = CGSize(width: imageWidth, height: imageHeight)
-    let start = Date()
+    self.t0 = CACurrentMediaTime()
 
     do {
       try requestHandler.perform([request])
@@ -98,10 +98,11 @@ public final class ObjectDetector: BasePredictor, @unchecked Sendable {
     } catch {
       YOLOLog.error("Object detection failed: \(error)")
     }
-    let elapsed = Date().timeIntervalSince(start)
 
-    var result = YOLOResult(orig_shape: inputSize, boxes: boxes, speed: elapsed, names: labels)
+    var result = YOLOResult(orig_shape: inputSize, boxes: boxes, speed: self.t1, names: labels)
     let annotatedImage = drawYOLODetections(on: image, result: result)
+    updateTime(notify: false)
+    result.speed = self.t1
     result.annotatedImage = annotatedImage
 
     return result

--- a/Sources/YOLO/ObjectDetector.swift
+++ b/Sources/YOLO/ObjectDetector.swift
@@ -80,29 +80,20 @@ public final class ObjectDetector: BasePredictor, @unchecked Sendable {
   /// - Parameter image: The CIImage to analyze for object detection.
   /// - Returns: A YOLOResult containing the detected objects with bounding boxes, class labels, and confidence scores.
   public override func predictOnImage(image: CIImage) -> YOLOResult {
-    let requestHandler = VNImageRequestHandler(ciImage: image, options: [:])
     guard let request = visionRequest else {
       let emptyResult = YOLOResult(orig_shape: inputSize, boxes: [], speed: 0, names: labels)
       return emptyResult
     }
     var boxes = [Box]()
 
-    let imageWidth = image.extent.width
-    let imageHeight = image.extent.height
-    self.inputSize = CGSize(width: imageWidth, height: imageHeight)
-    self.t0 = CACurrentMediaTime()
-
-    do {
-      try requestHandler.perform([request])
+    let requestHandler = makeRequestHandler(for: image)
+    if perform(request, with: requestHandler, errorMessage: "Object detection failed") {
       boxes = decodeBoxes(from: request)
-    } catch {
-      YOLOLog.error("Object detection failed: \(error)")
     }
 
-    var result = YOLOResult(orig_shape: inputSize, boxes: boxes, speed: self.t1, names: labels)
+    var result = YOLOResult(orig_shape: inputSize, boxes: boxes, speed: 0, names: labels)
     let annotatedImage = drawYOLODetections(on: image, result: result)
-    updateTime(notify: false)
-    result.speed = self.t1
+    result.speed = finishTiming(notify: false)
     result.annotatedImage = annotatedImage
 
     return result

--- a/Sources/YOLO/Plot.swift
+++ b/Sources/YOLO/Plot.swift
@@ -290,14 +290,16 @@ func generateCombinedMaskImage(
       ))
   }
 
-  for i in 0..<N {
-    let box = maskBoxes[i]
-    let startIdx = i * HW
-    for y in 0..<maskHeight {
-      let rowStart = startIdx + y * maskWidth
-      let insideY = y >= box.y1 && y < box.y2
-      for x in 0..<maskWidth where !insideY || x < box.x1 || x >= box.x2 {
-        combinedMask[rowStart + x] = 0
+  if returnIndividualMasks {
+    for i in 0..<N {
+      let box = maskBoxes[i]
+      let startIdx = i * HW
+      for y in 0..<maskHeight {
+        let rowStart = startIdx + y * maskWidth
+        let insideY = y >= box.y1 && y < box.y2
+        for x in 0..<maskWidth where !insideY || x < box.x1 || x >= box.x2 {
+          combinedMask[rowStart + x] = 0
+        }
       }
     }
   }

--- a/Sources/YOLO/Plot.swift
+++ b/Sources/YOLO/Plot.swift
@@ -196,7 +196,7 @@ func generateCombinedMaskImage(
   protos: MLMultiArray,  // shape: [1, C, H, W]
   inputWidth: Int,
   inputHeight: Int,
-  threshold: Float = 0.5,
+  threshold: Float = 0.0,
   cropRect: CGRect? = nil,
   returnIndividualMasks: Bool = true
 ) -> (CGImage?, [[[Float]]]?)? {
@@ -272,21 +272,43 @@ func generateCombinedMaskImage(
   let outputHeight = Int(outputRect.height)
   guard outputWidth > 0, outputHeight > 0 else { return nil }
 
+  // Match Ultralytics process_mask(): crop each mask to its detection box before thresholding
+  // or returning per-instance data.
+  var maskBoxes: [(x1: Int, y1: Int, x2: Int, y2: Int)] = []
+  maskBoxes.reserveCapacity(N)
+  for (box, _, _, _) in detectedObjects {
+    let x1 = Int((Float(box.minX) * scaleX).rounded())
+    let y1 = Int((Float(box.minY) * scaleY).rounded())
+    let x2 = Int((Float(box.maxX) * scaleX).rounded())
+    let y2 = Int((Float(box.maxY) * scaleY).rounded())
+    maskBoxes.append(
+      (
+        x1: max(0, min(x1, maskWidth)),
+        y1: max(0, min(y1, maskHeight)),
+        x2: max(0, min(x2, maskWidth)),
+        y2: max(0, min(y2, maskHeight))
+      ))
+  }
+
+  for i in 0..<N {
+    let box = maskBoxes[i]
+    let startIdx = i * HW
+    for y in 0..<maskHeight {
+      let rowStart = startIdx + y * maskWidth
+      let insideY = y >= box.y1 && y < box.y2
+      for x in 0..<maskWidth where !insideY || x < box.x1 || x >= box.x2 {
+        combinedMask[rowStart + x] = 0
+      }
+    }
+  }
+
   // 8) Per-instance probability maps are built later (section 10) with bulk row copies.
   var probabilityMasks: [[[Float]]]? = nil
 
   // 9) Compose according to sort order
-  for (originalIndex, box, classID, _) in sortedObjects {
-    // Convert boundingBox to mask coordinate system
-    let minX = Int(Float(box.minX) * scaleX)
-    let minY = Int(Float(box.minY) * scaleY)
-    let maxX = Int(Float(box.maxX) * scaleX)
-    let maxY = Int(Float(box.maxY) * scaleY)
-
-    let boxX1 = max(0, min(minX, maskWidth - 1))
-    let boxX2 = max(0, min(maxX, maskWidth - 1))
-    let boxY1 = max(0, min(minY, maskHeight - 1))
-    let boxY2 = max(0, min(maxY, maskHeight - 1))
+  for (originalIndex, _, classID, _) in sortedObjects {
+    let maskBox = maskBoxes[originalIndex]
+    guard maskBox.x1 < maskBox.x2, maskBox.y1 < maskBox.y2 else { continue }
 
     let startIdx = originalIndex * HW
 
@@ -300,8 +322,8 @@ func generateCombinedMaskImage(
     let b = UInt8(color.blue)
 
     // Pixel loop: box range only
-    for y in boxY1...boxY2 {
-      for x in boxX1...boxX2 {
+    for y in maskBox.y1..<maskBox.y2 {
+      for x in maskBox.x1..<maskBox.x2 {
         let px = y * maskWidth + x
         let maskVal = combinedMask[startIdx + px]
         if maskVal > threshold {

--- a/Sources/YOLO/PoseEstimator.swift
+++ b/Sources/YOLO/PoseEstimator.swift
@@ -85,7 +85,8 @@ public final class PoseEstimator: BasePredictor, @unchecked Sendable {
         speed: finishTiming(notify: false), names: labels)
       return result
     }
-    return YOLOResult(orig_shape: inputSize, boxes: [], speed: finishTiming(notify: false), names: labels)
+    return YOLOResult(
+      orig_shape: inputSize, boxes: [], speed: finishTiming(notify: false), names: labels)
   }
 
   func PostProcessPose(

--- a/Sources/YOLO/PoseEstimator.swift
+++ b/Sources/YOLO/PoseEstimator.swift
@@ -45,59 +45,47 @@ public final class PoseEstimator: BasePredictor, @unchecked Sendable {
   }
 
   public override func predictOnImage(image: CIImage) -> YOLOResult {
-    let requestHandler = VNImageRequestHandler(ciImage: image, options: [:])
     guard let request = visionRequest else {
       let emptyResult = YOLOResult(orig_shape: inputSize, boxes: [], speed: 0, names: labels)
       return emptyResult
     }
 
-    let imageWidth = image.extent.width
-    let imageHeight = image.extent.height
-    self.inputSize = CGSize(width: imageWidth, height: imageHeight)
-    self.t0 = CACurrentMediaTime()
+    let requestHandler = makeRequestHandler(for: image)
+    if perform(request, with: requestHandler, errorMessage: "Pose estimation failed"),
+      let results = request.results as? [VNCoreMLFeatureValueObservation],
+      let prediction = results.first?.featureValue.multiArrayValue
+    {
 
-    do {
-      try requestHandler.perform([request])
+      let preds = PostProcessPose(
+        prediction: prediction, confidenceThreshold: Float(self.confidenceThreshold),
+        iouThreshold: Float(self.iouThreshold))
+      var keypointsList = [Keypoints]()
+      var boxes = [Box]()
+      var keypointsForImage = [[(x: Float, y: Float)]]()
+      var confsList: [[Float]] = []
 
-      if let results = request.results as? [VNCoreMLFeatureValueObservation] {
-
-        if let prediction = results.first?.featureValue.multiArrayValue {
-
-          let preds = PostProcessPose(
-            prediction: prediction, confidenceThreshold: Float(self.confidenceThreshold),
-            iouThreshold: Float(self.iouThreshold))
-          var keypointsList = [Keypoints]()
-          var boxes = [Box]()
-          var keypointsForImage = [[(x: Float, y: Float)]]()
-          var confsList: [[Float]] = []
-
-          let limitedPreds = preds.prefix(self.numItemsThreshold)
-          for person in limitedPreds {
-            boxes.append(person.box)
-            keypointsList.append(person.keypoints)
-            keypointsForImage.append(person.keypoints.xyn)
-            confsList.append(person.keypoints.conf)
-          }
-
-          let annotatedImage = drawYOLOPoseWithBoxes(
-            ciImage: image,
-            keypointsList: keypointsForImage,
-            confsList: confsList,
-            boundingBoxes: boxes
-          )
-
-          updateTime(notify: false)
-          let result = YOLOResult(
-            orig_shape: inputSize, boxes: boxes, masks: nil, probs: nil,
-            keypointsList: keypointsList, annotatedImage: annotatedImage, speed: self.t1,
-            names: labels)
-          return result
-        }
+      let limitedPreds = preds.prefix(self.numItemsThreshold)
+      for person in limitedPreds {
+        boxes.append(person.box)
+        keypointsList.append(person.keypoints)
+        keypointsForImage.append(person.keypoints.xyn)
+        confsList.append(person.keypoints.conf)
       }
-    } catch {
-      YOLOLog.error("Pose estimation failed: \(error)")
+
+      let annotatedImage = drawYOLOPoseWithBoxes(
+        ciImage: image,
+        keypointsList: keypointsForImage,
+        confsList: confsList,
+        boundingBoxes: boxes
+      )
+
+      let result = YOLOResult(
+        orig_shape: inputSize, boxes: boxes, masks: nil, probs: nil,
+        keypointsList: keypointsList, annotatedImage: annotatedImage,
+        speed: finishTiming(notify: false), names: labels)
+      return result
     }
-    return YOLOResult(orig_shape: inputSize, boxes: [], speed: 0, names: labels)
+    return YOLOResult(orig_shape: inputSize, boxes: [], speed: finishTiming(notify: false), names: labels)
   }
 
   func PostProcessPose(

--- a/Sources/YOLO/PoseEstimator.swift
+++ b/Sources/YOLO/PoseEstimator.swift
@@ -19,28 +19,29 @@ import Vision
 public final class PoseEstimator: BasePredictor, @unchecked Sendable {
 
   override func processObservations(for request: VNRequest, _ error: Error?) {
-    if let results = request.results as? [VNCoreMLFeatureValueObservation] {
-
-      if let prediction = results.first?.featureValue.multiArrayValue {
-
-        let preds = PostProcessPose(
-          prediction: prediction, confidenceThreshold: Float(self.confidenceThreshold),
-          iouThreshold: Float(self.iouThreshold))
-        var keypointsList = [Keypoints]()
-        var boxes = [Box]()
-
-        let limitedPreds = preds.prefix(self.numItemsThreshold)
-        for person in limitedPreds {
-          boxes.append(person.box)
-          keypointsList.append(person.keypoints)
-        }
-        self.updateTime()
-        let result = YOLOResult(
-          orig_shape: inputSize, boxes: boxes, masks: nil, probs: nil, keypointsList: keypointsList,
-          annotatedImage: nil, speed: self.t2, fps: 1 / self.t4, names: labels)
-        self.currentOnResultsListener?.on(result: result)
-      }
+    guard let results = request.results as? [VNCoreMLFeatureValueObservation],
+      let prediction = results.first?.featureValue.multiArrayValue
+    else {
+      self.isUpdating = false
+      return
     }
+
+    let preds = PostProcessPose(
+      prediction: prediction, confidenceThreshold: Float(self.confidenceThreshold),
+      iouThreshold: Float(self.iouThreshold))
+    var keypointsList = [Keypoints]()
+    var boxes = [Box]()
+
+    let limitedPreds = preds.prefix(self.numItemsThreshold)
+    for person in limitedPreds {
+      boxes.append(person.box)
+      keypointsList.append(person.keypoints)
+    }
+    self.updateTime()
+    let result = YOLOResult(
+      orig_shape: inputSize, boxes: boxes, masks: nil, probs: nil, keypointsList: keypointsList,
+      annotatedImage: nil, speed: self.t2, fps: 1 / self.t4, names: labels)
+    self.currentOnResultsListener?.on(result: result)
   }
 
   public override func predictOnImage(image: CIImage) -> YOLOResult {
@@ -53,6 +54,7 @@ public final class PoseEstimator: BasePredictor, @unchecked Sendable {
     let imageWidth = image.extent.width
     let imageHeight = image.extent.height
     self.inputSize = CGSize(width: imageWidth, height: imageHeight)
+    self.t0 = CACurrentMediaTime()
 
     do {
       try requestHandler.perform([request])
@@ -84,11 +86,11 @@ public final class PoseEstimator: BasePredictor, @unchecked Sendable {
             boundingBoxes: boxes
           )
 
-          updateTime()
+          updateTime(notify: false)
           let result = YOLOResult(
             orig_shape: inputSize, boxes: boxes, masks: nil, probs: nil,
-            keypointsList: keypointsList, annotatedImage: annotatedImage, speed: self.t2,
-            fps: 1 / self.t4, names: labels)
+            keypointsList: keypointsList, annotatedImage: annotatedImage, speed: self.t1,
+            names: labels)
           return result
         }
       }

--- a/Sources/YOLO/Segmenter.swift
+++ b/Sources/YOLO/Segmenter.swift
@@ -45,7 +45,7 @@ public final class Segmenter: BasePredictor, @unchecked Sendable {
           inputHeight: capturedModelInputSize.height,
           cropRect: capturedMaskCropRect,
           returnIndividualMasks: false
-        ) as? (CGImage?, [[[Float]]]?)
+        )
       else {
         DispatchQueue.main.async { [weak self] in self?.isUpdating = false }
         return
@@ -87,7 +87,8 @@ public final class Segmenter: BasePredictor, @unchecked Sendable {
           maskHeight: parsed.masks.shape[2].intValue,
           inputSize: inputSize,
           modelInputSize: modelInputSize)
-      ) as? (CGImage?, [[[Float]]])
+      ),
+      let masks = processed.1
     else {
       return YOLOResult(
         orig_shape: inputSize, boxes: boxes, speed: finishTiming(notify: false), names: labels)
@@ -97,7 +98,7 @@ public final class Segmenter: BasePredictor, @unchecked Sendable {
       ciImage: image, boxes: boxes, maskImage: processed.0)
     return YOLOResult(
       orig_shape: inputSize, boxes: boxes,
-      masks: Masks(masks: processed.1, combinedMask: processed.0),
+      masks: Masks(masks: masks, combinedMask: processed.0),
       annotatedImage: annotatedImage,
       speed: finishTiming(notify: false), names: labels)
   }

--- a/Sources/YOLO/Segmenter.swift
+++ b/Sources/YOLO/Segmenter.swift
@@ -48,7 +48,6 @@ public final class Segmenter: BasePredictor, @unchecked Sendable {
           protos: capturedMasks,
           inputWidth: capturedModelInputSize.width,
           inputHeight: capturedModelInputSize.height,
-          threshold: 0.5,
           cropRect: capturedMaskCropRect
         ) as? (CGImage?, [[[Float]]])
       else {
@@ -84,7 +83,6 @@ public final class Segmenter: BasePredictor, @unchecked Sendable {
         let processed = generateCombinedMaskImage(
           detectedObjects: limitedObjects, protos: parsed.masks,
           inputWidth: self.modelInputSize.width, inputHeight: self.modelInputSize.height,
-          threshold: 0.5,
           cropRect: inputMaskCropRect(
             maskWidth: parsed.masks.shape[3].intValue,
             maskHeight: parsed.masks.shape[2].intValue,

--- a/Sources/YOLO/Segmenter.swift
+++ b/Sources/YOLO/Segmenter.swift
@@ -26,14 +26,9 @@ public final class Segmenter: BasePredictor, @unchecked Sendable {
     let limitedObjects = Array(parsed.detectedObjects.prefix(self.numItemsThreshold))
     let boxes = buildBoxes(from: limitedObjects)
 
-    // Update timing before capturing values to avoid one-frame lag.
-    self.updateTime()
-
     let capturedMasks = parsed.masks
     let capturedInputSize = self.inputSize
     let capturedModelInputSize = self.modelInputSize
-    let capturedT2 = self.t2
-    let capturedT4 = self.t4
     let capturedLabels = self.labels
     let capturedMaskCropRect = inputMaskCropRect(
       maskWidth: capturedMasks.shape[3].intValue,
@@ -48,17 +43,19 @@ public final class Segmenter: BasePredictor, @unchecked Sendable {
           protos: capturedMasks,
           inputWidth: capturedModelInputSize.width,
           inputHeight: capturedModelInputSize.height,
-          cropRect: capturedMaskCropRect
-        ) as? (CGImage?, [[[Float]]])
+          cropRect: capturedMaskCropRect,
+          returnIndividualMasks: false
+        ) as? (CGImage?, [[[Float]]]?)
       else {
         DispatchQueue.main.async { [weak self] in self?.isUpdating = false }
         return
       }
+      self?.updateTime()
       let result = YOLOResult(
         orig_shape: capturedInputSize,
         boxes: boxes,
-        masks: Masks(masks: processed.1, combinedMask: processed.0),
-        speed: capturedT2, fps: 1 / capturedT4, names: capturedLabels)
+        masks: Masks(masks: processed.1 ?? [], combinedMask: processed.0),
+        speed: self?.t2 ?? 0, fps: self.map { 1 / $0.t4 }, names: capturedLabels)
       self?.currentOnResultsListener?.on(result: result)
     }
   }
@@ -71,6 +68,7 @@ public final class Segmenter: BasePredictor, @unchecked Sendable {
 
     self.inputSize = CGSize(width: image.extent.width, height: image.extent.height)
     var result = YOLOResult(orig_shape: inputSize, boxes: [], speed: 0, names: labels)
+    self.t0 = CACurrentMediaTime()
 
     do {
       try requestHandler.perform([request])
@@ -93,13 +91,14 @@ public final class Segmenter: BasePredictor, @unchecked Sendable {
         return YOLOResult(orig_shape: inputSize, boxes: boxes, speed: 0, names: labels)
       }
 
-      updateTime()
+      let annotatedImage = drawYOLOSegmentationWithBoxes(
+        ciImage: image, boxes: boxes, maskImage: processed.0)
+      updateTime(notify: false)
       result = YOLOResult(
         orig_shape: inputSize, boxes: boxes,
         masks: Masks(masks: processed.1, combinedMask: processed.0),
-        annotatedImage: drawYOLOSegmentationWithBoxes(
-          ciImage: image, boxes: boxes, maskImage: processed.0),
-        speed: self.t2, fps: 1 / self.t4, names: labels)
+        annotatedImage: annotatedImage,
+        speed: self.t1, names: labels)
     } catch {
       YOLOLog.error("Segmentation failed: \(error)")
     }

--- a/Sources/YOLO/Segmenter.swift
+++ b/Sources/YOLO/Segmenter.swift
@@ -61,48 +61,45 @@ public final class Segmenter: BasePredictor, @unchecked Sendable {
   }
 
   public override func predictOnImage(image: CIImage) -> YOLOResult {
-    let requestHandler = VNImageRequestHandler(ciImage: image, options: [:])
     guard let request = visionRequest else {
       return YOLOResult(orig_shape: inputSize, boxes: [], speed: 0, names: labels)
     }
 
-    self.inputSize = CGSize(width: image.extent.width, height: image.extent.height)
+    let requestHandler = makeRequestHandler(for: image)
     var result = YOLOResult(orig_shape: inputSize, boxes: [], speed: 0, names: labels)
-    self.t0 = CACurrentMediaTime()
 
-    do {
-      try requestHandler.perform([request])
-      guard let parsed = parseSegmentationRequest(request) else { return result }
-
-      let limitedObjects = Array(parsed.detectedObjects.prefix(self.numItemsThreshold))
-      let boxes = buildBoxes(from: limitedObjects)
-
-      guard
-        let processed = generateCombinedMaskImage(
-          detectedObjects: limitedObjects, protos: parsed.masks,
-          inputWidth: self.modelInputSize.width, inputHeight: self.modelInputSize.height,
-          cropRect: inputMaskCropRect(
-            maskWidth: parsed.masks.shape[3].intValue,
-            maskHeight: parsed.masks.shape[2].intValue,
-            inputSize: inputSize,
-            modelInputSize: modelInputSize)
-        ) as? (CGImage?, [[[Float]]])
-      else {
-        return YOLOResult(orig_shape: inputSize, boxes: boxes, speed: 0, names: labels)
-      }
-
-      let annotatedImage = drawYOLOSegmentationWithBoxes(
-        ciImage: image, boxes: boxes, maskImage: processed.0)
-      updateTime(notify: false)
-      result = YOLOResult(
-        orig_shape: inputSize, boxes: boxes,
-        masks: Masks(masks: processed.1, combinedMask: processed.0),
-        annotatedImage: annotatedImage,
-        speed: self.t1, names: labels)
-    } catch {
-      YOLOLog.error("Segmentation failed: \(error)")
+    guard perform(request, with: requestHandler, errorMessage: "Segmentation failed"),
+      let parsed = parseSegmentationRequest(request)
+    else {
+      result.speed = finishTiming(notify: false)
+      return result
     }
-    return result
+
+    let limitedObjects = Array(parsed.detectedObjects.prefix(self.numItemsThreshold))
+    let boxes = buildBoxes(from: limitedObjects)
+
+    guard
+      let processed = generateCombinedMaskImage(
+        detectedObjects: limitedObjects, protos: parsed.masks,
+        inputWidth: self.modelInputSize.width, inputHeight: self.modelInputSize.height,
+        cropRect: inputMaskCropRect(
+          maskWidth: parsed.masks.shape[3].intValue,
+          maskHeight: parsed.masks.shape[2].intValue,
+          inputSize: inputSize,
+          modelInputSize: modelInputSize)
+      ) as? (CGImage?, [[[Float]]])
+    else {
+      return YOLOResult(
+        orig_shape: inputSize, boxes: boxes, speed: finishTiming(notify: false), names: labels)
+    }
+
+    let annotatedImage = drawYOLOSegmentationWithBoxes(
+      ciImage: image, boxes: boxes, maskImage: processed.0)
+    return YOLOResult(
+      orig_shape: inputSize, boxes: boxes,
+      masks: Masks(masks: processed.1, combinedMask: processed.0),
+      annotatedImage: annotatedImage,
+      speed: finishTiming(notify: false), names: labels)
   }
 
   /// Pulls the `(masks, detectedObjects)` tuple out of a completed Vision request. The shape-4 output is the

--- a/Sources/YOLO/SemanticSegmenter.swift
+++ b/Sources/YOLO/SemanticSegmenter.swift
@@ -27,29 +27,22 @@ public final class SemanticSegmenter: BasePredictor, @unchecked Sendable {
   }
 
   public override func predictOnImage(image: CIImage) -> YOLOResult {
-    let requestHandler = VNImageRequestHandler(ciImage: image, options: [:])
     guard let request = visionRequest else {
       return YOLOResult(orig_shape: inputSize, boxes: [], speed: 0, names: labels)
     }
 
-    self.inputSize = CGSize(width: image.extent.width, height: image.extent.height)
     var semanticMask: SemanticMask?
-    self.t0 = CACurrentMediaTime()
-
-    do {
-      try requestHandler.perform([request])
+    let requestHandler = makeRequestHandler(for: image)
+    if perform(request, with: requestHandler, errorMessage: "Semantic segmentation failed") {
       semanticMask = firstFeatureArray(request).flatMap { postProcessSemantic($0) }
-    } catch {
-      YOLOLog.error("Semantic segmentation failed: \(error)")
     }
 
     var result = YOLOResult(
       orig_shape: inputSize, boxes: [], semanticMask: semanticMask,
-      speed: self.t1, names: labels)
+      speed: 0, names: labels)
     result.annotatedImage = drawYOLOSemanticSegmentation(
       ciImage: image, semanticMask: semanticMask?.maskImage)
-    updateTime(notify: false)
-    result.speed = self.t1
+    result.speed = finishTiming(notify: false)
     return result
   }
 

--- a/Sources/YOLO/SemanticSegmenter.swift
+++ b/Sources/YOLO/SemanticSegmenter.swift
@@ -33,8 +33,8 @@ public final class SemanticSegmenter: BasePredictor, @unchecked Sendable {
     }
 
     self.inputSize = CGSize(width: image.extent.width, height: image.extent.height)
-    let start = Date()
     var semanticMask: SemanticMask?
+    self.t0 = CACurrentMediaTime()
 
     do {
       try requestHandler.perform([request])
@@ -45,9 +45,11 @@ public final class SemanticSegmenter: BasePredictor, @unchecked Sendable {
 
     var result = YOLOResult(
       orig_shape: inputSize, boxes: [], semanticMask: semanticMask,
-      speed: Date().timeIntervalSince(start), names: labels)
+      speed: self.t1, names: labels)
     result.annotatedImage = drawYOLOSemanticSegmentation(
       ciImage: image, semanticMask: semanticMask?.maskImage)
+    updateTime(notify: false)
+    result.speed = self.t1
     return result
   }
 

--- a/Sources/YOLO/VideoCapture.swift
+++ b/Sources/YOLO/VideoCapture.swift
@@ -495,6 +495,7 @@ extension VideoCapture: ResultsListener, InferenceTimeListener {
 
   public func on(result: YOLOResult) {
     DispatchQueue.main.async { [weak self] in
+      defer { self?.predictor?.isUpdating = false }
       self?.delegate?.onPredict(result: result)
     }
   }

--- a/Sources/YOLO/VideoCapture.swift
+++ b/Sources/YOLO/VideoCapture.swift
@@ -396,9 +396,11 @@ public final class VideoCapture: NSObject, @unchecked Sendable {
 
   private func predictOnFrame(sampleBuffer: CMSampleBuffer) {
     guard let predictor = predictor, currentBuffer == nil,
+      !predictor.isUpdating,
       let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer)
     else { return }
     currentBuffer = pixelBuffer
+    self.predictor?.isUpdating = true
     if !frameSizeCaptured {
       let w = CGFloat(CVPixelBufferGetWidth(pixelBuffer))
       let h = CGFloat(CVPixelBufferGetHeight(pixelBuffer))

--- a/Sources/YOLO/YOLOView.swift
+++ b/Sources/YOLO/YOLOView.swift
@@ -57,8 +57,6 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   }
 
   public func onPredict(result: YOLOResult) {
-    defer { self.videoCapture.predictor?.isUpdating = false }
-
     // Notify delegate of detection results
     delegate?.yoloView(self, didReceiveResult: result)
 

--- a/Sources/YOLO/YOLOView.swift
+++ b/Sources/YOLO/YOLOView.swift
@@ -57,6 +57,8 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   }
 
   public func onPredict(result: YOLOResult) {
+    defer { self.videoCapture.predictor?.isUpdating = false }
+
     // Notify delegate of detection results
     delegate?.yoloView(self, didReceiveResult: result)
 
@@ -68,14 +70,12 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
         ? result.masks?.combinedMask : result.semanticMask?.maskImage
       {
         guard let maskLayer = self.maskLayer else {
-          self.videoCapture.predictor?.isUpdating = false
           return
         }
         maskLayer.isHidden = false
         maskLayer.frame = imageFrameInOverlay(for: result.orig_shape)
         maskLayer.contents = maskImage
       }
-      self.videoCapture.predictor?.isUpdating = false
     } else if task == .classify {
       self.overlayYOLOClassificationsCALayer(on: self, result: result)
     } else if task == .pose {

--- a/Tests/YOLOTests/BasePredictorTests.swift
+++ b/Tests/YOLOTests/BasePredictorTests.swift
@@ -19,7 +19,6 @@ class BasePredictorTests: XCTestCase {
     XCTAssertEqual(predictor.iouThreshold, 0.7, accuracy: 0.001)
     XCTAssertEqual(predictor.numItemsThreshold, 30)
     XCTAssertFalse(predictor.isUpdating)
-    XCTAssertNil(predictor.currentBuffer)
   }
 
   func testConfidenceThresholdSetting() {

--- a/Tests/YOLOTests/PlotTests.swift
+++ b/Tests/YOLOTests/PlotTests.swift
@@ -231,7 +231,7 @@ class PlotTests: XCTestCase {
       let result = generateCombinedMaskImage(
         detectedObjects: detected, protos: protos,
         inputWidth: W, inputHeight: H, threshold: 0.5,
-        cropRect: nil, returnIndividualMasks: true) as? (CGImage?, [[[Float]]]?),
+        cropRect: nil, returnIndividualMasks: true),
       let masks = result.1
     else {
       XCTFail("generateCombinedMaskImage returned nil or wrong type")
@@ -265,7 +265,7 @@ class PlotTests: XCTestCase {
       let result = generateCombinedMaskImage(
         detectedObjects: detected, protos: protos,
         inputWidth: W, inputHeight: H,
-        cropRect: nil, returnIndividualMasks: true) as? (CGImage?, [[[Float]]]?),
+        cropRect: nil, returnIndividualMasks: true),
       let masks = result.1
     else {
       XCTFail("generateCombinedMaskImage returned nil or wrong type")
@@ -288,7 +288,7 @@ class PlotTests: XCTestCase {
       generateCombinedMaskImage(
         detectedObjects: [], protos: protos,
         inputWidth: 4, inputHeight: 4, threshold: 0.5,
-        cropRect: nil, returnIndividualMasks: true) as? (CGImage?, [[[Float]]]?)
+        cropRect: nil, returnIndividualMasks: true)
     XCTAssertNotNil(result)
     XCTAssertNil(result?.0)
     XCTAssertEqual(result?.1?.count, 0)

--- a/Tests/YOLOTests/PlotTests.swift
+++ b/Tests/YOLOTests/PlotTests.swift
@@ -249,6 +249,38 @@ class PlotTests: XCTestCase {
     }
   }
 
+  func testGenerateCombinedMaskImageCropsPerInstanceMasksToDetectionBox() {
+    let C = 1
+    let H = 4
+    let W = 4
+    let protos = try! MLMultiArray(shape: [1, C, H, W] as [NSNumber], dataType: .float32)
+    let pPtr = protos.dataPointer.assumingMemoryBound(to: Float.self)
+    for i in 0..<(H * W) { pPtr[i] = 1 }
+
+    let detected: [(CGRect, Int, Float, [Float])] = [
+      (CGRect(x: 1, y: 1, width: 2, height: 2), 0, 0.9, [1])
+    ]
+
+    guard
+      let result = generateCombinedMaskImage(
+        detectedObjects: detected, protos: protos,
+        inputWidth: W, inputHeight: H,
+        cropRect: nil, returnIndividualMasks: true) as? (CGImage?, [[[Float]]]?),
+      let masks = result.1
+    else {
+      XCTFail("generateCombinedMaskImage returned nil or wrong type")
+      return
+    }
+
+    XCTAssertEqual(masks.count, 1)
+    for y in 0..<H {
+      for x in 0..<W {
+        let expected: Float = (1..<3).contains(x) && (1..<3).contains(y) ? 1 : 0
+        XCTAssertEqual(masks[0][y][x], expected, accuracy: 1e-4)
+      }
+    }
+  }
+
   func testGenerateCombinedMaskImageEmptyDetectionsReturnsGracefully() {
     // Zero detections must not crash on the unsafe-buffer paths; it returns no image and empty masks.
     let protos = try! MLMultiArray(shape: [1, 2, 4, 4] as [NSNumber], dataType: .float32)


### PR DESCRIPTION
## Summary
- crop each generated instance mask to its detection box before rendering or returning per-instance mask data
- use Ultralytics-style raw logit thresholding for segmentation mask rendering
- speed up realtime segmentation by skipping per-instance nested mask arrays on camera frames
- unify realtime profiling so every task measures from frame acceptance through task postprocessing/result emission
- keep frame lifecycle ownership in the camera pipeline instead of the renderer
- share request-handler setup, timing, and Vision error handling across static and realtime inference paths
- remove the duplicate BasePredictor frame-buffer gate; VideoCapture owns frame admission
- add a regression test that verifies per-instance masks are zero outside the detection box

## Validation
- xcodebuild -project YOLOiOSApp/YOLOiOSApp.xcodeproj -scheme YOLOiOSApp -destination 'generic/platform=iOS Simulator' build
- swift test --filter PlotTests (fails before tests run: SwiftPM host build cannot import UIKit)
- xcodebuild ... -scheme YOLO test and -scheme YOLOiOSApp test (both schemes are not configured for the test action)

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR refactors the iOS prediction pipeline to improve real-time stability, unify timing/error handling, and make segmentation masks more accurate.

### 📊 Key Changes
- 🔄 **Refactored shared prediction flow in `BasePredictor`**
  - Removed older per-frame buffer tracking from `BasePredictor`.
  - Added reusable helpers for creating Vision request handlers, running requests, and finishing timing.
  - Simplified `VNCoreMLRequest` setup so live-camera results are processed explicitly after inference.

- ⏱️ **Unified and improved inference timing**
  - Timing is now calculated consistently across classification, detection, pose, OBB, segmentation, and semantic segmentation.
  - Added `finishTiming()` and updated `updateTime()` so reported speed/FPS is more accurate and avoids stale values.

- 📷 **Safer real-time frame processing**
  - `VideoCapture` now checks `predictor.isUpdating` before starting a new frame.
  - In-progress state is set and cleared more reliably, reducing the chance of overlapping frame processing or UI-related race conditions.

- 🧹 **Cleaner failure handling**
  - Several predictors now explicitly reset update state when request results are missing or invalid.
  - Common request execution logic reduces duplicated `do/catch` blocks and standardizes logging.

- 🎭 **Improved segmentation mask behavior**
  - `generateCombinedMaskImage()` now crops each instance mask to its detection box before thresholding or returning mask data.
  - Default threshold changed from `0.5` to `0.0` in the mask generation helper, aligning better with the updated mask-processing flow.
  - Segmentation now supports skipping per-instance mask generation when only the combined mask is needed for live results.

- ✅ **CI and test updates**
  - GitHub Actions now tolerates missing coverage reports with `handle_no_reports_found: true`.
  - Added/updated tests for the new mask-cropping behavior and removed a test tied to the deleted buffer state.

### 🎯 Purpose & Impact
- 🚀 **Better real-time performance and stability**
  - Helps prevent duplicate or overlapping camera-frame inference, which should make the app smoother during live use.

- 📏 **More accurate speed reporting**
  - Users and developers should see inference timing that better reflects actual model execution across tasks.

- 🎯 **More precise segmentation outputs**
  - Instance masks are now constrained to their detected objects, reducing mask spill outside bounding boxes and improving visual quality.

- 🧩 **Easier maintenance**
  - Shared helper methods reduce repeated code, making the prediction pipeline easier to extend and less error-prone.

- 🛡️ **More resilient CI**
  - Builds are less likely to fail when coverage files are unavailable, improving workflow reliability for contributors.