### PR TITLE
Fix YOLOView storyboard module reference (8.9.1)

### DIFF
--- a/UltralyticsYOLO.podspec
+++ b/UltralyticsYOLO.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'UltralyticsYOLO'
-  s.version          = '8.9.0'
+  s.version          = '8.9.1'
   s.summary          = 'Ultralytics YOLO core inference for iOS (CoreML/Vision).'
   s.homepage         = 'https://github.com/ultralytics/yolo-ios-app'
   s.license          = { :type => 'AGPL-3.0', :file => 'LICENSE' }

--- a/YOLOiOSApp/YOLOiOSApp.xcodeproj/project.pbxproj
+++ b/YOLOiOSApp/YOLOiOSApp.xcodeproj/project.pbxproj
@@ -386,7 +386,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.9.0;
+				MARKETING_VERSION = 8.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ultralytics.iDetection;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -414,7 +414,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.9.0;
+				MARKETING_VERSION = 8.9.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ultralytics.iDetection;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/YOLOiOSApp/YOLOiOSApp/Main.storyboard
+++ b/YOLOiOSApp/YOLOiOSApp/Main.storyboard
@@ -17,7 +17,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ShC-gv-PaQ" customClass="YOLOView" customModule="YOLO">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ShC-gv-PaQ" customClass="YOLOView" customModule="UltralyticsYOLO">
                                 <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BZf-Ft-ERG" userLabel="Label Time">


### PR DESCRIPTION
## Summary

Patch release **8.9.1** fixing a launch crash in `YOLOiOSApp` introduced by the module rename in #257.

`Main.storyboard` pinned the camera view to `customModule="YOLO"` — the Swift module name **before** it was renamed to `UltralyticsYOLO`. This compiles cleanly (so the build-only CI in #257 passed), but at runtime Interface Builder cannot resolve `_TtC4YOLO8YOLOView`, instantiates a fallback object, and the app crashes on launch:

```
Unknown class _TtC4YOLO8YOLOView in Interface Builder file.
*** -[UITraitCollection sublayers]: unrecognized selector sent to instance ...
```

## Fix

- `Main.storyboard`: `customModule="YOLO"` → `customModule="UltralyticsYOLO"` (the only stale IB/module reference in the repo — grepped storyboards/XIBs and `NSClassFromString`).
- Bump `MARKETING_VERSION` and the podspec to **8.9.1**.

## Verification

Built **and launched** `YOLOiOSApp` on an iOS simulator (not just `xcodebuild build`) — the storyboard loads and the app runs, no crash. Confirmed independently in Xcode.

## Note

CI only ran `xcodebuild build`, which compiles storyboards but does not load them, so this runtime-only regression slipped through. Adding a launch/smoke step to CI (boot a simulator and launch the app) would catch this class of issue — proposed as a follow-up.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔖 This PR makes a small iOS release update to version `8.9.1` and fixes the storyboard module reference so the app correctly points to the `UltralyticsYOLO` framework.

### 📊 Key Changes
- Bumped the CocoaPods package version in `UltralyticsYOLO.podspec` from `8.9.0` to `8.9.1` 📦
- Updated the app’s Xcode marketing version from `8.9.0` to `8.9.1` in the project settings 🛠️
- Fixed the `Main.storyboard` custom module reference for `YOLOView`, changing it from `YOLO` to `UltralyticsYOLO` ✅

### 🎯 Purpose & Impact
- Ensures the iOS app and podspec stay in sync under the new `8.9.1` release number, which helps with cleaner packaging and distribution 🚀
- Resolves a likely integration/runtime issue where Interface Builder was referencing the wrong module name for `YOLOView` 🧩
- Improves reliability for developers using the iOS app or embedding the `UltralyticsYOLO` pod, especially when loading the UI from storyboard files 📱
- Overall, this is a maintenance-focused release with a practical compatibility fix rather than a feature update 🔧