### PR TITLE
Harden CI test warning handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,20 +31,25 @@ jobs:
           chmod +x scripts/download-models.sh && scripts/download-models.sh
 
       - name: Install dependencies
-        run: xcodebuild -resolvePackageDependencies
+        run: swift package resolve
 
       - name: Build and Test
         run: |
           IOS_SIMULATOR=$(xcrun simctl list devices available | grep -E "iPhone.*" | head -1 | sed -E 's/.*\(([A-Z0-9-]+)\).*/\1/')
-          DESTINATION=${IOS_SIMULATOR:+id=$IOS_SIMULATOR}
-          DESTINATION=${DESTINATION:-name=iPhone 14}
+          if [ -z "$IOS_SIMULATOR" ]; then
+            IOS_DEVICE_TYPE=$(xcrun simctl list devicetypes | grep -E "iPhone" | tail -1 | sed -E 's/.*\(([^)]+)\).*/\1/')
+            IOS_RUNTIME=$(xcrun simctl list runtimes available | grep -E "iOS" | tail -1 | sed -E 's/.*\(([^)]+)\).*/\1/')
+            IOS_SIMULATOR=$(xcrun simctl create "CI iPhone" "$IOS_DEVICE_TYPE" "$IOS_RUNTIME")
+          fi
+          DESTINATION="platform=iOS Simulator,id=$IOS_SIMULATOR,arch=arm64"
 
           xcodebuild \
             -scheme UltralyticsYOLO \
             -sdk iphonesimulator \
             -derivedDataPath Build/ \
-            -destination "platform=iOS Simulator,$DESTINATION" \
+            -destination "$DESTINATION" \
             -enableCodeCoverage YES \
+            IPHONEOS_DEPLOYMENT_TARGET=16.0 \
             clean build test
 
       - name: Generate Code Coverage Report
@@ -91,24 +96,24 @@ jobs:
             if [ -s info.lcov ]; then
                 echo "Coverage report generated successfully: info.lcov"
             else
-                echo "WARNING: info.lcov was generated but is empty."
-                touch info.lcov # Ensure file exists for Codecov step
+                echo "ERROR: info.lcov was generated but is empty."
+                exit 1
             fi
           else
             echo "Could not generate coverage report - required binary or profdata file missing or invalid."
             echo "Binary Path: $BINARY_PATH"
             echo "Profdata Path: $PROFDATA_PATH"
-            touch info.lcov # Create empty info.lcov for Codecov
-            echo "Empty info.lcov created as a fallback."
+            exit 1
           fi
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v6
-        if: always()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./info.lcov
           slug: ultralytics/yolo-ios-app
+          disable_search: true
+          plugins: noop
           fail_ci_if_error: false
           handle_no_reports_found: true
 
@@ -126,8 +131,12 @@ jobs:
       - name: Run Periphery
         run: |
           IOS_SIMULATOR=$(xcrun simctl list devices available | grep -E "iPhone.*" | head -1 | sed -E 's/.*\(([A-Z0-9-]+)\).*/\1/')
-          DESTINATION=${IOS_SIMULATOR:+id=$IOS_SIMULATOR}
-          DESTINATION=${DESTINATION:-name=iPhone 14}
+          if [ -z "$IOS_SIMULATOR" ]; then
+            IOS_DEVICE_TYPE=$(xcrun simctl list devicetypes | grep -E "iPhone" | tail -1 | sed -E 's/.*\(([^)]+)\).*/\1/')
+            IOS_RUNTIME=$(xcrun simctl list runtimes available | grep -E "iOS" | tail -1 | sed -E 's/.*\(([^)]+)\).*/\1/')
+            IOS_SIMULATOR=$(xcrun simctl create "CI iPhone" "$IOS_DEVICE_TYPE" "$IOS_RUNTIME")
+          fi
+          DESTINATION="platform=iOS Simulator,id=$IOS_SIMULATOR,arch=arm64"
 
           periphery scan \
             --project YOLOiOSApp/YOLOiOSApp.xcodeproj \
@@ -138,4 +147,4 @@ jobs:
             --format github-actions \
             --strict \
             -- \
-            -destination "platform=iOS Simulator,$DESTINATION"
+            -destination "$DESTINATION"

--- a/Tests/YOLOTests/YOLOSSOTMergeTests.swift
+++ b/Tests/YOLOTests/YOLOSSOTMergeTests.swift
@@ -7,6 +7,22 @@ import XCTest
 @testable import UltralyticsYOLO
 
 final class YOLOSSOTMergeTests: XCTestCase {
+  private final class AsyncResultBox<T>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var result: Result<T, Error>?
+
+    func store(_ result: Result<T, Error>) {
+      lock.lock()
+      defer { lock.unlock() }
+      self.result = result
+    }
+
+    func load() -> Result<T, Error>? {
+      lock.lock()
+      defer { lock.unlock() }
+      return result
+    }
+  }
 
   private func modelURL(_ name: String) throws -> URL {
     let testsDirectory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
@@ -23,7 +39,7 @@ final class YOLOSSOTMergeTests: XCTestCase {
   ) throws -> BasePredictor {
     let expectation = XCTestExpectation(description: "Load \(name)")
     let url = try modelURL(name)
-    var loaded: Result<BasePredictor, Error>?
+    let loaded = AsyncResultBox<BasePredictor>()
 
     BasePredictor.create(
       for: task,
@@ -31,12 +47,12 @@ final class YOLOSSOTMergeTests: XCTestCase {
       useGpu: useGpu,
       numItemsThreshold: numItemsThreshold
     ) { result in
-      loaded = result
+      loaded.store(result)
       expectation.fulfill()
     }
 
     wait(for: [expectation], timeout: 30)
-    return try XCTUnwrap(loaded).get()
+    return try XCTUnwrap(loaded.load()).get()
   }
 
   private func testImage(width: CGFloat = 640, height: CGFloat = 640) -> CIImage {


### PR DESCRIPTION
## Summary
- remove the Swift 6 captured-var warning in async model-load tests with a locked result holder
- run CI model tests with an explicit arm64 simulator destination and iOS 16 deployment target for YOLO26 CoreML resources
- make coverage generation fail on missing or empty LCOV output instead of uploading an empty fallback, and disable Codecov report search when uploading the explicit LCOV file
- use `swift package resolve` for package resolution instead of a generic `xcodebuild -resolvePackageDependencies` call

## Validation
- `swift package resolve`
- `xcodebuild -scheme UltralyticsYOLO -sdk iphonesimulator -derivedDataPath Build/ -destination "platform=iOS Simulator,id=CC69A7E3-91C5-4B4C-894D-FE69ADDB8028,arch=arm64" -enableCodeCoverage YES IPHONEOS_DEPLOYMENT_TARGET=16.0 clean build test` passes 90 tests locally
- local LCOV generation produced a non-empty `info.lcov` (397723 bytes)

Note: Xcode/CoreML still emits simulator framework runtime noise while loading CoreML models locally, but the actionable compiler/CI warnings from the pasted run are addressed here.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🚀 This PR makes the iOS app’s CI pipeline more reliable on GitHub Actions and improves test safety for async model loading in `YOLOSSOTMergeTests`.

### 📊 Key Changes
- 🔧 Replaced `xcodebuild -resolvePackageDependencies` with `swift package resolve` for dependency setup in CI.
- 📱 Improved simulator handling in CI:
  - Detects an available iPhone simulator if one exists.
  - Automatically creates a simulator when none is available.
  - Uses a fixed `platform=iOS Simulator,id=...,arch=arm64` destination for more consistent builds.
- 🏗️ Added `IPHONEOS_DEPLOYMENT_TARGET=16.0` during build and test steps.
- ✅ Tightened code coverage checks:
  - CI now fails if `info.lcov` is empty or coverage data cannot be generated.
  - Removed the fallback behavior that created empty coverage files.
- ☁️ Updated Codecov upload settings with `disable_search: true` and `plugins: noop` for a more explicit upload configuration.
- 🔍 Applied the same improved simulator-selection logic to the Periphery dead-code scan job.
- 🧵 Refactored async test result handling in `YOLOSSOTMergeTests.swift`:
  - Added a thread-safe `AsyncResultBox` using `NSLock`.
  - Replaced direct shared mutable state with locked storage for async callback results.

### 🎯 Purpose & Impact
- 🛠️ Reduces flaky CI failures caused by missing or mismatched iOS simulators in hosted environments.
- 📦 Makes dependency resolution more aligned with Swift Package Manager workflows.
- 📈 Ensures coverage reports are real and usable, instead of silently passing with empty files.
- 🔒 Improves test reliability and thread safety, helping avoid race conditions in async unit tests.
- 👩‍💻 For contributors, this means more predictable builds, clearer CI failures, and easier debugging when something breaks.