### PR TITLE
Add capturesInstanceMasks for live segmentation mask streaming (8.9.2)

### DIFF
--- a/Sources/UltralyticsYOLO/BasePredictor.swift
+++ b/Sources/UltralyticsYOLO/BasePredictor.swift
@@ -41,6 +41,12 @@ public class BasePredictor: Predictor, @unchecked Sendable {
   /// Whether camera predictions should include a copy of the original input image in `YOLOResult`.
   public var capturesOriginalImage = false
 
+  /// Whether realtime (camera) segmentation predictions should materialize per-instance masks
+  /// (`YOLOResult.masks.masks`) in addition to the combined display mask. Off by default to avoid the per-frame cost
+  /// when only the on-screen overlay is needed; consumers (e.g. the Flutter plugin) enable it when a live stream
+  /// explicitly requests individual masks.
+  public var capturesInstanceMasks = false
+
   /// The original camera image captured for the current prediction when `capturesOriginalImage` is enabled.
   var currentOriginalImage: UIImage?
 

--- a/Sources/UltralyticsYOLO/Segmenter.swift
+++ b/Sources/UltralyticsYOLO/Segmenter.swift
@@ -31,6 +31,7 @@ public final class Segmenter: BasePredictor, @unchecked Sendable {
     let capturedModelInputSize = self.modelInputSize
     let capturedLabels = self.labels
     let capturedOriginalImage = self.currentOriginalImage
+    let capturedWantsInstanceMasks = self.capturesInstanceMasks
     let capturedMaskCropRect = inputMaskCropRect(
       maskWidth: capturedMasks.shape[3].intValue,
       maskHeight: capturedMasks.shape[2].intValue,
@@ -45,7 +46,7 @@ public final class Segmenter: BasePredictor, @unchecked Sendable {
           inputWidth: capturedModelInputSize.width,
           inputHeight: capturedModelInputSize.height,
           cropRect: capturedMaskCropRect,
-          returnIndividualMasks: false
+          returnIndividualMasks: capturedWantsInstanceMasks
         )
       else {
         DispatchQueue.main.async { [weak self] in self?.isUpdating = false }

--- a/UltralyticsYOLO.podspec
+++ b/UltralyticsYOLO.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'UltralyticsYOLO'
-  s.version          = '8.9.1'
+  s.version          = '8.9.2'
   s.summary          = 'Ultralytics YOLO core inference for iOS (CoreML/Vision).'
   s.homepage         = 'https://github.com/ultralytics/yolo-ios-app'
   s.license          = { :type => 'AGPL-3.0', :file => 'LICENSE' }

--- a/YOLOiOSApp/YOLOiOSApp.xcodeproj/project.pbxproj
+++ b/YOLOiOSApp/YOLOiOSApp.xcodeproj/project.pbxproj
@@ -386,7 +386,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.9.1;
+				MARKETING_VERSION = 8.9.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ultralytics.iDetection;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -414,7 +414,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.9.1;
+				MARKETING_VERSION = 8.9.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ultralytics.iDetection;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";


### PR DESCRIPTION
Adds a public `BasePredictor.capturesInstanceMasks` flag (default `false`) that gates per-instance mask materialization in the realtime `Segmenter.processObservations` path (which previously hardcoded `returnIndividualMasks: false`). Without it, `YOLOResult.masks.masks` is always empty for camera predictions, so consumers streaming per-instance segmentation masks (the Flutter plugin's `includeMasks` live-stream option) get none. Single-image `predictOnImage` is unaffected (already returns individual masks). Bumps to 8.9.2. Package tests green (90).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Adds an opt-in setting for realtime segmentation to return per-object instance masks, while keeping the faster default behavior for live camera use 🚀

### 📊 Key Changes
- Added a new `capturesInstanceMasks` option to `BasePredictor` 🧩
  - Controls whether live segmentation results include individual instance masks in `YOLOResult.masks.masks`
  - Default is `false` to avoid extra per-frame processing cost
- Updated `Segmenter` to respect this new setting during realtime mask generation 🎥
  - Previously, individual masks were always skipped in this path
  - Now they are generated only when explicitly requested
- Bumped the iOS package/app version from `8.9.1` to `8.9.2` 📦

### 🎯 Purpose & Impact
- Improves flexibility for apps that need more detailed live segmentation output, such as plugins or integrations that use per-instance masks 🛠️
- Preserves performance for most camera-based use cases by leaving the heavier mask generation disabled by default ⚡
- Makes the iOS library better suited for cross-platform consumers, like Flutter integrations, that may need both overlay masks and individual object masks 🔄
- Version bump signals a small feature update with minimal surface-area change and low migration risk ✅