### PR TITLE
Filter iOS coverage before Codecov upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,18 @@ jobs:
             exit 1
           fi
 
+      - name: Filter Coverage Report
+        run: |
+          awk '
+            /^SF:/ {
+              file = $0
+              skip = file ~ /Sources\/UltralyticsYOLO\/(BoundingBoxView|VideoCapture|YOLOCamera|YOLOInfoViewController|YOLOModelDownloader|YOLOView)\.swift$/
+            }
+            !skip { print }
+            /^end_of_record/ { skip = 0 }
+          ' info.lcov > info.filtered.lcov
+          mv info.filtered.lcov info.lcov
+
       - name: Upload to Codecov
         uses: codecov/codecov-action@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,8 @@ jobs:
           awk '
             /^SF:/ {
               file = $0
-              skip = file ~ /Sources\/UltralyticsYOLO\/(BoundingBoxView|VideoCapture|YOLOCamera|YOLOInfoViewController|YOLOModelDownloader|YOLOView)\.swift$/
+              skip = file ~ /Build\/Build\/Intermediates\.noindex\// ||
+                file ~ /Sources\/UltralyticsYOLO\/(BoundingBoxView|VideoCapture|YOLOCamera|YOLOInfoViewController|YOLOModelDownloader|YOLOView)\.swift$/
             }
             !skip { print }
             /^end_of_record/ { skip = 0 }

--- a/Sources/UltralyticsYOLO/ObbDetector.swift
+++ b/Sources/UltralyticsYOLO/ObbDetector.swift
@@ -94,6 +94,9 @@ public final class ObbDetector: BasePredictor, @unchecked Sendable {
     let pointer = feature.dataPointer.bindMemory(
       to: Float.self,
       capacity: feature.count)
+    let strides = feature.strides.map { $0.intValue }
+    let channelStride = strides[1]
+    let anchorStride = strides[2]
     let inputW = Float(modelInputSize.width)
     let inputH = Float(modelInputSize.height)
 
@@ -123,16 +126,17 @@ public final class ObbDetector: BasePredictor, @unchecked Sendable {
 
     // 1) Parallel-extract predictions
     DispatchQueue.concurrentPerform(iterations: numAnchors) { i in
-      let cx = pointerWrapper.pointer[i] / inputW
-      let cy = pointerWrapper.pointer[numAnchors + i] / inputH
-      let w = pointerWrapper.pointer[2 * numAnchors + i] / inputW
-      let h = pointerWrapper.pointer[3 * numAnchors + i] / inputH
+      let anchorOffset = i * anchorStride
+      let cx = pointerWrapper.pointer[anchorOffset] / inputW
+      let cy = pointerWrapper.pointer[channelStride + anchorOffset] / inputH
+      let w = pointerWrapper.pointer[2 * channelStride + anchorOffset] / inputW
+      let h = pointerWrapper.pointer[3 * channelStride + anchorOffset] / inputH
 
       // Find best class & score
       var bestScore: Float = 0
       var bestClass: Int = 0
       for c in 0..<numClasses {
-        let sc = pointerWrapper.pointer[(4 + c) * numAnchors + i]
+        let sc = pointerWrapper.pointer[(4 + c) * channelStride + anchorOffset]
         if sc > bestScore {
           bestScore = sc
           bestClass = c
@@ -140,7 +144,7 @@ public final class ObbDetector: BasePredictor, @unchecked Sendable {
       }
 
       // Angle is the last channel
-      let angleIndex = (4 + numClasses) * numAnchors + i
+      let angleIndex = (4 + numClasses) * channelStride + anchorOffset
       let angle = pointerWrapper.pointer[angleIndex]
 
       // Threshold

--- a/Tests/YOLOTests/YOLOMainTests.swift
+++ b/Tests/YOLOTests/YOLOMainTests.swift
@@ -135,6 +135,20 @@ class YOLOMainTests: XCTestCase {
     XCTAssertNotEqual(cache.cacheKey(for: sourceURL, task: .detect), cache.cacheKey(for: sourceURL))
   }
 
+  func testLoggerEvaluatesMessages() {
+    var emitted = 0
+    func message(_ text: String) -> String {
+      emitted += 1
+      return text
+    }
+
+    YOLOLog.info(message("info"))
+    YOLOLog.warning(message("warning"))
+    YOLOLog.error(message("error"))
+
+    XCTAssertEqual(emitted, 3)
+  }
+
 }
 
 private func makeTestImage(size: CGSize, color: UIColor) -> UIImage {

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,0 @@
-# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
-
-- "Sources/UltralyticsYOLO/VideoCapture.swift"
-- "Sources/UltralyticsYOLO/YOLOCamera.swift"
-- "Sources/UltralyticsYOLO/YOLOInfoViewController.swift"
-- "Sources/UltralyticsYOLO/YOLOModelDownloader.swift"
-- "Sources/UltralyticsYOLO/YOLOView.swift"


### PR DESCRIPTION
## Summary
- remove the root `codecov.yml` file and filter LCOV in CI before Codecov upload
- drop generated Xcode/CoreML build intermediates plus low-signal native UI/camera files from uploaded coverage
- fix traditional OBB decoding to respect `MLMultiArray.strides`, which also restored the focused OBB test
- add a compact logger autoclosure test so diagnostics are covered by meaningful behavior

## Coverage
- raw local LCOV: 57.34% lines (4371/7623)
- filtered Codecov upload: 90.95% lines (4342/4774)

## Validation
- `xcodebuild ... -only-testing:YOLOTests/BasePredictorTests/testObbDetectorDecodesTraditionalTensorAndRunsRotatedNMS test`
- `xcodebuild ... -enableCodeCoverage YES build test` (95 tests passed)
- verified no root `codecov.yml`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR improves iOS app reliability and test reporting by fixing oriented bounding box tensor parsing, adding a small logger test, and cleaning up coverage filtering in CI 🛠️📱

### 📊 Key Changes
- Fixed `ObbDetector.swift` to read model output tensors using actual tensor **strides** instead of assuming a tightly packed layout.
- Updated bounding box extraction logic for:
  - box center coordinates
  - width and height
  - class scores
  - rotation angle
- Added a new unit test in `YOLOMainTests.swift` to verify that log message expressions are actually evaluated when calling `YOLOLog.info`, `YOLOLog.warning`, and `YOLOLog.error` ✅
- Moved coverage exclusions out of the deleted `codecov.yml` file and into the GitHub Actions CI workflow using an `awk` filter.
- Coverage filtering now excludes generated build artifacts and selected UI/camera-related Swift files before uploading results to Codecov 📊

### 🎯 Purpose & Impact
- Improves correctness for oriented bounding box detection, especially when model outputs use non-standard memory layouts or tensor strides 🎯
- Reduces the risk of incorrect detections caused by reading output data from the wrong positions.
- Makes test coverage reporting more accurate and easier to maintain by handling exclusions directly in CI instead of a separate config file 🧹
- Adds a lightweight test safeguard for logging behavior, helping catch regressions in developer tooling.
- Overall, this PR strengthens model output handling and CI reliability, which should lead to more dependable app behavior and cleaner quality metrics 🚀