### PR TITLE
Initialize synthetic OBB tensors

### DIFF
--- a/Tests/YOLOTests/BasePredictorTests.swift
+++ b/Tests/YOLOTests/BasePredictorTests.swift
@@ -482,6 +482,7 @@ private func makeArray(
 ) throws -> MLMultiArray {
   let array = try MLMultiArray(shape: shape.map(NSNumber.init(value:)), dataType: .float32)
   let pointer = array.dataPointer.assumingMemoryBound(to: Float.self)
+  pointer.initialize(repeating: 0, count: array.count)
   let strides = array.strides.map { $0.intValue }
 
   writeValues { indices, value in


### PR DESCRIPTION
## Summary
- zero-initialize synthetic MLMultiArray buffers in the shared test helper so unwritten anchors cannot contain random CI memory
- keeps the OBB stride regression test deterministic after #263

## Validation
- `xcodebuild -scheme UltralyticsYOLO -sdk iphonesimulator -derivedDataPath Build/ -destination "$DESTINATION" -only-testing:YOLOTests/BasePredictorTests/testObbDetectorDecodesTraditionalTensorAndRunsRotatedNMS IPHONEOS_DEPLOYMENT_TARGET=16.0 test`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR improves test reliability by explicitly zero-initializing `MLMultiArray` memory before writing values in `BasePredictorTests.swift`.

### 📊 Key Changes
- Added `pointer.initialize(repeating: 0, count: array.count)` when creating test `MLMultiArray` data.
- Ensures the underlying float buffer starts from a clean, known state before test values are written.
- Change is limited to the test suite in `Tests/YOLOTests/BasePredictorTests.swift`, with no production app logic modified.

### 🎯 Purpose & Impact
- ✅ Prevents flaky or inconsistent test behavior caused by uninitialized memory.
- 🔍 Makes test results more deterministic and easier to trust across devices, environments, and CI runs.
- 🧪 Improves stability of predictor-related tests without affecting the app’s runtime behavior or user-facing features.
- 🚀 Helps developers debug failures more confidently by removing a subtle source of randomness.