### PR TITLE
Add YOLOView.showOverlays for custom overlay rendering (8.9.3)

### DIFF
--- a/Sources/UltralyticsYOLO/YOLOView.swift
+++ b/Sources/UltralyticsYOLO/YOLOView.swift
@@ -62,11 +62,17 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   }
 
   public func onPredict(result: YOLOResult) {
-    // Notify delegate of detection results
+    // Notify consumers of detection results regardless of overlay visibility.
     delegate?.yoloView(self, didReceiveResult: result)
+    onDetection?(result)
+
+    // Consumers drawing their own overlays disable the built-in rendering below via `showOverlays`.
+    guard showOverlays else {
+      clearPredictionOverlays()
+      return
+    }
 
     task == .obb ? showOBBs(predictions: result) : showBoxes(predictions: result)
-    onDetection?(result)
 
     if task == .segment || task == .semantic {
       if let maskImage = task == .segment
@@ -100,6 +106,16 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   }
 
   public var onDetection: ((YOLOResult) -> Void)?
+
+  /// Controls whether the built-in prediction overlays (boxes, masks, pose, classification) are drawn.
+  /// When `false`, inference and the result callbacks (`delegate`, `onDetection`) keep firing, but nothing is
+  /// rendered — letting consumers draw fully custom overlays. Defaults to `true`.
+  public var showOverlays: Bool = true {
+    didSet {
+      if !showOverlays { clearPredictionOverlays() }
+    }
+  }
+
   private var videoCapture: VideoCapture
   private var busy = false
   var task = YOLOTask.detect
@@ -504,6 +520,15 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
         layer.removeFromSuperlayer()
       }
     }
+  }
+
+  /// Hides and clears all built-in prediction overlays (boxes, classification, mask, pose).
+  private func clearPredictionOverlays() {
+    boundingBoxViews.forEach { $0.hide() }
+    removeClassificationLayers()
+    maskLayer?.isHidden = true
+    maskLayer?.contents = nil
+    removeAllSubLayers(parentLayer: poseLayer)
   }
 
   func overlayYOLOClassificationsCALayer(on view: UIView, result: YOLOResult) {

--- a/Sources/UltralyticsYOLO/YOLOView.swift
+++ b/Sources/UltralyticsYOLO/YOLOView.swift
@@ -66,11 +66,9 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     delegate?.yoloView(self, didReceiveResult: result)
     onDetection?(result)
 
-    // Consumers drawing their own overlays disable the built-in rendering below via `showOverlays`.
-    guard showOverlays else {
-      clearPredictionOverlays()
-      return
-    }
+    // Consumers drawing their own overlays disable the built-in rendering below via `showOverlays`;
+    // its `didSet` already cleared anything previously drawn, so just skip.
+    guard showOverlays else { return }
 
     task == .obb ? showOBBs(predictions: result) : showBoxes(predictions: result)
 

--- a/UltralyticsYOLO.podspec
+++ b/UltralyticsYOLO.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'UltralyticsYOLO'
-  s.version          = '8.9.2'
+  s.version          = '8.9.3'
   s.summary          = 'Ultralytics YOLO core inference for iOS (CoreML/Vision).'
   s.homepage         = 'https://github.com/ultralytics/yolo-ios-app'
   s.license          = { :type => 'AGPL-3.0', :file => 'LICENSE' }

--- a/YOLOiOSApp/YOLOiOSApp.xcodeproj/project.pbxproj
+++ b/YOLOiOSApp/YOLOiOSApp.xcodeproj/project.pbxproj
@@ -386,7 +386,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.9.2;
+				MARKETING_VERSION = 8.9.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ultralytics.iDetection;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -414,7 +414,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.9.2;
+				MARKETING_VERSION = 8.9.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ultralytics.iDetection;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";


### PR DESCRIPTION
## Summary

Adds a `showOverlays` toggle to `YOLOView` so consumers can disable the built-in prediction overlays (boxes, OBB, masks, pose, classification) and draw fully custom ones, while inference and the result callbacks (`delegate`, `onDetection`) keep firing. Requested for custom-overlay workflows in ultralytics/yolo-flutter-app#506; the Flutter plugin's iOS fork already ships these exact semantics, so this brings the upstream package to parity.

- `YOLOView.showOverlays` (default `true`): setting `false` clears existing overlays immediately and skips all overlay drawing per frame; callbacks are unaffected.
- `onPredict` now notifies `delegate` and `onDetection` before drawing, then guards the rendering path.
- New private `clearPredictionOverlays()` composes the existing helpers (`BoundingBoxView.hide()`, `removeClassificationLayers()`, mask layer hide/clear, `removeAllSubLayers(poseLayer)`).

Releases **8.9.3**: bumps `UltralyticsYOLO.podspec` and `MARKETING_VERSION` so the merge auto-tags `v8.9.3`, creates the release, and publishes the pod to trunk. Beyond `showOverlays`, 8.9.3 ships the previously-merged but unreleased package changes: the `ObbDetector` strides fix for transposed traditional-OBB tensors, the `YOLOViewDelegate` default no-op for `didReceiveResult`, and the docs/comment accuracy pass (#265).

## Validation

- Package tests on iPhone simulator — **95/95 passed**
- `pod lib lint UltralyticsYOLO.podspec --allow-warnings` — passed validation at 8.9.3
- `xcodebuild` YOLOiOSApp simulator build — succeeded
- `periphery scan --strict` (CI arguments) — no unused code detected
- Independent diff review — no blocking findings

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR adds a new `showOverlays` option to `YOLOView`, letting iOS developers disable built-in prediction drawings while still receiving detection results normally 🎨📱

### 📊 Key Changes
- Added a new public `showOverlays` property to `YOLOView`, defaulting to `true`.
- Detection callbacks now always fire before any overlay drawing logic:
  - `delegate?.yoloView(self, didReceiveResult: result)`
  - `onDetection?(result)`
- Built-in overlay rendering is now skipped when `showOverlays` is set to `false`.
- Added a private `clearPredictionOverlays()` helper to remove existing built-in visuals, including:
  - bounding boxes
  - classification layers
  - masks
  - pose overlays
- Updated inline documentation to clarify that users can keep inference and callbacks while drawing their own custom overlays.
- Bumped the package/app version from `8.9.2` to `8.9.3` 🚀

### 🎯 Purpose & Impact
- Gives app developers more flexibility to build fully custom UI overlays on top of YOLO results without fighting the default renderer 🛠️
- Ensures results are still delivered even when built-in visuals are turned off, improving reliability for custom integrations ✅
- Helps avoid stale boxes, masks, or pose drawings by automatically clearing old overlays when disabled 🧹
- Makes `YOLOView` easier to use in production apps that want custom branding, different visualization styles, or advanced post-processing 🎯
- The version bump signals a small but useful feature release for iOS consumers of the `ultralytics/yolo-ios-app` package 📦