### PR TITLE
Add camera torch toggle to YOLOView (8.9.4)

### DIFF
--- a/Sources/UltralyticsYOLO/YOLOView.swift
+++ b/Sources/UltralyticsYOLO/YOLOView.swift
@@ -139,6 +139,9 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   let selection = UISelectionFeedbackGenerator()
   private let lensControl = UISegmentedControl()
   private let lensCaptionLabel = UILabel()
+  private let torchButton = UIButton()
+  private let torchCaptionLabel = UILabel()
+  private var isTorchOn = false
   private var cameraTransitionView: UIView?
   private var lensDevices = [AVCaptureDevice]()
   private var selectedLensDeviceID: String?
@@ -292,6 +295,8 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   }
 
   public func stop() {
+    // Stopping the capture session turns the hardware torch off; keep the chip truthful.
+    setTorchUI(on: false)
     videoCapture.stop()
   }
 
@@ -694,6 +699,23 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     lensCaptionLabel.textColor = UIColor.white.withAlphaComponent(0.78)
     lensCaptionLabel.font = UIFont.systemFont(ofSize: 11, weight: .medium)
     self.addSubview(lensCaptionLabel)
+
+    torchButton.isHidden = true
+    torchButton.backgroundColor = UIColor.black.withAlphaComponent(0.38)
+    torchButton.layer.cornerRadius = 8
+    torchButton.addTarget(self, action: #selector(torchTapped), for: .touchUpInside)
+    self.addSubview(torchButton)
+
+    torchCaptionLabel.isHidden = true
+    torchCaptionLabel.text = "Torch on"
+    torchCaptionLabel.textColor = .systemYellow
+    torchCaptionLabel.font = UIFont.systemFont(ofSize: 11, weight: .semibold)
+    // Shrink rather than truncate when the clamped frame is a few points short (375pt-wide triple-lens phones),
+    // mirroring the Flutter row's scale-down behavior.
+    torchCaptionLabel.adjustsFontSizeToFitWidth = true
+    torchCaptionLabel.minimumScaleFactor = 0.7
+    self.addSubview(torchCaptionLabel)
+    setTorchUI(on: false)
   }
 
   public override func layoutSubviews() {
@@ -863,6 +885,21 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
       width: controlWidth,
       height: controlHeight
     )
+    // Torch chip sits directly right of the centered lens pill, with its "Torch on" note beside it —
+    // mirrors the Flutter showcase layout (`yolo-flutter-app/lib/widgets/lens_picker.dart`).
+    torchButton.frame = CGRect(
+      x: lensControl.frame.maxX + 6,
+      y: lensControl.frame.minY,
+      width: 41,
+      height: controlHeight
+    )
+    let captionX = torchButton.frame.maxX + 6
+    torchCaptionLabel.frame = CGRect(
+      x: captionX,
+      y: lensControl.frame.minY,
+      width: min(60, max(0, width - captionX)),
+      height: controlHeight
+    )
     lensCaptionLabel.frame = CGRect(
       x: 20,
       y: lensControl.frame.minY - captionHeight - 4,
@@ -977,6 +1014,51 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     }
   }
 
+  /// Turns the torch on/off and returns the actual resulting state (`false` when the active device has no torch or
+  /// configuration fails), keeping the torch chip in sync with the hardware.
+  @discardableResult
+  public func setTorchMode(_ enabled: Bool) -> Bool {
+    var on = false
+    defer { setTorchUI(on: on) }
+    guard let device = videoCapture.captureDevice, device.hasTorch else { return false }
+
+    do {
+      try device.lockForConfiguration()
+      defer {
+        device.unlockForConfiguration()
+      }
+
+      if enabled {
+        try device.setTorchModeOn(level: AVCaptureDevice.maxAvailableTorchLevel)
+      } else {
+        device.torchMode = .off
+      }
+      on = device.torchMode == .on
+      return on
+    } catch {
+      YOLOLog.error("Torch configuration failed: \(error.localizedDescription)")
+      return false
+    }
+  }
+
+  @objc private func torchTapped() {
+    selection.selectionChanged()
+    setTorchMode(!isTorchOn)
+  }
+
+  /// Syncs the torch chip and its "Torch on" note to the given state — bolt glyph in yellow when on, slashed bolt
+  /// in white when off, matching the Flutter showcase torch chip.
+  private func setTorchUI(on: Bool) {
+    isTorchOn = on
+    let config = UIImage.SymbolConfiguration(pointSize: 17, weight: .regular, scale: .default)
+    torchButton.setImage(
+      UIImage(systemName: on ? "bolt.fill" : "bolt.slash.fill", withConfiguration: config),
+      for: .normal)
+    torchButton.tintColor = on ? .systemYellow : .white
+    torchButton.accessibilityLabel = on ? "Turn torch off" : "Turn torch on"
+    torchCaptionLabel.isHidden = torchButton.isHidden || !on
+  }
+
   @objc func playTapped() {
     selection.selectionChanged()
     pausedShareImage = nil
@@ -989,6 +1071,8 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     selection.selectionChanged()
     playButton.isEnabled = true
     pauseButton.isEnabled = false
+    // Stopping the capture session turns the hardware torch off; keep the chip truthful.
+    setTorchUI(on: false)
     videoCapture.captureNextFrame { [weak self] image in
       self?.pausedShareImage = image
       self?.videoCapture.stop()
@@ -1076,6 +1160,9 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
         ?? min(max(activeDevice.videoZoomFactor, self.minimumZoom), self.maximumZoom)
       self.lastZoomFactor = rawZoomFactor
       self.labelZoom.text = self.zoomLabelText(rawZoomFactor: rawZoomFactor, device: activeDevice)
+      // Switching the camera input drops the torch (the new device may not have one); sync the chip
+      // with the actual hardware state so it never reads stale.
+      self.setTorchUI(on: activeDevice.torchMode == .on)
       self.updateLensControl()
     }
   }
@@ -1157,6 +1244,8 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   private func updateLensControlVisibility() {
     lensControl.isHidden = switchCameraButton.isHidden || lensDevices.isEmpty
     lensCaptionLabel.isHidden = lensControl.isHidden
+    torchButton.isHidden = lensControl.isHidden
+    torchCaptionLabel.isHidden = lensControl.isHidden || !isTorchOn
   }
 
   private func lensTitle(for device: AVCaptureDevice) -> String {

--- a/Sources/UltralyticsYOLO/YOLOView.swift
+++ b/Sources/UltralyticsYOLO/YOLOView.swift
@@ -1047,9 +1047,8 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     setTorchMode(!isTorchOn)
   }
 
-  /// Syncs the torch chip and its "Torch on" note to the given state — bolt glyph in yellow when on, slashed bolt
-  /// in white when off, matching the Flutter showcase torch chip. SF Symbols point size is a font size, not an
-  /// icon-box size: the bolt at 13pt renders 13x17, matching Flutter's 17pt icon box (17pt would render 17x22).
+  /// Syncs the torch chip and its "Torch on" note to the given state, matching the Flutter showcase torch chip.
+  /// 13pt is the SF Symbols font size whose rendered bolt matches Flutter's 17pt icon box.
   private func setTorchUI(on: Bool) {
     isTorchOn = on
     let config = UIImage.SymbolConfiguration(pointSize: 13, weight: .regular, scale: .default)

--- a/Sources/UltralyticsYOLO/YOLOView.swift
+++ b/Sources/UltralyticsYOLO/YOLOView.swift
@@ -1246,8 +1246,10 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   private func updateLensControlVisibility() {
     lensControl.isHidden = switchCameraButton.isHidden || lensDevices.isEmpty
     lensCaptionLabel.isHidden = lensControl.isHidden
-    torchButton.isHidden = lensControl.isHidden
-    torchCaptionLabel.isHidden = lensControl.isHidden || !isTorchOn
+    // Hide the torch chip when the active device has no torch (e.g. front camera) — a visible chip
+    // that can't do anything reads as broken.
+    torchButton.isHidden = lensControl.isHidden || videoCapture.captureDevice?.hasTorch != true
+    torchCaptionLabel.isHidden = torchButton.isHidden || !isTorchOn
   }
 
   private func lensTitle(for device: AVCaptureDevice) -> String {

--- a/Sources/UltralyticsYOLO/YOLOView.swift
+++ b/Sources/UltralyticsYOLO/YOLOView.swift
@@ -702,7 +702,8 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
 
     torchButton.isHidden = true
     torchButton.backgroundColor = UIColor.black.withAlphaComponent(0.38)
-    torchButton.layer.cornerRadius = 8
+    // Capsule, matching the lens pill next to it (UISegmentedControl renders as a capsule).
+    torchButton.layer.cornerRadius = 17
     torchButton.addTarget(self, action: #selector(torchTapped), for: .touchUpInside)
     self.addSubview(torchButton)
 
@@ -1047,10 +1048,11 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
   }
 
   /// Syncs the torch chip and its "Torch on" note to the given state — bolt glyph in yellow when on, slashed bolt
-  /// in white when off, matching the Flutter showcase torch chip.
+  /// in white when off, matching the Flutter showcase torch chip. SF Symbols point size is a font size, not an
+  /// icon-box size: the bolt at 13pt renders 13x17, matching Flutter's 17pt icon box (17pt would render 17x22).
   private func setTorchUI(on: Bool) {
     isTorchOn = on
-    let config = UIImage.SymbolConfiguration(pointSize: 17, weight: .regular, scale: .default)
+    let config = UIImage.SymbolConfiguration(pointSize: 13, weight: .regular, scale: .default)
     torchButton.setImage(
       UIImage(systemName: on ? "bolt.fill" : "bolt.slash.fill", withConfiguration: config),
       for: .normal)

--- a/UltralyticsYOLO.podspec
+++ b/UltralyticsYOLO.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'UltralyticsYOLO'
-  s.version          = '8.9.3'
+  s.version          = '8.9.4'
   s.summary          = 'Ultralytics YOLO core inference for iOS (CoreML/Vision).'
   s.homepage         = 'https://github.com/ultralytics/yolo-ios-app'
   s.license          = { :type => 'AGPL-3.0', :file => 'LICENSE' }

--- a/YOLOiOSApp/YOLOiOSApp.xcodeproj/project.pbxproj
+++ b/YOLOiOSApp/YOLOiOSApp.xcodeproj/project.pbxproj
@@ -386,7 +386,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.9.3;
+				MARKETING_VERSION = 8.9.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ultralytics.iDetection;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -414,7 +414,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.9.3;
+				MARKETING_VERSION = 8.9.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ultralytics.iDetection;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/YOLOiOSApp/YOLOiOSApp/ExternalDisplay/ViewController+ExternalDisplay.swift
+++ b/YOLOiOSApp/YOLOiOSApp/ExternalDisplay/ViewController+ExternalDisplay.swift
@@ -123,6 +123,8 @@ extension ViewController {
         self.yoloView.shareButton,
         self.yoloView.infoButton,
       ].forEach { $0.isHidden = false }
+      // Lens and torch controls derive their visibility from switchCameraButton during layout.
+      self.yoloView.setNeedsLayout()
 
       self.yoloView.resume()
       self.yoloView.setInferenceFlag(ok: true)

--- a/YOLOiOSApp/YOLOiOSApp/ExternalDisplay/ViewController+ExternalDisplay.swift
+++ b/YOLOiOSApp/YOLOiOSApp/ExternalDisplay/ViewController+ExternalDisplay.swift
@@ -75,6 +75,8 @@ extension ViewController {
           self.yoloView.shareButton,
           self.yoloView.infoButton,
         ].forEach { $0.isHidden = true }
+        // Lens and torch controls derive their visibility from switchCameraButton during layout.
+        self.yoloView.setNeedsLayout()
         self.modelSegmentedControl.setNeedsLayout()
         self.modelSegmentedControl.layoutIfNeeded()
       }


### PR DESCRIPTION
Ports the camera torch (flashlight) support from the Flutter plugin (ultralytics/yolo-flutter-app#435, ultralytics/yolo-flutter-app#501) so both frontends stay at feature parity.

## UI (matches the Flutter showcase)

- Torch chip sits directly right of the centered lens pill with a "Torch on" note beside it — same position, glyphs, and visual tokens as the Flutter `LensPicker`/torch chip: `bolt.fill` in `systemYellow` when on, `bolt.slash.fill` in white when off, black 0.38 chip with 8pt corner radius, 6pt gaps, 11pt semibold yellow note, selection haptic on tap.
- The lens pill stays centered on screen (the Flutter row balances the trailing torch with an invisible counterweight; the UIKit layout keeps the pill centered and hangs the chip off its right edge — same visual result).
- The note clamps to the screen edge and scales down rather than clipping on narrow triple-lens phones (375pt iPhone 11 Pro class), mirroring the Flutter row's `FittedBox` scale-down.
- Visibility follows the lens row, so it auto-hides on the external display path; that path now also calls `setNeedsLayout()` so the lens/torch row hides immediately when camera controls are hidden.

## API

- `YOLOView.setTorchMode(_:) -> Bool` (public, `@discardableResult`) — same contract as the Flutter plugin's native implementation: turns the torch on at `maxAvailableTorchLevel` or off, returns the actual resulting hardware state (`false` when the active device has no torch, e.g. front cameras, or configuration fails), and keeps the chip in sync from a single source of truth.

## Behavior

- Switching cameras re-syncs the chip from the real hardware state, so flipping to the front camera resets it (the torch drops with the input switch) while in-cluster lens changes that ramp zoom on the same virtual device preserve it.
- Pause/stop reset the chip since stopping the capture session turns the hardware torch off.

Releases 8.9.4 (podspec + MARKETING_VERSION). Built and tested on iOS Simulator (95 tests pass); Periphery strict scan clean.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR adds an in-app camera torch toggle to the iOS YOLO view 💡, improves UI state syncing when cameras or playback states change, and bumps the app/package version to `8.9.4` 📦.

### 📊 Key Changes
- Added a new **torch button** and **"Torch on" caption** to `YOLOView` for supported camera devices 💡
- Implemented `setTorchMode(_:)` to safely turn the device torch on/off and keep the UI aligned with the actual hardware state
- Added torch state updates when:
  - stopping the camera session
  - pausing capture
  - switching camera devices
- Automatically **hides the torch control** when the active camera does not support a torch, such as some front cameras 👀
- Updated layout so the torch control appears beside the lens selector, matching the app’s existing control style and Flutter showcase layout 🎨
- Improved accessibility by updating the torch button label based on its current action
- Fixed external display behavior so lens/torch visibility refreshes correctly when UI controls are hidden or restored 🖥️
- Bumped the CocoaPods and app marketing version from `8.9.3` to `8.9.4` 🚀

### 🎯 Purpose & Impact
- Makes the iOS app more useful in **low-light scenarios** by letting users control the camera torch directly from the interface 🌙
- Prevents confusing or stale UI by ensuring the torch indicator always reflects the real hardware state ✅
- Avoids showing non-functional controls on unsupported cameras, improving clarity and usability 👍
- Keeps the iOS experience more visually consistent with related Ultralytics app interfaces 🔄
- Delivers a small but practical feature update with better polish, especially for users switching cameras, pausing capture, or using external displays 📱