### PR TITLE
Validate and retry model downloads in download-models.sh

### DIFF
--- a/scripts/download-models.sh
+++ b/scripts/download-models.sh
@@ -39,9 +39,23 @@ process_model() {
     # Remove existing model directory if present
     rm -rf "$model_path"
 
-    # Download the model
+    # Download the model: -f fails on HTTP errors, --retry covers transient network/server failures,
+    # and unzip -t catches truncated or corrupt archives before extraction
     echo "Downloading $model_name..."
-    curl -L "$BASE_URL/$model_name.mlpackage.zip" -o "$zip_path" --progress-bar
+    local attempt
+    for attempt in 1 2 3; do
+      if curl -fL --retry 3 --connect-timeout 15 "$BASE_URL/$model_name.mlpackage.zip" -o "$zip_path" --progress-bar \
+        && unzip -tqq "$zip_path" > /dev/null; then
+        break
+      fi
+      rm -f "$zip_path"
+      if [[ $attempt -eq 3 ]]; then
+        echo "❌ Failed to download a valid $model_name archive after 3 attempts"
+        exit 1
+      fi
+      echo "⚠️ $model_name download failed or archive invalid (attempt $attempt), retrying..."
+      sleep 5
+    done
 
     # Extract to temp directory to handle nested structure
     local tmp_dir="$OUTPUT_DIR/_tmp_extract_$$"
@@ -65,8 +79,13 @@ process_model() {
     # Clean up
     rm -rf "$tmp_dir" "$zip_path"
 
-    # Quick verification
-    [ -f "$model_path/Manifest.json" ] && echo "✅ Model $model_name ready" || echo "⚠️ Model $model_name may be incomplete"
+    # Verify extraction; remove the bad directory so a re-run re-downloads instead of skipping it
+    if [[ ! -f "$model_path/Manifest.json" ]]; then
+      rm -rf "$model_path"
+      echo "❌ Model $model_name is incomplete (missing Manifest.json)"
+      exit 1
+    fi
+    echo "✅ Model $model_name ready"
   fi
 
   # Copy to app model directory if not present


### PR DESCRIPTION
## Summary

CI failed on `macos-26-arm64` when `yolo26n-cls.mlpackage.zip` downloaded as a truncated/invalid archive but `curl` exited 0, so the script only blew up later at `unzip` with a cryptic exit code 9 ([failing run log excerpt](https://github.com/ultralytics/yolo-ios-app/actions)):

```
End-of-central-directory signature not found.  Either this file is not a zipfile...
##[error]Process completed with exit code 9.
```

Root cause: `curl -L` without `-f` saves whatever the server returns (error page, truncated body) and reports success, and the script never validates the archive before extracting.

## Changes

`scripts/download-models.sh`:

- `curl -fL --retry 3 --connect-timeout 15` — fail on HTTP error responses and retry transient network/server failures at the curl level.
- Validate each downloaded archive with `unzip -t` before extraction; on failure, delete the bad zip and re-download, up to 3 attempts, then fail with a clear error.
- Make the post-extraction `Manifest.json` check a hard failure that removes the bad `.mlpackage` directory — previously it printed a warning, exited 0, and left a broken cached model that the existence guard would skip forever on re-runs.

## Testing

- Happy path: deleted a cached model, re-ran the script — downloads, validates, and extracts normally.
- Failure path: stubbed `curl` to write a non-zip body with exit 0 — script retries 3 times with clear warnings, then exits 1 with `❌ Failed to download a valid yolo26n-cls archive after 3 attempts` instead of unzip's exit 9.
- `shellcheck` clean.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔒 This PR makes model downloads in the iOS app setup script much more reliable by adding retries, archive validation, and stricter failure checks.

### 📊 Key Changes
- Added a retry loop to `scripts/download-models.sh` that attempts each model download up to 3 times.
- Updated `curl` usage to:
  - fail on HTTP errors with `-f`
  - follow redirects with `-L`
  - retry transient failures
  - enforce a connection timeout
- Added ZIP archive validation with `unzip -tqq` before extraction to catch corrupt or incomplete downloads early. 📦
- If a download attempt fails or the archive is invalid, the script now deletes the bad ZIP file and retries after a short delay. 🔁
- Strengthened post-extraction verification:
  - the script now checks for `Manifest.json`
  - if missing, it removes the incomplete model directory and exits with an error
- Replaced the previous soft warning for incomplete models with a hard failure, preventing broken model packages from being treated as usable. ✅

### 🎯 Purpose & Impact
- Improves reliability when downloading CoreML model packages, especially on unstable networks or when server issues occur. 🌐
- Prevents corrupted or partial model files from being extracted and silently reused later.
- Makes failures more visible and easier to diagnose by stopping early with clear error messages. 🚨
- Reduces the chance of shipping or testing the app with incomplete models, which should lead to fewer runtime issues for developers and users.
- Helps ensure re-running the script produces clean, valid model downloads instead of skipping over broken files. 🛠️