### PR TITLE
Bump codecov/codecov-action from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
           mv info.filtered.lcov info.lcov
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./info.lcov


### PR DESCRIPTION
Bump codecov/codecov-action from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the GitHub Actions CI workflow to use `codecov/codecov-action@v7` instead of `@v6` for uploading code coverage reports.

### 📊 Key Changes
- ⬆️ Upgraded the Codecov GitHub Action in `.github/workflows/ci.yml`
- 🔁 Changed coverage upload step from `codecov/codecov-action@v6` to `codecov/codecov-action@v7`
- 🧪 No app code or model functionality was changed; this is a CI/CD maintenance update

### 🎯 Purpose & Impact
- 🛠️ Keeps the repository’s CI pipeline up to date with the latest Codecov GitHub Action version
- 🔒 May improve reliability, security, and compatibility for coverage reporting in GitHub Actions
- 📈 Helps maintain accurate test coverage uploads without affecting the iOS app’s user-facing behavior
- ✅ Low-risk change with minimal impact on developers beyond a more current CI setup