### PR TITLE
Fix Codecov OIDC upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ concurrency:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   test:
@@ -122,13 +123,12 @@ jobs:
       - name: Upload to Codecov
         uses: codecov/codecov-action@v7
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./info.lcov
           slug: ultralytics/yolo-ios-app
+          use_oidc: true
           disable_search: true
           plugins: noop
-          fail_ci_if_error: false
-          handle_no_reports_found: true
+          fail_ci_if_error: true
 
   periphery:
     runs-on: macos-26

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![Ultralytics Actions](https://github.com/ultralytics/yolo-ios-app/actions/workflows/format.yml/badge.svg)](https://github.com/ultralytics/yolo-ios-app/actions/workflows/format.yml)
 [![CI](https://github.com/ultralytics/yolo-ios-app/actions/workflows/ci.yml/badge.svg)](https://github.com/ultralytics/yolo-ios-app/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/ultralytics/yolo-ios-app/branch/main/graph/badge.svg)](https://codecov.io/gh/ultralytics/yolo-ios-app)
+[![codecov](https://codecov.io/github/ultralytics/yolo-ios-app/branch/main/graph/badge.svg)](https://app.codecov.io/github/ultralytics/yolo-ios-app)
 
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
 [![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,7 +6,7 @@
 
 [![Ultralytics Actions](https://github.com/ultralytics/yolo-ios-app/actions/workflows/format.yml/badge.svg)](https://github.com/ultralytics/yolo-ios-app/actions/workflows/format.yml)
 [![CI](https://github.com/ultralytics/yolo-ios-app/actions/workflows/ci.yml/badge.svg)](https://github.com/ultralytics/yolo-ios-app/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/ultralytics/yolo-ios-app/branch/main/graph/badge.svg)](https://codecov.io/gh/ultralytics/yolo-ios-app)
+[![codecov](https://codecov.io/github/ultralytics/yolo-ios-app/branch/main/graph/badge.svg)](https://app.codecov.io/github/ultralytics/yolo-ios-app)
 
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
 [![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)


### PR DESCRIPTION
## Summary
- update README Codecov badges to the app.codecov.io target and codecov.io/github badge URL
- switch Codecov upload to GitHub OIDC auth
- make Codecov upload failures fail CI while preserving explicit info.lcov upload settings

## Validation
- ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f); puts "parsed #{f}" }'
- actionlint .github/workflows/ci.yml
- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔐 This PR modernizes Codecov integration in the iOS app CI workflow, improving security, reliability, and documentation links.

### 📊 Key Changes
- Added `id-token: write` permission in GitHub Actions to support secure Codecov authentication with OIDC 🔑
- Removed the `CODECOV_TOKEN` dependency from the CI workflow, replacing it with `use_oidc: true` for tokenless uploads 🛡️
- Made Codecov upload failures break CI by changing `fail_ci_if_error` from `false` to `true` ✅
- Removed `handle_no_reports_found: true`, tightening coverage reporting expectations 📈
- Updated Codecov badge and project links in both `README.md` and `README.zh-CN.md` to the newer Codecov URL format 🔗

### 🎯 Purpose & Impact
- Improves CI security by avoiding long-lived secrets for coverage uploads 🔒
- Makes coverage reporting more trustworthy by surfacing upload problems instead of silently ignoring them 🚨
- Helps maintainers catch missing or broken test coverage reports earlier in development 🧪
- Keeps project documentation current, so users land on the correct Codecov pages from the README 📘
- May cause CI to fail more often when coverage reporting is misconfigured, but this should lead to faster fixes and a healthier pipeline ⚙️