### PR TITLE
Scope Codecov OIDC permission to test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,14 @@ concurrency:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   test:
     runs-on: macos-26
     timeout-minutes: 25
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
- keep workflow-level permissions at `contents: read`
- move `id-token: write` to the `test` job that runs `codecov/codecov-action`
- leave Swift build/test and coverage generation unchanged

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "YAML OK"'`
- `actionlint .github/workflows/ci.yml`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔐 This PR tightens GitHub Actions permissions by limiting `id-token` access to only the CI test job that needs it.

### 📊 Key Changes
- Moved `id-token: write` permission out of the global workflow permissions block in `.github/workflows/ci.yml`.
- Added a job-specific `permissions` section under the `test` job.
- Kept global workflow permissions minimal with only `contents: read`.
- Preserved the `test` job’s existing behavior while making permission scope more explicit.

### 🎯 Purpose & Impact
- Improves security by following the principle of least privilege 🔒.
- Reduces the chance of unnecessary token access across other workflow jobs or future additions.
- Makes the CI configuration clearer and easier to maintain 🛠️.
- Has little to no impact on normal app development, but strengthens the repository’s automation setup and security posture ✅