### PR TITLE
8.9.6 - Expose capture session preset on YOLOView

### DIFF
--- a/Sources/UltralyticsYOLO/YOLOView.swift
+++ b/Sources/UltralyticsYOLO/YOLOView.swift
@@ -285,7 +285,8 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     guard !busy else { return }
     busy = true
     videoCapture.setUp(
-      sessionPreset: captureSessionPreset, position: position, videoOrientation: currentVideoOrientation()
+      sessionPreset: captureSessionPreset, position: position,
+      videoOrientation: currentVideoOrientation()
     ) {
       [weak self] success in
       Task { @MainActor in

--- a/Sources/UltralyticsYOLO/YOLOView.swift
+++ b/Sources/UltralyticsYOLO/YOLOView.swift
@@ -265,15 +265,27 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     }
   }
 
+  /// Capture session preset for the camera feed (default `.hd1280x720`).
+  ///
+  /// The default captures at 720p rather than `.photo`: full-sensor frames must be downscaled to the model input
+  /// every frame — the dominant preprocessing cost — and 720p roughly doubles sustained throughput with no accuracy
+  /// change for standard 640px models. Models with larger inputs picking out small objects can request a higher
+  /// preset (e.g. `.hd1920x1080`); unsupported presets fall back to `.high` then `.photo`. Changing this while the
+  /// camera is running restarts the session with the new preset.
+  public var captureSessionPreset: AVCaptureSession.Preset = .hd1280x720 {
+    didSet {
+      guard oldValue != captureSessionPreset, videoCapture.previewLayer != nil else { return }
+      let position = videoCapture.captureDevice?.position ?? .back
+      videoCapture.stop()
+      start(position: position)
+    }
+  }
+
   private func start(position: AVCaptureDevice.Position) {
     guard !busy else { return }
     busy = true
-    // Capture at 720p rather than `.photo`. `.photo` delivers full-sensor (~2 MP) frames that must be downscaled to
-    // the model's 640 input every frame — the dominant preprocessing cost. 720p roughly halves per-frame work and
-    // doubles sustained throughput on-device with no change to detection accuracy (the model always sees a 640 input).
-    // The letterbox pipeline is aspect-agnostic, so this 16:9 stream is handled the same as the previous 4:3 `.photo`.
     videoCapture.setUp(
-      sessionPreset: .hd1280x720, position: position, videoOrientation: currentVideoOrientation()
+      sessionPreset: captureSessionPreset, position: position, videoOrientation: currentVideoOrientation()
     ) {
       [weak self] success in
       Task { @MainActor in

--- a/UltralyticsYOLO.podspec
+++ b/UltralyticsYOLO.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'UltralyticsYOLO'
-  s.version          = '8.9.5'
+  s.version          = '8.9.6'
   s.summary          = 'Ultralytics YOLO core inference for iOS (CoreML/Vision).'
   s.homepage         = 'https://github.com/ultralytics/yolo-ios-app'
   s.license          = { :type => 'AGPL-3.0', :file => 'LICENSE' }

--- a/YOLOiOSApp/YOLOiOSApp.xcodeproj/project.pbxproj
+++ b/YOLOiOSApp/YOLOiOSApp.xcodeproj/project.pbxproj
@@ -386,7 +386,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.9.5;
+				MARKETING_VERSION = 8.9.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ultralytics.iDetection;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -414,7 +414,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.9.5;
+				MARKETING_VERSION = 8.9.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ultralytics.iDetection;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";


### PR DESCRIPTION
`YOLOView` hardcodes the `.hd1280x720` capture preset, so apps running models with inputs larger than 720p cannot request more sensor detail for small-object detection — the same class of limitation reported against the Android plugin in ultralytics/yolo-flutter-app#529 (where CameraX capped analysis frames at ~640x480).

This exposes the preset that `VideoCapture` already supports:

- `captureSessionPreset` on `YOLOView`, default unchanged (`.hd1280x720`)
- unsupported presets fall back through `.high` then `.photo` (existing `canSetSessionPreset` guard)
- changing it while running restarts the session with the new preset
- patch version bump to 8.9.6 for a CocoaPods release

Verified: package builds for the iOS simulator; default path is untouched (same preset constant, now sourced from the property).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR adds a configurable camera capture quality setting to the iOS YOLO view, making it easier to balance speed 🚀 and image detail 🔍, while also bumping the package version to `8.9.6`.

### 📊 Key Changes
- Added a new public `captureSessionPreset` property in `YOLOView.swift`.
- Set the default camera capture preset to `AVCaptureSession.Preset.hd1280x720` instead of hardcoding it internally.
- Made the camera session automatically restart when this preset changes while the camera is running.
- Documented why 720p is the default: it reduces per-frame preprocessing work and can improve real-time throughput without hurting accuracy for standard 640px models.
- Clarified that higher presets such as `1080p` may still be useful for larger-input models or small-object detection.
- Updated the library and app version from `8.9.5` to `8.9.6` 📦.

### 🎯 Purpose & Impact
- Gives developers more control over camera performance and quality tradeoffs 🎛️.
- Improves flexibility for different model sizes and use cases, especially when detecting smaller objects.
- Helps maintain better real-time performance on-device by keeping 720p as the sensible default ⚡.
- Makes the iOS integration more configurable without changing the default behavior for most users.
- Signals a small release update with the new feature through the version bump ✅