### PR TITLE
8.9.7 - Keep semantic postprocess fast in debug builds

### DIFF
--- a/Sources/UltralyticsYOLO/SemanticSegmenter.swift
+++ b/Sources/UltralyticsYOLO/SemanticSegmenter.swift
@@ -280,13 +280,17 @@ public final class SemanticSegmenter: BasePredictor, @unchecked Sendable {
     defer { planes.deallocate() }
 
     var srcF = vImage_Buffer(
-      data: indices, height: height, width: width, rowBytes: outputWidth * MemoryLayout<Float>.stride)
+      data: indices, height: height, width: width,
+      rowBytes: outputWidth * MemoryLayout<Float>.stride)
     var index8 = vImage_Buffer(data: planes, height: height, width: width, rowBytes: outputWidth)
     vImageConvert_PlanarFtoPlanar8(&srcF, &index8, 255, 0, vImage_Flags(kvImageNoFlags))
 
-    var red = vImage_Buffer(data: planes + count, height: height, width: width, rowBytes: outputWidth)
-    var green = vImage_Buffer(data: planes + count * 2, height: height, width: width, rowBytes: outputWidth)
-    var blue = vImage_Buffer(data: planes + count * 3, height: height, width: width, rowBytes: outputWidth)
+    var red = vImage_Buffer(
+      data: planes + count, height: height, width: width, rowBytes: outputWidth)
+    var green = vImage_Buffer(
+      data: planes + count * 2, height: height, width: width, rowBytes: outputWidth)
+    var blue = vImage_Buffer(
+      data: planes + count * 3, height: height, width: width, rowBytes: outputWidth)
     vImageTableLookUp_Planar8(&index8, &red, &rTable, vImage_Flags(kvImageNoFlags))
     vImageTableLookUp_Planar8(&index8, &green, &gTable, vImage_Flags(kvImageNoFlags))
     vImageTableLookUp_Planar8(&index8, &blue, &bTable, vImage_Flags(kvImageNoFlags))
@@ -296,7 +300,8 @@ public final class SemanticSegmenter: BasePredictor, @unchecked Sendable {
     pixels.withUnsafeMutableBytes { rawBuffer in
       var rgba = vImage_Buffer(
         data: rawBuffer.baseAddress, height: height, width: width, rowBytes: outputWidth * 4)
-      vImageConvert_Planar8toARGB8888(&red, &green, &blue, &index8, &rgba, vImage_Flags(kvImageNoFlags))
+      vImageConvert_Planar8toARGB8888(
+        &red, &green, &blue, &index8, &rgba, vImage_Flags(kvImageNoFlags))
     }
   }
 

--- a/Sources/UltralyticsYOLO/SemanticSegmenter.swift
+++ b/Sources/UltralyticsYOLO/SemanticSegmenter.swift
@@ -8,6 +8,7 @@
 //  individual object instances. It supports both [1, C, H, W] and [1, H, W, C] tensor layouts, removes letterbox
 //  padding via the input mask crop rect, and renders a color overlay for visualization.
 
+import Accelerate
 import CoreML
 import Foundation
 import UIKit
@@ -91,16 +92,50 @@ public final class SemanticSegmenter: BasePredictor, @unchecked Sendable {
     guard outputWidth > 0, outputHeight > 0 else { return nil }
 
     let outCount = outputWidth * outputHeight
-    var classMap = [Int](repeating: 0, count: outCount)
+    var classMap = [Int32](repeating: 0, count: outCount)
     var pixels = Data(count: outCount * 4)
     let colors = semanticColors(classCount: classCount == 1 ? 2 : classCount)
     let classStride = isClassMap ? 0 : (isNCHW ? strides[1] : strides[3])
     let rowStride = isClassMap ? strides[1] : (isNCHW ? strides[2] : strides[1])
     let colStride = isClassMap ? strides[2] : (isNCHW ? strides[3] : strides[2])
 
+    if isClassMap, colStride == 1 {
+      // The NPU already did the argmax - gather, clamp, and paint the per-pixel class indices entirely through
+      // vDSP/vImage. Full-resolution maps are ~1M pixels per frame, and Accelerate runs vectorized C, so this
+      // stays fast even in -Onone debug builds where a scalar Swift sweep costs ~100 ms.
+      var staged = [Float](repeating: 0, count: outCount)
+      staged.withUnsafeMutableBufferPointer { dst in
+        switch logits.dataType {
+        case .int32:
+          let p = logits.dataPointer.assumingMemoryBound(to: Int32.self)
+          for y in 0..<outputHeight {
+            vDSP_vflt32(
+              p + (y + outputY) * rowStride + outputX, 1,
+              dst.baseAddress! + y * outputWidth, 1, vDSP_Length(outputWidth))
+          }
+        default:
+          let p = logits.dataPointer.assumingMemoryBound(to: Float.self)
+          for y in 0..<outputHeight {
+            (dst.baseAddress! + y * outputWidth)
+              .update(from: p + (y + outputY) * rowStride + outputX, count: outputWidth)
+          }
+        }
+        var low: Float = 0
+        var high = Float(classCount - 1)
+        vDSP_vclip(dst.baseAddress!, 1, &low, &high, dst.baseAddress!, 1, vDSP_Length(outCount))
+        classMap.withUnsafeMutableBufferPointer { cm in
+          vDSP_vfix32(dst.baseAddress!, 1, cm.baseAddress!, 1, vDSP_Length(outCount))
+        }
+        paintPixels(
+          fromClampedIndices: dst.baseAddress!, colors: colors,
+          outputWidth: outputWidth, outputHeight: outputHeight, pixels: &pixels)
+      }
+      return SemanticMask(
+        classMap: classMap, width: outputWidth, height: outputHeight,
+        maskImage: makeImage(fromRGBA: pixels, width: outputWidth, height: outputHeight))
+    }
     if isClassMap {
-      // The NPU already did the argmax - just read the per-pixel class indices (dtype depends on the runtime).
-      // Typed tight loops, not a per-pixel closure: full-resolution maps are ~1M pixels per frame.
+      // Non-contiguous class-map rows (not produced by Core ML in practice): scalar fallback
       classMap.withUnsafeMutableBufferPointer { cm in
         switch logits.dataType {
         case .int32:
@@ -109,7 +144,7 @@ public final class SemanticSegmenter: BasePredictor, @unchecked Sendable {
             let srcRow = (y + outputY) * rowStride + outputX * colStride
             let outRow = y * outputWidth
             for x in 0..<outputWidth {
-              cm[outRow + x] = min(max(Int(p[srcRow + x * colStride]), 0), classCount - 1)
+              cm[outRow + x] = Int32(min(max(Int(p[srcRow + x * colStride]), 0), classCount - 1))
             }
           }
         default:
@@ -118,7 +153,7 @@ public final class SemanticSegmenter: BasePredictor, @unchecked Sendable {
             let srcRow = (y + outputY) * rowStride + outputX * colStride
             let outRow = y * outputWidth
             for x in 0..<outputWidth {
-              cm[outRow + x] = min(max(Int(p[srcRow + x * colStride]), 0), classCount - 1)
+              cm[outRow + x] = Int32(min(max(Int(p[srcRow + x * colStride]), 0), classCount - 1))
             }
           }
         }
@@ -140,7 +175,7 @@ public final class SemanticSegmenter: BasePredictor, @unchecked Sendable {
         let srcRow = (y + outputY) * rowStride + outputX * colStride
         let outRow = y * outputWidth
         for x in 0..<outputWidth {
-          classMap[outRow + x] = pointer[srcRow + x * colStride] > binaryThreshold ? 1 : 0
+          classMap[outRow + x] = pointer[srcRow + x * colStride] > binaryThreshold ? 1 : 0 as Int32
         }
       }
     } else {
@@ -157,7 +192,7 @@ public final class SemanticSegmenter: BasePredictor, @unchecked Sendable {
                 let oi = outRow + x
                 if score > bb[oi] {
                   bb[oi] = score
-                  cm[oi] = c
+                  cm[oi] = Int32(c)
                 }
               }
             }
@@ -171,24 +206,19 @@ public final class SemanticSegmenter: BasePredictor, @unchecked Sendable {
       outputWidth: outputWidth, outputHeight: outputHeight)
   }
 
-  /// Paints the RGBA buffer from a resolved class map in one sequential sweep and packages the result.
+  /// Paints the RGBA buffer from a resolved class map and packages the result.
   private func finishSemanticMask(
-    classMap: [Int], pixels: inout Data, colors: [(red: UInt8, green: UInt8, blue: UInt8)],
+    classMap: [Int32], pixels: inout Data, colors: [(red: UInt8, green: UInt8, blue: UInt8)],
     outputWidth: Int, outputHeight: Int
   ) -> SemanticMask {
-    // One packed RGBA word per class, written through a UInt32 view (arm64 is little-endian: R | G<<8 | B<<16)
-    let lut = colors.map {
-      UInt32($0.red) | UInt32($0.green) << 8 | UInt32($0.blue) << 16 | 0xFF00_0000
-    }
-    pixels.withUnsafeMutableBytes { rawBuffer in
-      let pixelBuffer = rawBuffer.bindMemory(to: UInt32.self)
+    var staged = [Float](repeating: 0, count: classMap.count)
+    staged.withUnsafeMutableBufferPointer { dst in
       classMap.withUnsafeBufferPointer { cm in
-        lut.withUnsafeBufferPointer { colorWords in
-          for i in 0..<cm.count {
-            pixelBuffer[i] = colorWords[cm[i]]
-          }
-        }
+        vDSP_vflt32(cm.baseAddress!, 1, dst.baseAddress!, 1, vDSP_Length(cm.count))
       }
+      paintPixels(
+        fromClampedIndices: dst.baseAddress!, colors: colors,
+        outputWidth: outputWidth, outputHeight: outputHeight, pixels: &pixels)
     }
 
     return SemanticMask(
@@ -224,6 +254,50 @@ public final class SemanticSegmenter: BasePredictor, @unchecked Sendable {
     }
     colorCache = (classCount, colors)
     return colors
+  }
+
+  /// Maps clamped float class indices to RGBA through vImage lookup tables - vectorized C, so debug builds
+  /// pay no Swift -Onone penalty on the ~1M-pixel sweep.
+  private func paintPixels(
+    fromClampedIndices indices: UnsafeMutablePointer<Float>,
+    colors: [(red: UInt8, green: UInt8, blue: UInt8)],
+    outputWidth: Int, outputHeight: Int, pixels: inout Data
+  ) {
+    var rTable = [UInt8](repeating: 0, count: 256)
+    var gTable = [UInt8](repeating: 0, count: 256)
+    var bTable = [UInt8](repeating: 0, count: 256)
+    for i in 0..<256 {
+      let color = colors[i % colors.count]
+      rTable[i] = color.red
+      gTable[i] = color.green
+      bTable[i] = color.blue
+    }
+
+    let count = outputWidth * outputHeight
+    let height = vImagePixelCount(outputHeight)
+    let width = vImagePixelCount(outputWidth)
+    let planes = UnsafeMutablePointer<UInt8>.allocate(capacity: count * 4)
+    defer { planes.deallocate() }
+
+    var srcF = vImage_Buffer(
+      data: indices, height: height, width: width, rowBytes: outputWidth * MemoryLayout<Float>.stride)
+    var index8 = vImage_Buffer(data: planes, height: height, width: width, rowBytes: outputWidth)
+    vImageConvert_PlanarFtoPlanar8(&srcF, &index8, 255, 0, vImage_Flags(kvImageNoFlags))
+
+    var red = vImage_Buffer(data: planes + count, height: height, width: width, rowBytes: outputWidth)
+    var green = vImage_Buffer(data: planes + count * 2, height: height, width: width, rowBytes: outputWidth)
+    var blue = vImage_Buffer(data: planes + count * 3, height: height, width: width, rowBytes: outputWidth)
+    vImageTableLookUp_Planar8(&index8, &red, &rTable, vImage_Flags(kvImageNoFlags))
+    vImageTableLookUp_Planar8(&index8, &green, &gTable, vImage_Flags(kvImageNoFlags))
+    vImageTableLookUp_Planar8(&index8, &blue, &bTable, vImage_Flags(kvImageNoFlags))
+    // Reuse the index plane as the alpha plane: every pixel fully opaque
+    memset(planes, 0xFF, count)
+
+    pixels.withUnsafeMutableBytes { rawBuffer in
+      var rgba = vImage_Buffer(
+        data: rawBuffer.baseAddress, height: height, width: width, rowBytes: outputWidth * 4)
+      vImageConvert_Planar8toARGB8888(&red, &green, &blue, &index8, &rgba, vImage_Flags(kvImageNoFlags))
+    }
   }
 
   private func makeImage(fromRGBA pixels: Data, width: Int, height: Int) -> CGImage? {

--- a/Sources/UltralyticsYOLO/SemanticSegmenter.swift
+++ b/Sources/UltralyticsYOLO/SemanticSegmenter.swift
@@ -99,7 +99,7 @@ public final class SemanticSegmenter: BasePredictor, @unchecked Sendable {
     let rowStride = isClassMap ? strides[1] : (isNCHW ? strides[2] : strides[1])
     let colStride = isClassMap ? strides[2] : (isNCHW ? strides[3] : strides[2])
 
-    if isClassMap, colStride == 1 {
+    if isClassMap, colStride == 1, classCount <= 256 {
       // The NPU already did the argmax - gather, clamp, and paint the per-pixel class indices entirely through
       // vDSP/vImage. Full-resolution maps are ~1M pixels per frame, and Accelerate runs vectorized C, so this
       // stays fast even in -Onone debug builds where a scalar Swift sweep costs ~100 ms.
@@ -211,14 +211,31 @@ public final class SemanticSegmenter: BasePredictor, @unchecked Sendable {
     classMap: [Int32], pixels: inout Data, colors: [(red: UInt8, green: UInt8, blue: UInt8)],
     outputWidth: Int, outputHeight: Int
   ) -> SemanticMask {
-    var staged = [Float](repeating: 0, count: classMap.count)
-    staged.withUnsafeMutableBufferPointer { dst in
-      classMap.withUnsafeBufferPointer { cm in
-        vDSP_vflt32(cm.baseAddress!, 1, dst.baseAddress!, 1, vDSP_Length(cm.count))
+    if colors.count <= 256 {
+      var staged = [Float](repeating: 0, count: classMap.count)
+      staged.withUnsafeMutableBufferPointer { dst in
+        classMap.withUnsafeBufferPointer { cm in
+          vDSP_vflt32(cm.baseAddress!, 1, dst.baseAddress!, 1, vDSP_Length(cm.count))
+        }
+        paintPixels(
+          fromClampedIndices: dst.baseAddress!, colors: colors,
+          outputWidth: outputWidth, outputHeight: outputHeight, pixels: &pixels)
       }
-      paintPixels(
-        fromClampedIndices: dst.baseAddress!, colors: colors,
-        outputWidth: outputWidth, outputHeight: outputHeight, pixels: &pixels)
+    } else {
+      // vImage lookup tables are 8-bit; beyond 256 classes paint scalar so class indices keep their own colors
+      let lut = colors.map {
+        UInt32($0.red) | UInt32($0.green) << 8 | UInt32($0.blue) << 16 | 0xFF00_0000
+      }
+      pixels.withUnsafeMutableBytes { rawBuffer in
+        let pixelBuffer = rawBuffer.bindMemory(to: UInt32.self)
+        classMap.withUnsafeBufferPointer { cm in
+          lut.withUnsafeBufferPointer { colorWords in
+            for i in 0..<cm.count {
+              pixelBuffer[i] = colorWords[Int(cm[i])]
+            }
+          }
+        }
+      }
     }
 
     return SemanticMask(
@@ -300,6 +317,9 @@ public final class SemanticSegmenter: BasePredictor, @unchecked Sendable {
     pixels.withUnsafeMutableBytes { rawBuffer in
       var rgba = vImage_Buffer(
         data: rawBuffer.baseAddress, height: height, width: width, rowBytes: outputWidth * 4)
+      // The four source planes land in bytes 0-3 in argument order (the A,R,G,B parameter names are nominal),
+      // so (red, green, blue, alpha) produces the RGBA byte order makeImage expects. Verified by
+      // testClassMapMaskImagePixelColors.
       vImageConvert_Planar8toARGB8888(
         &red, &green, &blue, &index8, &rgba, vImage_Flags(kvImageNoFlags))
     }

--- a/Sources/UltralyticsYOLO/YOLOResult.swift
+++ b/Sources/UltralyticsYOLO/YOLOResult.swift
@@ -111,7 +111,7 @@ public struct Masks: @unchecked Sendable {
 /// pre-rendered color overlay for display.
 public struct SemanticMask: @unchecked Sendable {
   /// Dense class IDs in row-major order with `width * height` elements.
-  public let classMap: [Int]
+  public let classMap: [Int32]
 
   /// Width of the dense class map.
   public let width: Int

--- a/Tests/YOLOTests/SemanticSegmenterTests.swift
+++ b/Tests/YOLOTests/SemanticSegmenterTests.swift
@@ -36,4 +36,38 @@ final class SemanticSegmenterTests: XCTestCase {
     XCTAssertEqual(mask.height, 2)
     XCTAssertEqual(mask.classMap, [1, 0, 2, 0])
   }
+
+  func testClassMapMaskImagePixelColors() {
+    // In-graph-ArgMax export shape [1, H, W]: the vImage paint path must write RGBA byte order with
+    // each pixel taking its class's palette color and full alpha.
+    let segmenter = SemanticSegmenter()
+    segmenter.labels = ["a", "b", "c"]
+
+    let classMap = try! MLMultiArray(shape: [1, 2, 2] as [NSNumber], dataType: .int32)
+    let ids: [Int32] = [1, 0, 2, 0]
+    let p = classMap.dataPointer.assumingMemoryBound(to: Int32.self)
+    for i in 0..<ids.count { p[i] = ids[i] }
+
+    guard let mask = segmenter.postProcessSemantic(classMap), let image = mask.maskImage,
+      let data = image.dataProvider?.data as Data?
+    else {
+      XCTFail("postProcessSemantic returned no mask image")
+      return
+    }
+    XCTAssertEqual(mask.classMap, ids)
+
+    let colors = (0..<3).map { ultralyticsColors[$0 % ultralyticsColors.count] }
+    for (pixel, id) in ids.enumerated() {
+      let expected = UIColor(cgColor: colors[Int(id)].cgColor)
+      var r: CGFloat = 0
+      var g: CGFloat = 0
+      var b: CGFloat = 0
+      expected.getRed(&r, green: &g, blue: &b, alpha: nil)
+      let o = pixel * 4
+      XCTAssertEqual(data[o], UInt8(r * 255), "red, pixel \(pixel)")
+      XCTAssertEqual(data[o + 1], UInt8(g * 255), "green, pixel \(pixel)")
+      XCTAssertEqual(data[o + 2], UInt8(b * 255), "blue, pixel \(pixel)")
+      XCTAssertEqual(data[o + 3], 255, "alpha, pixel \(pixel)")
+    }
+  }
 }

--- a/UltralyticsYOLO.podspec
+++ b/UltralyticsYOLO.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'UltralyticsYOLO'
-  s.version          = '8.9.7'
+  s.version          = '8.10.0'
   s.summary          = 'Ultralytics YOLO core inference for iOS (CoreML/Vision).'
   s.homepage         = 'https://github.com/ultralytics/yolo-ios-app'
   s.license          = { :type => 'AGPL-3.0', :file => 'LICENSE' }

--- a/UltralyticsYOLO.podspec
+++ b/UltralyticsYOLO.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'UltralyticsYOLO'
-  s.version          = '8.10.0'
+  s.version          = '8.9.7'
   s.summary          = 'Ultralytics YOLO core inference for iOS (CoreML/Vision).'
   s.homepage         = 'https://github.com/ultralytics/yolo-ios-app'
   s.license          = { :type => 'AGPL-3.0', :file => 'LICENSE' }

--- a/UltralyticsYOLO.podspec
+++ b/UltralyticsYOLO.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'UltralyticsYOLO'
-  s.version          = '8.9.6'
+  s.version          = '8.9.7'
   s.summary          = 'Ultralytics YOLO core inference for iOS (CoreML/Vision).'
   s.homepage         = 'https://github.com/ultralytics/yolo-ios-app'
   s.license          = { :type => 'AGPL-3.0', :file => 'LICENSE' }
@@ -10,5 +10,8 @@ Pod::Spec.new do |s|
   s.source           = { :git => 'https://github.com/ultralytics/yolo-ios-app.git', :tag => "v#{s.version}" }
   s.source_files     = 'Sources/UltralyticsYOLO/**/*.swift'
   s.ios.deployment_target = '13.0'
+  # Inference postprocessing sweeps millions of pixels per frame; without optimization a consumer's
+  # Debug build makes the SDK look ~100x slower than it ships. Always compile the pod optimized.
+  s.pod_target_xcconfig = { 'SWIFT_OPTIMIZATION_LEVEL' => '-O' }
   s.swift_version    = '5.10'
 end

--- a/YOLOiOSApp/YOLOiOSApp.xcodeproj/project.pbxproj
+++ b/YOLOiOSApp/YOLOiOSApp.xcodeproj/project.pbxproj
@@ -386,7 +386,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.9.6;
+				MARKETING_VERSION = 8.9.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ultralytics.iDetection;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -414,7 +414,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.9.6;
+				MARKETING_VERSION = 8.9.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ultralytics.iDetection;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/YOLOiOSApp/YOLOiOSApp.xcodeproj/project.pbxproj
+++ b/YOLOiOSApp/YOLOiOSApp.xcodeproj/project.pbxproj
@@ -386,7 +386,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.9.7;
+				MARKETING_VERSION = 8.10.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ultralytics.iDetection;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -414,7 +414,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.9.7;
+				MARKETING_VERSION = 8.10.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ultralytics.iDetection;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/YOLOiOSApp/YOLOiOSApp.xcodeproj/project.pbxproj
+++ b/YOLOiOSApp/YOLOiOSApp.xcodeproj/project.pbxproj
@@ -389,7 +389,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.10.0;
+				MARKETING_VERSION = 8.9.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ultralytics.iDetection;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -416,7 +416,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.10.0;
+				MARKETING_VERSION = 8.9.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ultralytics.iDetection;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/YOLOiOSApp/YOLOiOSApp.xcodeproj/project.pbxproj
+++ b/YOLOiOSApp/YOLOiOSApp.xcodeproj/project.pbxproj
@@ -140,7 +140,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1010;
-				LastUpgradeCheck = 2640;
+				LastUpgradeCheck = 2650;
 				ORGANIZATIONNAME = Ultralytics;
 				TargetAttributes = {
 					7BCB411621C3096100BFC4D0 = {
@@ -285,8 +285,10 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = 3MR4P6CL3X;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -349,8 +351,10 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = 3MR4P6CL3X;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -377,7 +381,6 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 0;
-				DEVELOPMENT_TEAM = 3MR4P6CL3X;
 				INFOPLIST_FILE = YOLOiOSApp/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Ultralytics YOLO";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
@@ -405,7 +408,6 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 0;
-				DEVELOPMENT_TEAM = 3MR4P6CL3X;
 				INFOPLIST_FILE = YOLOiOSApp/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Ultralytics YOLO";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
@@ -455,9 +457,6 @@
 			relativePath = ../;
 		};
 /* End XCLocalSwiftPackageReference section */
-
-/* Begin XCRemoteSwiftPackageReference section */
-/* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
 		73220ED22D373C2E00A94B92 /* UltralyticsYOLO */ = {

--- a/YOLOiOSApp/YOLOiOSApp.xcodeproj/xcshareddata/xcschemes/YOLOiOSApp.xcscheme
+++ b/YOLOiOSApp/YOLOiOSApp.xcodeproj/xcshareddata/xcschemes/YOLOiOSApp.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "2640"
+   LastUpgradeVersion = "2650"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/YOLOiOSApp/YOLOiOSApp/Info.plist
+++ b/YOLOiOSApp/YOLOiOSApp/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>574</string>
+	<string>577</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
Full-resolution semantic class maps (#24799 assets) exposed a ~100x Swift `-Onone` penalty in the per-pixel postprocess: Xcode Debug builds show ~90 ms post where Release runs 0.8 ms — anyone profiling from Xcode concludes the models are broken-slow.

Two fixes so debug and release behave alike:

- **Accelerate everywhere it counts**: the class-map gather/clamp runs through `vDSP` (`vflt32`/`vclip`/`vfix32`) and the RGBA paint through `vImage` 256-entry lookup tables with a planar-to-interleaved convert — vectorized C with no dependence on the Swift optimizer. Non-contiguous layouts keep a scalar fallback.
- **CocoaPods consumers** (e.g. the Flutter plugin) additionally get the pod compiled `-O` in every configuration via `pod_target_xcconfig` — standard practice for inference SDKs.

`SemanticMask.classMap` becomes `[Int32]` so the index conversion vectorizes (and the map halves in memory); test literals and the Flutter bridge forward unchanged.

Verified: package builds; SemanticSegmenter/YOLOResult/BasePredictor test suites pass on an iPhone 17 Pro; patch bump to 8.9.7 for a CocoaPods release on merge.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🚀 This PR speeds up semantic segmentation post-processing on iOS, especially in Debug builds, by switching key pixel-processing paths to Apple’s Accelerate framework and updating the app/package version to 8.9.7.

### 📊 Key Changes
- ⚡ Added `Accelerate`-based processing in `SemanticSegmenter.swift` for semantic class-map handling and mask color rendering.
- 🖼️ Introduced a new vectorized `paintPixels()` path using `vDSP` and `vImage` to convert class IDs into RGBA mask overlays much faster.
- 🔢 Changed `SemanticMask.classMap` from `[Int]` to `[Int32]` for closer alignment with Core ML output types and more efficient processing.
- 🛟 Kept scalar fallback logic for less common non-contiguous class-map layouts and for cases with more than 256 classes.
- ✅ Added a new test to verify that generated mask images use the correct RGBA pixel colors and full opacity.
- 📦 Bumped the CocoaPods package version from `8.9.6` to `8.9.7`.
- 🛠️ Updated the podspec to always compile the pod with Swift optimization (`-O`) so SDK performance stays strong even when the consuming app is built in Debug mode.
- 📱 Updated Xcode project/app version metadata and related project settings.

### 🎯 Purpose & Impact
- 🚀 Makes semantic segmentation overlays much faster to generate, especially for large full-resolution masks.
- 🧪 Improves the developer experience by avoiding misleadingly slow Debug-build performance during testing and integration.
- 🎨 Ensures mask colors are rendered correctly and consistently through added test coverage.
- 🔄 Better matches Core ML tensor data types, which can reduce unnecessary conversions and improve efficiency.
- 👩‍💻 For app developers using this SDK, segmentation features should feel more responsive and closer to release-build performance during development.