### PR TITLE
Add CocoaPods badge to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Ultralytics Actions](https://github.com/ultralytics/yolo-ios-app/actions/workflows/format.yml/badge.svg)](https://github.com/ultralytics/yolo-ios-app/actions/workflows/format.yml)
 [![CI](https://github.com/ultralytics/yolo-ios-app/actions/workflows/ci.yml/badge.svg)](https://github.com/ultralytics/yolo-ios-app/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/github/ultralytics/yolo-ios-app/branch/main/graph/badge.svg)](https://app.codecov.io/github/ultralytics/yolo-ios-app)
+[![CocoaPods](https://img.shields.io/cocoapods/v/UltralyticsYOLO?logo=cocoapods&logoColor=white&label=CocoaPods)](https://cocoapods.org/pods/UltralyticsYOLO)
 
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
 [![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,6 +7,7 @@
 [![Ultralytics Actions](https://github.com/ultralytics/yolo-ios-app/actions/workflows/format.yml/badge.svg)](https://github.com/ultralytics/yolo-ios-app/actions/workflows/format.yml)
 [![CI](https://github.com/ultralytics/yolo-ios-app/actions/workflows/ci.yml/badge.svg)](https://github.com/ultralytics/yolo-ios-app/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/github/ultralytics/yolo-ios-app/branch/main/graph/badge.svg)](https://app.codecov.io/github/ultralytics/yolo-ios-app)
+[![CocoaPods](https://img.shields.io/cocoapods/v/UltralyticsYOLO?logo=cocoapods&logoColor=white&label=CocoaPods)](https://cocoapods.org/pods/UltralyticsYOLO)
 
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
 [![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)


### PR DESCRIPTION
## Summary
- add a CocoaPods version badge to the English README
- mirror the badge in the Chinese README

## Testing
- Not run; Markdown badge-only change

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📦 This PR updates the English and Chinese README files to add a CocoaPods version badge for the `UltralyticsYOLO` iOS package.

### 📊 Key Changes
- Added a **CocoaPods badge** to `README.md` ✅
- Added the same **CocoaPods badge** to `README.zh-CN.md` 🌐
- The new badge links directly to the [`UltralyticsYOLO` CocoaPods page](https://cocoapods.org/pods/UltralyticsYOLO) 🔗
- No app code, model logic, or runtime behavior was changed 🛠️

### 🎯 Purpose & Impact
- Makes it easier for iOS developers to quickly see that `UltralyticsYOLO` is available via CocoaPods 🚀
- Improves project discoverability and installation clarity for new users 👀
- Keeps English and Chinese documentation aligned for a more consistent experience 🤝
- Since this is a documentation-only update, it carries **no functional risk** to the app itself ✅