### PR TITLE
Update redirected links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -81,6 +81,6 @@ body:
       label: Are you willing to submit a PR?
       description: >
         (Optional) We encourage you to submit a [Pull Request](https://github.com/ultralytics/yolo-ios-app/pulls) to help improve Ultralytics YOLO iOS App, especially if you know how to fix the issue.
-        See the Ultralytics [Contributing Guide](https://docs.ultralytics.com/help/contributing/) to get started.
+        See the Ultralytics [Contributing Guide](https://docs.ultralytics.com/help/contributing) to get started.
       options:
         - label: Yes I'd like to help by submitting a PR!

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -46,6 +46,6 @@ body:
       label: Are you willing to submit a PR?
       description: >
         (Optional) We encourage you to submit a [Pull Request](https://github.com/ultralytics/yolo-ios-app/pulls) to help improve Ultralytics YOLO iOS App.
-        See the Ultralytics [Contributing Guide](https://docs.ultralytics.com/help/contributing/) to get started.
+        See the Ultralytics [Contributing Guide](https://docs.ultralytics.com/help/contributing) to get started.
       options:
         - label: Yes I'd like to help by submitting a PR!


### PR DESCRIPTION
## Summary\n- update issue template links to the canonical contributing guide URL\n- normalize docs.ultralytics.com links now that trailing slashes are no longer canonical\n\n## Validation\n- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR makes a small documentation cleanup by fixing contributing guide links in the GitHub issue and feature request templates.

### 📊 Key Changes
- Updated the **Contributing Guide** URL in `.github/ISSUE_TEMPLATE/bug-report.yml`
- Updated the same **Contributing Guide** URL in `.github/ISSUE_TEMPLATE/feature-request.yml`
- Removed the trailing slash from the docs link so both templates now point to the corrected documentation path

### 🎯 Purpose & Impact
- Improves the contributor experience by ensuring users are directed to the correct Ultralytics contributing documentation ✨
- Reduces friction for people who want to help by submitting PRs from bug reports or feature requests
- Has no effect on app functionality, but slightly improves repository maintenance and onboarding 🛠️