### PR TITLE
Bump actions/checkout from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Xcode Version
         run: xcodebuild -version
@@ -136,7 +136,7 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install Periphery
         run: brew install periphery

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
       marketing_version: ${{ steps.check_version.outputs.marketing_version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets._GITHUB_TOKEN }}
@@ -86,7 +86,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets._GITHUB_TOKEN }}
@@ -118,7 +118,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.source_branch || 'main' }}
       - name: Setup Xcode
@@ -142,7 +142,7 @@ jobs:
       name: Release - TestFlight
       url: https://appstoreconnect.apple.com/apps
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
@@ -193,7 +193,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Extract PR Details
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Bump actions/checkout from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates GitHub Actions workflows to use `actions/checkout@v7` instead of `@v6`, modernizing the CI and release pipelines across the repository.

### 📊 Key Changes
- Replaced `actions/checkout@v6` with `actions/checkout@v7` in the main CI workflow ✅
- Updated the same checkout action in the publish/release workflow ✅
- Applied the upgrade across multiple jobs, including:
  - CI builds
  - code analysis steps
  - versioning and release preparation
  - App Store/TestFlight publishing
  - PR detail extraction
- No app source code or model-related logic was changed 🧩

### 🎯 Purpose & Impact
- Improves workflow maintenance by keeping GitHub Actions dependencies up to date 🔧
- Helps ensure better compatibility with current GitHub Actions infrastructure 🚀
- Reduces risk of issues tied to older workflow action versions 🛡️
- Has little to no direct user-facing impact, but supports more reliable testing, releases, and deployment for the iOS app 📱