### PR TITLE
docs(performance): ultralytics CoreML on macOS hosts now uses the ANE

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -107,6 +107,8 @@ Device, `yolo26n` detect, 4-cell matrix (raw = un-smoothed per-frame ms):
 
 Host (`coremltools`, `yolo26n`): `CPU_AND_NE` **2.6 ms** vs `CPU_ONLY` **8.6 ms** — the ANE is ~3× faster than CPU. (GPU-only is not measurable host-side; `ALL`/`CPU_AND_GPU` crash the Mac.)
 
+The same applies to the **Ultralytics Python package on a Mac**: its CoreML backend defaulted to `ComputeUnit.ALL`, so `YOLO("model.mlpackage").predict()` crashed on macOS hosts. Fixed in [ultralytics#24885](https://github.com/ultralytics/ultralytics/pull/24885) — it now loads `CPU_AND_NE` (ANE, ~3× faster; `CPU_ONLY` fallback on macOS <13), so host inference and `val()` run on the Neural Engine out of the box.
+
 **Shipped: `.cpuAndNeuralEngine`** — keeps the conv backbone on the ANE and avoids GPU contention. Do not switch to `.all`.
 
 ## 🎯 Experiment: YOLO26 End2end Head vs. Legacy Head + NMS


### PR DESCRIPTION
Adds a note to the Compute Units experiment: the Ultralytics Python package's CoreML backend defaulted to `ComputeUnit.ALL`, which **crashes on macOS hosts** (the same MPSGraph bug this doc already documents). Fixed in [ultralytics#24885](https://github.com/ultralytics/ultralytics/pull/24885) — it now loads `CPU_AND_NE` (ANE, ~3× faster; CPU_ONLY fallback on macOS <13), so `YOLO("model.mlpackage").predict()` / `val()` run on the Neural Engine on a Mac out of the box. Surfaced while benchmarking YOLO26 CoreML/ONNX on an M5 Pro.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📘 This PR updates the performance docs to clarify that a CoreML crash on Mac in the Ultralytics Python package has been fixed, and that Mac host inference now uses the Neural Engine by default for faster, more reliable performance.

### 📊 Key Changes
- Added a new note to `docs/performance.md` about the **Ultralytics Python package on macOS** using CoreML with safer default compute settings.
- Documented that CoreML previously defaulted to `ComputeUnit.ALL`, which could cause `YOLO("model.mlpackage").predict()` to crash on Mac hosts.
- Referenced the fix in [Ultralytics PR #24885](https://github.com/ultralytics/ultralytics/pull/24885).
- Clarified the new default behavior:
  - Uses `CPU_AND_NE` on supported macOS versions ✅
  - Falls back to `CPU_ONLY` on macOS versions earlier than 13
- Highlighted the practical performance benefit: Neural Engine inference is about **3× faster** than CPU-only on Mac hosts 🚀

### 🎯 Purpose & Impact
- Helps users understand that **Mac-based CoreML inference is now both more stable and faster**.
- Reduces confusion around crashes when running `.mlpackage` models from Python on macOS 💻
- Reinforces that the **Neural Engine is the preferred path** for host-side inference and validation, instead of GPU-based settings.
- Improves the documentation so developers can make better deployment decisions without trial and error 📚
- Benefits users running `predict()` or `val()` locally on Macs by enabling **out-of-the-box acceleration** with safer defaults ⚡