### PR TITLE
Use quantize export arg in CoreML export examples

### DIFF
--- a/ExampleApps/README.md
+++ b/ExampleApps/README.md
@@ -71,7 +71,7 @@ Follow these steps to get the examples up and running:
               for size in model_sizes:
                   model_name = f"yolo26{size}{model_type}"
                   model = YOLO(f"{model_name}.pt")
-                  model.export(format="coreml", int8=True, imgsz=imgsz, nms=nms, end2end=True)
+                  model.export(format="coreml", quantize=8, imgsz=imgsz, nms=nms, end2end=True)
                   zip_directory(f"{model_name}.mlpackage").rename(f"{model_name}.mlpackage.zip")
 
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The iOS app registry is [`RemoteModels.swift`](YOLOiOSApp/YOLOiOSApp/RemoteModel
 | Model IDs      | `yolo26{n,s,m,l,x}`                 | `yolo26{n,s,m,l,x}`              |
 | Tasks          | detect, seg, sem, cls, pose, obb    | detect, seg, sem, cls, pose, obb |
 | Format         | `.mlpackage.zip`                    | `.tflite`                        |
-| `int8`         | `True`                              | `True`                           |
+| `quantize`     | `8`                                 | `8`                              |
 | `imgsz`        | `224` cls; `1024` OBB; `640` others | `224` cls; `640` others          |
 | `nms`          | `False`                             | `False`                          |
 | `end2end`      | `True`                              | `False`                          |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -91,17 +91,17 @@ URL 模式：
 
 iOS 应用的模型注册表是 [`RemoteModels.swift`](YOLOiOSApp/YOLOiOSApp/RemoteModels.swift)。它枚举了检测、分割、语义分割、分类、姿态和 OBB 任务的 YOLO26 `n/s/m/l/x` 资源，并将每个模型 ID 指向 `v8.3.0` Core ML 发布版本。下表中的 Core ML 列由本仓库维护；TFLite 列概述了 Flutter 仓库的 Android 导出脚本及其发布资源。
 
-| 属性      | Core ML                            | TFLite                           |
-| --------- | ---------------------------------- | -------------------------------- |
-| 模型 ID   | `yolo26{n,s,m,l,x}`                | `yolo26{n,s,m,l,x}`              |
-| 任务      | detect、seg、sem、cls、pose、obb   | detect、seg、sem、cls、pose、obb |
-| 格式      | `.mlpackage.zip`                   | `.tflite`                        |
-| `int8`    | `True`                             | `True`                           |
-| `imgsz`   | 分类 `224`；OBB `1024`；其余 `640` | 分类 `224`；其余 `640`           |
-| `nms`     | `False`                            | `False`                          |
-| `end2end` | `True`                             | `False`                          |
-| 校准      | 导出器默认值                       | 按任务的 `TASK2CALIBRATIONDATA`  |
-| 后处理    | Swift/Core ML                      | Android 原生                     |
+| 属性       | Core ML                            | TFLite                           |
+| ---------- | ---------------------------------- | -------------------------------- |
+| 模型 ID    | `yolo26{n,s,m,l,x}`                | `yolo26{n,s,m,l,x}`              |
+| 任务       | detect、seg、sem、cls、pose、obb   | detect、seg、sem、cls、pose、obb |
+| 格式       | `.mlpackage.zip`                   | `.tflite`                        |
+| `quantize` | `8`                                | `8`                              |
+| `imgsz`    | 分类 `224`；OBB `1024`；其余 `640` | 分类 `224`；其余 `640`           |
+| `nms`      | `False`                            | `False`                          |
+| `end2end`  | `True`                             | `False`                          |
+| 校准       | 导出器默认值                       | 按任务的 `TASK2CALIBRATIONDATA`  |
+| 后处理     | Swift/Core ML                      | Android 原生                     |
 
 Core ML 资源使用 `nms=False` 和 `end2end=True` 导出：`nms=False` 会去掉 Core ML NMS 流水线，`end2end=True` 则提供由 Swift 解码器消费的 YOLO26 解码输出契约。TFLite 导出脚本同时传入 `nms=False` 和 `end2end=False`；`end2end=False` 会为 Android LiteRT 转换路径禁用 YOLO26 端到端头。
 

--- a/Sources/UltralyticsYOLO/README.md
+++ b/Sources/UltralyticsYOLO/README.md
@@ -260,7 +260,7 @@ URL patterns:
 
 The `YOLO` class can load a Core ML release URL directly; it downloads once and caches the compiled model locally. If you download manually, unzip the `.mlpackage.zip` asset and add the `.mlpackage` to your app target's "Copy Bundle Resources" build phase.
 
-The [repository root README](../../README.md#-official-model-assets) is the authoritative reference for official model properties, including `imgsz`, `int8`, `nms`, `end2end`, calibration, postprocessing, and release hosting.
+The [repository root README](../../README.md#-official-model-assets) is the authoritative reference for official model properties, including `imgsz`, `quantize`, `nms`, `end2end`, calibration, postprocessing, and release hosting.
 
 ### Reproduce The Official Core ML Assets
 

--- a/Tests/YOLOTests/README.md
+++ b/Tests/YOLOTests/README.md
@@ -71,7 +71,7 @@ def export_and_zip_yolo_models(
         for size in model_sizes:
             model_name = f"yolo26{size}{model_type}"
             model = YOLO(f"{model_name}.pt")
-            model.export(format="coreml", int8=True, imgsz=[imgsz, imgsz], nms=nms, end2end=True)
+            model.export(format="coreml", quantize=8, imgsz=[imgsz, imgsz], nms=nms, end2end=True)
             zip_directory(f"{model_name}.mlpackage").rename(f"{model_name}.mlpackage.zip")
 
 

--- a/scripts/export-models.py
+++ b/scripts/export-models.py
@@ -118,7 +118,7 @@ def main() -> None:
             exported = Path(
                 model.export(
                     format="coreml",
-                    int8=True,
+                    quantize=8,
                     nms=False,
                     end2end=True,
                     imgsz=task.imgsz,


### PR DESCRIPTION
Update the CoreML export examples to use the new unified `quantize` arg instead of the deprecated `int8`/`half` precision booleans.

- `int8=True` → `quantize=8` (INT8) in `scripts/export-models.py`, `ExampleApps/README.md`, and `Tests/YOLOTests/README.md`.

This follows ultralytics/ultralytics#24918, which replaces `int8`/`half` with a single `quantize` arg (`quantize=8` for INT8, `quantize=16` for FP16). The old args still work with a deprecation warning, so this should land after that PR ships `quantize`.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR updates the iOS app’s model export docs and scripts to use the newer `quantize=8` setting instead of the older `int8=True` option for YOLO26 Core ML exports.

### 📊 Key Changes
- 🔄 Replaced `int8=True` with `quantize=8` in Core ML export examples and scripts.
- 🧪 Updated the main export script in `scripts/export-models.py` to use the new quantization argument.
- 📘 Refreshed documentation across multiple files:
  - root `README.md`
  - `README.zh-CN.md`
  - `ExampleApps/README.md`
  - `Sources/UltralyticsYOLO/README.md`
  - `Tests/YOLOTests/README.md`
- 📋 Updated model property tables to show `quantize: 8` instead of `int8: True` for both Core ML and TFLite references.
- 🌍 Kept English and Chinese documentation aligned for consistency.

### 🎯 Purpose & Impact
- ✅ Aligns this repository with the current Ultralytics export API and terminology.
- 🚀 Helps prevent confusion or breakage for developers exporting YOLO26 models for iOS.
- 📚 Improves documentation accuracy, making setup and reproduction of official model assets clearer.
- 🔧 Reduces the chance of users copying outdated export commands from the repo.
- 👥 Benefits both app developers and broader users by keeping examples, tests, and docs consistent with current Ultralytics workflows.