### PR TITLE
Update TFLite→LiteRT terminology in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,16 +82,16 @@ The main YOLOiOSApp **bundles all six nano models** (one per task: detect, segme
 | Runtime asset                 | Used by                                      | Release                                                                                          |
 | ----------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------ |
 | Core ML int8 `.mlpackage.zip` | iOS app, Swift package, Flutter on iOS/macOS | [yolo-ios-app `v8.3.0`](https://github.com/ultralytics/yolo-ios-app/releases/tag/v8.3.0)         |
-| TFLite int8 `.tflite`         | Flutter on Android                           | [yolo-flutter-app `v0.3.5`](https://github.com/ultralytics/yolo-flutter-app/releases/tag/v0.3.5) |
+| LiteRT int8 `.tflite`         | Flutter on Android                           | [yolo-flutter-app `v0.3.5`](https://github.com/ultralytics/yolo-flutter-app/releases/tag/v0.3.5) |
 
 URL patterns:
 
 - Core ML: `https://github.com/ultralytics/yolo-ios-app/releases/download/v8.3.0/<model>.mlpackage.zip`
-- TFLite: `https://github.com/ultralytics/yolo-flutter-app/releases/download/v0.3.5/<model>_int8.tflite`
+- LiteRT: `https://github.com/ultralytics/yolo-flutter-app/releases/download/v0.3.5/<model>_int8.tflite`
 
-The iOS app registry is [`RemoteModels.swift`](YOLOiOSApp/YOLOiOSApp/RemoteModels.swift). It enumerates YOLO26 `n/s/m/l/x` assets for detect, segment, semantic, classify, pose, and OBB and points each model ID at the `v8.3.0` Core ML release. The Core ML column below is owned by this repo; the TFLite column summarizes the Flutter repo's Android export script and release assets.
+The iOS app registry is [`RemoteModels.swift`](YOLOiOSApp/YOLOiOSApp/RemoteModels.swift). It enumerates YOLO26 `n/s/m/l/x` assets for detect, segment, semantic, classify, pose, and OBB and points each model ID at the `v8.3.0` Core ML release. The Core ML column below is owned by this repo; the LiteRT column summarizes the Flutter repo's Android export script and release assets.
 
-| Property       | Core ML                             | TFLite                           |
+| Property       | Core ML                             | LiteRT                           |
 | -------------- | ----------------------------------- | -------------------------------- |
 | Model IDs      | `yolo26{n,s,m,l,x}`                 | `yolo26{n,s,m,l,x}`              |
 | Tasks          | detect, seg, sem, cls, pose, obb    | detect, seg, sem, cls, pose, obb |
@@ -103,7 +103,7 @@ The iOS app registry is [`RemoteModels.swift`](YOLOiOSApp/YOLOiOSApp/RemoteModel
 | Calibration    | exporter default                    | `TASK2CALIBRATIONDATA` per task  |
 | Postprocessing | Swift/Core ML                       | Android native                   |
 
-Core ML assets use `nms=False` and `end2end=True`: `nms=False` suppresses the Core ML NMS pipeline, and `end2end=True` supplies the YOLO26 decoded output contract consumed by the Swift decoders. The TFLite export script passes both `nms=False` and `end2end=False`; `end2end=False` disables the YOLO26 end-to-end head for the Android LiteRT conversion path.
+Core ML assets use `nms=False` and `end2end=True`: `nms=False` suppresses the Core ML NMS pipeline, and `end2end=True` supplies the YOLO26 decoded output contract consumed by the Swift decoders. The LiteRT export script passes both `nms=False` and `end2end=False`; `end2end=False` disables the YOLO26 end-to-end head for the Android LiteRT conversion path.
 
 ### Core ML Release Workflow
 
@@ -127,7 +127,7 @@ uv run python scripts/export-models.py --upload --repo ultralytics/yolo-ios-app 
 
 The script exports from checkpoints named `yolo26<size><suffix>.pt`, for example `yolo26n.pt`, `yolo26s-seg.pt`, `yolo26m-sem.pt`, `yolo26l-pose.pt`, and `yolo26x-obb.pt`. YOLO26 is NMS-free in this SDK, so official Core ML assets are exported with `nms=False` and `end2end=True`; Swift-side postprocessing handles the end2end detect, segment, pose, and OBB outputs (classify and semantic outputs need no NMS decode).
 
-### Android TFLite Counterparts
+### Android LiteRT Counterparts
 
 The Android assets used by the Flutter package are maintained in the Flutter repo, not this iOS repo. Their canonical export script is `scripts/export-tflite-models.py` in `ultralytics/yolo-flutter-app`; it exports the matching YOLO26 task/size matrix as int8 `.tflite` assets calibrated with the per-task `ultralytics.cfg.TASK2CALIBRATIONDATA` defaults and uploads them to `yolo-flutter-app` `v0.3.5`.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -82,16 +82,16 @@ var body: some View {
 | 运行时资源                    | 使用方                                          | 发布版本                                                                                         |
 | ----------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------ |
 | Core ML int8 `.mlpackage.zip` | iOS 应用、Swift package、iOS/macOS 上的 Flutter | [yolo-ios-app `v8.3.0`](https://github.com/ultralytics/yolo-ios-app/releases/tag/v8.3.0)         |
-| TFLite int8 `.tflite`         | Android 上的 Flutter                            | [yolo-flutter-app `v0.3.5`](https://github.com/ultralytics/yolo-flutter-app/releases/tag/v0.3.5) |
+| LiteRT int8 `.tflite`         | Android 上的 Flutter                            | [yolo-flutter-app `v0.3.5`](https://github.com/ultralytics/yolo-flutter-app/releases/tag/v0.3.5) |
 
 URL 模式：
 
 - Core ML：`https://github.com/ultralytics/yolo-ios-app/releases/download/v8.3.0/<model>.mlpackage.zip`
-- TFLite：`https://github.com/ultralytics/yolo-flutter-app/releases/download/v0.3.5/<model>_int8.tflite`
+- LiteRT：`https://github.com/ultralytics/yolo-flutter-app/releases/download/v0.3.5/<model>_int8.tflite`
 
-iOS 应用的模型注册表是 [`RemoteModels.swift`](YOLOiOSApp/YOLOiOSApp/RemoteModels.swift)。它枚举了检测、分割、语义分割、分类、姿态和 OBB 任务的 YOLO26 `n/s/m/l/x` 资源，并将每个模型 ID 指向 `v8.3.0` Core ML 发布版本。下表中的 Core ML 列由本仓库维护；TFLite 列概述了 Flutter 仓库的 Android 导出脚本及其发布资源。
+iOS 应用的模型注册表是 [`RemoteModels.swift`](YOLOiOSApp/YOLOiOSApp/RemoteModels.swift)。它枚举了检测、分割、语义分割、分类、姿态和 OBB 任务的 YOLO26 `n/s/m/l/x` 资源，并将每个模型 ID 指向 `v8.3.0` Core ML 发布版本。下表中的 Core ML 列由本仓库维护；LiteRT 列概述了 Flutter 仓库的 Android 导出脚本及其发布资源。
 
-| 属性       | Core ML                            | TFLite                           |
+| 属性       | Core ML                            | LiteRT                           |
 | ---------- | ---------------------------------- | -------------------------------- |
 | 模型 ID    | `yolo26{n,s,m,l,x}`                | `yolo26{n,s,m,l,x}`              |
 | 任务       | detect、seg、sem、cls、pose、obb   | detect、seg、sem、cls、pose、obb |
@@ -103,7 +103,7 @@ iOS 应用的模型注册表是 [`RemoteModels.swift`](YOLOiOSApp/YOLOiOSApp/Rem
 | 校准       | 导出器默认值                       | 按任务的 `TASK2CALIBRATIONDATA`  |
 | 后处理     | Swift/Core ML                      | Android 原生                     |
 
-Core ML 资源使用 `nms=False` 和 `end2end=True` 导出：`nms=False` 会去掉 Core ML NMS 流水线，`end2end=True` 则提供由 Swift 解码器消费的 YOLO26 解码输出契约。TFLite 导出脚本同时传入 `nms=False` 和 `end2end=False`；`end2end=False` 会为 Android LiteRT 转换路径禁用 YOLO26 端到端头。
+Core ML 资源使用 `nms=False` 和 `end2end=True` 导出：`nms=False` 会去掉 Core ML NMS 流水线，`end2end=True` 则提供由 Swift 解码器消费的 YOLO26 解码输出契约。LiteRT 导出脚本同时传入 `nms=False` 和 `end2end=False`；`end2end=False` 会为 Android LiteRT 转换路径禁用 YOLO26 端到端头。
 
 ### Core ML 发布工作流
 
@@ -127,7 +127,7 @@ uv run python scripts/export-models.py --upload --repo ultralytics/yolo-ios-app 
 
 该脚本从名为 `yolo26<size><suffix>.pt` 的检查点导出，例如 `yolo26n.pt`、`yolo26s-seg.pt`、`yolo26m-sem.pt`、`yolo26l-pose.pt` 和 `yolo26x-obb.pt`。在本 SDK 中 YOLO26 是无 NMS 的，因此官方 Core ML 资源使用 `nms=False` 和 `end2end=True` 导出；Swift 侧后处理负责处理端到端的检测、分割、姿态和 OBB 输出（分类和语义分割输出无需 NMS 解码）。
 
-### Android TFLite 对应资源
+### Android LiteRT 对应资源
 
 Flutter package 使用的 Android 资源在 Flutter 仓库中维护，而不在本 iOS 仓库中。其规范导出脚本是 `ultralytics/yolo-flutter-app` 仓库中的 `scripts/export-tflite-models.py`；它将匹配的 YOLO26 任务/尺寸矩阵导出为 int8 `.tflite` 资源，使用按任务的 `ultralytics.cfg.TASK2CALIBRATIONDATA` 默认值进行校准，并上传到 `yolo-flutter-app` `v0.3.5`。
 

--- a/Sources/UltralyticsYOLO/README.md
+++ b/Sources/UltralyticsYOLO/README.md
@@ -251,12 +251,12 @@ Official Core ML assets are hosted in [yolo-ios-app `v8.3.0`](https://github.com
 | Runtime asset                 | Used by                                      | Release                                                                                          |
 | ----------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------ |
 | Core ML int8 `.mlpackage.zip` | iOS app, Swift package, Flutter on iOS/macOS | [yolo-ios-app `v8.3.0`](https://github.com/ultralytics/yolo-ios-app/releases/tag/v8.3.0)         |
-| TFLite int8 `.tflite`         | Flutter on Android                           | [yolo-flutter-app `v0.3.5`](https://github.com/ultralytics/yolo-flutter-app/releases/tag/v0.3.5) |
+| LiteRT int8 `.tflite`         | Flutter on Android                           | [yolo-flutter-app `v0.3.5`](https://github.com/ultralytics/yolo-flutter-app/releases/tag/v0.3.5) |
 
 URL patterns:
 
 - Core ML: `https://github.com/ultralytics/yolo-ios-app/releases/download/v8.3.0/<model>.mlpackage.zip`
-- TFLite: `https://github.com/ultralytics/yolo-flutter-app/releases/download/v0.3.5/<model>_int8.tflite`
+- LiteRT: `https://github.com/ultralytics/yolo-flutter-app/releases/download/v0.3.5/<model>_int8.tflite`
 
 The `YOLO` class can load a Core ML release URL directly; it downloads once and caches the compiled model locally. If you download manually, unzip the `.mlpackage.zip` asset and add the `.mlpackage` to your app target's "Copy Bundle Resources" build phase.
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -165,8 +165,8 @@ On A19, frame time is dominated by model inference (~7 ms, thermally bound under
 - ~~**In-graph ArgMax for semantic models.**~~ **Shipped** (ultralytics/ultralytics#24790 + #24799 + this SDK's
   `SemanticSegmenter` class-map support): semantic Core ML exports now embed the ArgMax and return a full-resolution
   `[1, H, W]` class map, replacing the CPU argmax decode with a sub-millisecond color sweep and making masks
-  pixel-sharp. The same recipe is QNN/Core ML-only: the TFLite GPU delegate cannot compile `ARG_MAX` (whole-graph
-  CPU fallback measured 3.6× slower than GPU logits), so Android TFLite keeps consumer-side argmax.
+  pixel-sharp. The same recipe is QNN/Core ML-only: the LiteRT GPU delegate cannot compile `ARG_MAX` (whole-graph
+  CPU fallback measured 3.6× slower than GPU logits), so Android LiteRT keeps consumer-side argmax.
 
 - **Cross-platform decode parity (context, not a lever).** The Flutter Android predictors previously spent
   ~12 ms/frame on detect decode (tensor reshape copies + JNI marshaling); rewriting them to direct flat reads —


### PR DESCRIPTION
## Summary

Refreshes the docs that describe the **Android counterpart assets** from "TFLite" to "LiteRT". Those assets are now produced via the Ultralytics `litert` export (litert-torch) and run on **LiteRT 2.x** (Google's rebrand of TensorFlow Lite) in the Flutter Android plugin.

Docs-only, terminology only — **no functional or iOS/Core ML changes**. The CoreML export path (`format="coreml"`, `quantize=8`) is unaffected.

## Changes
- `README.md`, `README.zh-CN.md`, `Sources/UltralyticsYOLO/README.md`: "TFLite" → "LiteRT" in the asset tables, URL labels, and the Core ML vs. Android comparison.
- `docs/performance.md`: "TFLite GPU delegate" / "Android TFLite" → "LiteRT".

## Unchanged (intentionally)
- The `.tflite` file extension, release asset filenames, and download URLs.
- The Flutter repo's export script name `scripts/export-tflite-models.py`.

## Context
Part of the coordinated LiteRT rollout: ultralytics adds `format=litert` and removes legacy `tflite`/`tfjs` (ultralytics#22870), the Flutter plugin migrates to LiteRT 2.x (yolo-flutter-app#548), and the platform export UI follows (portal). This PR only aligns the iOS repo's cross-reference terminology.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR is a documentation-only cleanup that renames Android model references from **TFLite** to **LiteRT** across the repo for clearer, more current cross-platform terminology.

### 📊 Key Changes
- 🔄 Replaced **“TFLite”** with **“LiteRT”** in multiple docs, including:
  - `README.md`
  - `README.zh-CN.md`
  - `Sources/UltralyticsYOLO/README.md`
  - `docs/performance.md`
- 📱 Updated Android asset descriptions to consistently refer to **LiteRT int8 `.tflite`** models.
- 📚 Revised tables, URL pattern labels, section headings, and explanatory text to match the new naming.
- 🌐 Kept both English and Chinese documentation aligned with the same terminology update.
- 🧩 Clarified that Android exports in the Flutter ecosystem still use `.tflite` files, but are now described as part of the **LiteRT** runtime path.

### 🎯 Purpose & Impact
- ✅ Improves documentation consistency across iOS, Swift package, Flutter, and performance docs.
- 🧠 Reduces confusion for users comparing Apple Core ML and Android runtime/model formats.
- 🚀 Better reflects current Android inference/runtime branding without changing actual model assets or code behavior.
- 🔒 Low-risk change: this appears to be **documentation-only**, so it should not affect app functionality, exports, or performance directly.
- 👥 Helps both developers and broader users more easily understand the cross-platform deployment story for **YOLO26** models.