### PR TITLE
Improve segment mask rendering

### DIFF
--- a/Sources/UltralyticsYOLO/NonMaxSuppression.swift
+++ b/Sources/UltralyticsYOLO/NonMaxSuppression.swift
@@ -18,9 +18,12 @@ import Foundation
 /// - Returns: Indices of the selected bounding boxes after suppression.
 public func nonMaxSuppression(boxes: [CGRect], scores: [Float], threshold: Float) -> [Int] {
   let count = boxes.count
-  let sortedIndices = scores.enumerated().sorted { $0.element > $1.element }.map { $0.offset }
+  if count < 2 { return Array(0..<count) }
+
+  let sortedIndices = (0..<count).sorted { scores[$0] > scores[$1] }
   let areas = boxes.map { $0.area }
   var selectedIndices = [Int]()
+  selectedIndices.reserveCapacity(count)
   var activeIndices = [Bool](repeating: true, count: count)
   let iouThreshold = CGFloat(threshold)
 
@@ -33,7 +36,12 @@ public func nonMaxSuppression(boxes: [CGRect], scores: [Float], threshold: Float
     for j in (i + 1)..<sortedIndices.count {
       let otherIdx = sortedIndices[j]
       if !activeIndices[otherIdx] { continue }
-      let interArea = boxA.intersection(boxes[otherIdx]).area
+      let boxB = boxes[otherIdx]
+      let interWidth = min(boxA.maxX, boxB.maxX) - max(boxA.minX, boxB.minX)
+      guard interWidth > 0 else { continue }
+      let interHeight = min(boxA.maxY, boxB.maxY) - max(boxA.minY, boxB.minY)
+      guard interHeight > 0 else { continue }
+      let interArea = interWidth * interHeight
       let union = areaA + areas[otherIdx] - interArea
       if union > 0 && interArea / union > iouThreshold {
         activeIndices[otherIdx] = false

--- a/Sources/UltralyticsYOLO/Plot.swift
+++ b/Sources/UltralyticsYOLO/Plot.swift
@@ -292,8 +292,10 @@ func generateCombinedMaskImage(
   let outputWidth = Int(outputRect.width)
   let outputHeight = Int(outputRect.height)
   guard outputWidth > 0, outputHeight > 0 else { return nil }
-  let targetWidth = max(1, Int((CGFloat(outputWidth) / CGFloat(maskWidth) * CGFloat(inputWidth)).rounded()))
-  let targetHeight = max(1, Int((CGFloat(outputHeight) / CGFloat(maskHeight) * CGFloat(inputHeight)).rounded()))
+  let targetWidth = max(
+    1, Int((CGFloat(outputWidth) / CGFloat(maskWidth) * CGFloat(inputWidth)).rounded()))
+  let targetHeight = max(
+    1, Int((CGFloat(outputHeight) / CGFloat(maskHeight) * CGFloat(inputHeight)).rounded()))
   let displayScaleX = CGFloat(targetWidth) / CGFloat(outputWidth)
   let displayScaleY = CGFloat(targetHeight) / CGFloat(outputHeight)
   var mergedPixels = [UInt32](repeating: 0, count: targetWidth * targetHeight)
@@ -353,8 +355,10 @@ func generateCombinedMaskImage(
 
     let targetX1 = max(0, Int(((visibleBox.minX - outputRect.minX) * displayScaleX).rounded(.down)))
     let targetY1 = max(0, Int(((visibleBox.minY - outputRect.minY) * displayScaleY).rounded(.down)))
-    let targetX2 = min(targetWidth, Int(((visibleBox.maxX - outputRect.minX) * displayScaleX).rounded(.up)))
-    let targetY2 = min(targetHeight, Int(((visibleBox.maxY - outputRect.minY) * displayScaleY).rounded(.up)))
+    let targetX2 = min(
+      targetWidth, Int(((visibleBox.maxX - outputRect.minX) * displayScaleX).rounded(.up)))
+    let targetY2 = min(
+      targetHeight, Int(((visibleBox.maxY - outputRect.minY) * displayScaleY).rounded(.up)))
     let targetBoxWidth = targetX2 - targetX1
     let targetBoxHeight = targetY2 - targetY1
     guard targetBoxWidth > 0, targetBoxHeight > 0 else { continue }
@@ -424,7 +428,9 @@ func generateCombinedMaskImage(
   }
 
   let pixelData = mergedPixels.withUnsafeBufferPointer { Data(buffer: $0) }
-  return (makeRGBAImage(from: pixelData, width: targetWidth, height: targetHeight), probabilityMasks)
+  return (
+    makeRGBAImage(from: pixelData, width: targetWidth, height: targetHeight), probabilityMasks
+  )
 }
 
 public func drawYOLOClassifications(on ciImage: CIImage, result: YOLOResult) -> UIImage {

--- a/Sources/UltralyticsYOLO/Plot.swift
+++ b/Sources/UltralyticsYOLO/Plot.swift
@@ -356,10 +356,14 @@ func generateCombinedMaskImage(
       let sourceHeight = Int(visibleBox.height)
       guard sourceWidth > 0, sourceHeight > 0 else { continue }
 
-      let targetX1 = max(0, Int(((visibleBox.minX - outputRect.minX) * displayScaleX).rounded(.down)))
-      let targetY1 = max(0, Int(((visibleBox.minY - outputRect.minY) * displayScaleY).rounded(.down)))
-      let targetX2 = min(targetWidth, Int(((visibleBox.maxX - outputRect.minX) * displayScaleX).rounded(.up)))
-      let targetY2 = min(targetHeight, Int(((visibleBox.maxY - outputRect.minY) * displayScaleY).rounded(.up)))
+      let targetX1 = max(
+        0, Int(((visibleBox.minX - outputRect.minX) * displayScaleX).rounded(.down)))
+      let targetY1 = max(
+        0, Int(((visibleBox.minY - outputRect.minY) * displayScaleY).rounded(.down)))
+      let targetX2 = min(
+        targetWidth, Int(((visibleBox.maxX - outputRect.minX) * displayScaleX).rounded(.up)))
+      let targetY2 = min(
+        targetHeight, Int(((visibleBox.maxY - outputRect.minY) * displayScaleY).rounded(.up)))
       let targetBoxWidth = targetX2 - targetX1
       let targetBoxHeight = targetY2 - targetY1
       guard targetBoxWidth > 0, targetBoxHeight > 0 else { continue }
@@ -429,7 +433,9 @@ func generateCombinedMaskImage(
     }
   }
 
-  return (makeRGBAImage(from: pixelData, width: targetWidth, height: targetHeight), probabilityMasks)
+  return (
+    makeRGBAImage(from: pixelData, width: targetWidth, height: targetHeight), probabilityMasks
+  )
 }
 
 public func drawYOLOClassifications(on ciImage: CIImage, result: YOLOResult) -> UIImage {

--- a/Sources/UltralyticsYOLO/Plot.swift
+++ b/Sources/UltralyticsYOLO/Plot.swift
@@ -86,6 +86,27 @@ let skeleton = [
   [5, 7],
 ]
 
+func makeRGBAImage(
+  from pixels: Data,
+  width: Int,
+  height: Int,
+  shouldInterpolate: Bool = true
+) -> CGImage? {
+  guard let provider = CGDataProvider(data: pixels as CFData) else { return nil }
+  return CGImage(
+    width: width,
+    height: height,
+    bitsPerComponent: 8,
+    bitsPerPixel: 32,
+    bytesPerRow: width * 4,
+    space: CGColorSpaceCreateDeviceRGB(),
+    bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue),
+    provider: provider,
+    decode: nil,
+    shouldInterpolate: shouldInterpolate,
+    intent: .defaultIntent)
+}
+
 /// Executes `body` inside a bitmap graphics context rendered at pixel scale.
 ///
 /// Flips the y-axis so drawing matches UIKit's top-left origin and draws the source image as the background, then
@@ -260,8 +281,8 @@ func generateCombinedMaskImage(
     detectedObjects.enumerated().map { (i, obj) in (i, obj.0, obj.1, obj.2) }
   let sortedObjects = indexedObjects.sorted { $0.3 < $1.3 }  // ascending by score
 
-  // 7) RGBA buffer (160x160)
-  var mergedPixels = [UInt8](repeating: 0, count: HW * 4)
+  // 7) Display geometry. Mask math stays at prototype resolution, but the visible composite is painted at
+  // model-input resolution so the app does not upscale a 160x160 image into blocky masks.
   let scaleX = Float(maskWidth) / Float(inputWidth)
   let scaleY = Float(maskHeight) / Float(inputHeight)
   let maskBounds = CGRect(x: 0, y: 0, width: maskWidth, height: maskHeight)
@@ -271,6 +292,11 @@ func generateCombinedMaskImage(
   let outputWidth = Int(outputRect.width)
   let outputHeight = Int(outputRect.height)
   guard outputWidth > 0, outputHeight > 0 else { return nil }
+  let targetWidth = max(1, Int((CGFloat(outputWidth) / CGFloat(maskWidth) * CGFloat(inputWidth)).rounded()))
+  let targetHeight = max(1, Int((CGFloat(outputHeight) / CGFloat(maskHeight) * CGFloat(inputHeight)).rounded()))
+  let displayScaleX = CGFloat(targetWidth) / CGFloat(outputWidth)
+  let displayScaleY = CGFloat(targetHeight) / CGFloat(outputHeight)
+  var mergedPixels = [UInt32](repeating: 0, count: targetWidth * targetHeight)
 
   // Match Ultralytics process_mask(): crop each mask to its detection box before thresholding
   // or returning per-instance data.
@@ -306,13 +332,32 @@ func generateCombinedMaskImage(
 
   // 8) Per-instance probability maps are built later (section 10) with bulk row copies.
   var probabilityMasks: [[[Float]]]? = nil
+  var scaledMask = [Float]()
 
-  // 9) Compose according to sort order
+  // 9) Compose according to sort order. Scale each instance's Float logits before thresholding so edges are
+  // high-resolution binary masks, not blurred RGBA pixels.
   for (originalIndex, _, classID, _) in sortedObjects {
     let maskBox = maskBoxes[originalIndex]
     guard maskBox.x1 < maskBox.x2, maskBox.y1 < maskBox.y2 else { continue }
 
     let startIdx = originalIndex * HW
+    let visibleBox = CGRect(
+      x: maskBox.x1, y: maskBox.y1, width: maskBox.x2 - maskBox.x1,
+      height: maskBox.y2 - maskBox.y1
+    ).intersection(outputRect).integral
+    let sourceX = Int(visibleBox.minX)
+    let sourceY = Int(visibleBox.minY)
+    let sourceWidth = Int(visibleBox.width)
+    let sourceHeight = Int(visibleBox.height)
+    guard sourceWidth > 0, sourceHeight > 0 else { continue }
+
+    let targetX1 = max(0, Int(((visibleBox.minX - outputRect.minX) * displayScaleX).rounded(.down)))
+    let targetY1 = max(0, Int(((visibleBox.minY - outputRect.minY) * displayScaleY).rounded(.down)))
+    let targetX2 = min(targetWidth, Int(((visibleBox.maxX - outputRect.minX) * displayScaleX).rounded(.up)))
+    let targetY2 = min(targetHeight, Int(((visibleBox.maxY - outputRect.minY) * displayScaleY).rounded(.up)))
+    let targetBoxWidth = targetX2 - targetX1
+    let targetBoxHeight = targetY2 - targetY1
+    guard targetBoxWidth > 0, targetBoxHeight > 0 else { continue }
 
     // Get class color
     let _colorIndex = classID % ultralyticsColors.count
@@ -322,19 +367,35 @@ func generateCombinedMaskImage(
     let r = UInt8(color.red)
     let g = UInt8(color.green)
     let b = UInt8(color.blue)
+    let colorWord = UInt32(r) | UInt32(g) << 8 | UInt32(b) << 16 | 0xFF00_0000
 
-    // Pixel loop: box range only
-    for y in maskBox.y1..<maskBox.y2 {
-      for x in maskBox.x1..<maskBox.x2 {
-        let px = y * maskWidth + x
-        let maskVal = combinedMask[startIdx + px]
-        if maskVal > threshold {
-          let pixIndex = px * 4
-          mergedPixels[pixIndex + 0] = r
-          mergedPixels[pixIndex + 1] = g
-          mergedPixels[pixIndex + 2] = b
-          mergedPixels[pixIndex + 3] = 255
-        }
+    let scaledCount = targetBoxWidth * targetBoxHeight
+    if scaledMask.count < scaledCount {
+      scaledMask = [Float](repeating: 0, count: scaledCount)
+    }
+    let scaleError = combinedMask.withUnsafeBufferPointer { sourceBuffer in
+      scaledMask.withUnsafeMutableBufferPointer { targetBuffer in
+        var source = vImage_Buffer(
+          data: UnsafeMutableRawPointer(
+            mutating: sourceBuffer.baseAddress! + startIdx + sourceY * maskWidth + sourceX),
+          height: vImagePixelCount(sourceHeight),
+          width: vImagePixelCount(sourceWidth),
+          rowBytes: maskWidth * MemoryLayout<Float>.stride)
+        var target = vImage_Buffer(
+          data: targetBuffer.baseAddress!,
+          height: vImagePixelCount(targetBoxHeight),
+          width: vImagePixelCount(targetBoxWidth),
+          rowBytes: targetBoxWidth * MemoryLayout<Float>.stride)
+        return vImageScale_PlanarF(&source, &target, nil, vImage_Flags(kvImageNoFlags))
+      }
+    }
+    guard scaleError == kvImageNoError else { continue }
+
+    for y in 0..<targetBoxHeight {
+      let sourceRow = y * targetBoxWidth
+      let targetRow = (targetY1 + y) * targetWidth + targetX1
+      for x in 0..<targetBoxWidth where scaledMask[sourceRow + x] > threshold {
+        mergedPixels[targetRow + x] = colorWord
       }
     }
   }
@@ -362,37 +423,8 @@ func generateCombinedMaskImage(
     }
   }
 
-  // 11) RGBA buffer -> CGImage
-  let colorSpace = CGColorSpaceCreateDeviceRGB()
-  let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue)
-  let totalBytes = mergedPixels.count
-
-  guard let providerRef = CGDataProvider(data: NSData(bytes: &mergedPixels, length: totalBytes))
-  else {
-    return nil
-  }
-  guard
-    let mergedCGImage = CGImage(
-      width: maskWidth,
-      height: maskHeight,
-      bitsPerComponent: 8,
-      bitsPerPixel: 32,
-      bytesPerRow: maskWidth * 4,
-      space: colorSpace,
-      bitmapInfo: bitmapInfo,
-      provider: providerRef,
-      decode: nil,
-      shouldInterpolate: false,
-      intent: .defaultIntent
-    )
-  else {
-    return nil
-  }
-
-  let outputImage =
-    outputRect == maskBounds
-    ? mergedCGImage : (mergedCGImage.cropping(to: outputRect) ?? mergedCGImage)
-  return (outputImage, probabilityMasks)
+  let pixelData = mergedPixels.withUnsafeBufferPointer { Data(buffer: $0) }
+  return (makeRGBAImage(from: pixelData, width: targetWidth, height: targetHeight), probabilityMasks)
 }
 
 public func drawYOLOClassifications(on ciImage: CIImage, result: YOLOResult) -> UIImage {

--- a/Sources/UltralyticsYOLO/Plot.swift
+++ b/Sources/UltralyticsYOLO/Plot.swift
@@ -298,7 +298,7 @@ func generateCombinedMaskImage(
     1, Int((CGFloat(outputHeight) / CGFloat(maskHeight) * CGFloat(inputHeight)).rounded()))
   let displayScaleX = CGFloat(targetWidth) / CGFloat(outputWidth)
   let displayScaleY = CGFloat(targetHeight) / CGFloat(outputHeight)
-  var mergedPixels = [UInt32](repeating: 0, count: targetWidth * targetHeight)
+  var pixelData = Data(count: targetWidth * targetHeight * MemoryLayout<UInt32>.stride)
 
   // Match Ultralytics process_mask(): crop each mask to its detection box before thresholding
   // or returning per-instance data.
@@ -336,70 +336,72 @@ func generateCombinedMaskImage(
   var probabilityMasks: [[[Float]]]? = nil
   var scaledMask = [Float]()
 
-  // 9) Compose according to sort order. Scale each instance's Float logits before thresholding so edges are
-  // high-resolution binary masks, not blurred RGBA pixels.
-  for (originalIndex, _, classID, _) in sortedObjects {
-    let maskBox = maskBoxes[originalIndex]
-    guard maskBox.x1 < maskBox.x2, maskBox.y1 < maskBox.y2 else { continue }
+  pixelData.withUnsafeMutableBytes { rawPixels in
+    let mergedPixels = rawPixels.bindMemory(to: UInt32.self)
 
-    let startIdx = originalIndex * HW
-    let visibleBox = CGRect(
-      x: maskBox.x1, y: maskBox.y1, width: maskBox.x2 - maskBox.x1,
-      height: maskBox.y2 - maskBox.y1
-    ).intersection(outputRect).integral
-    let sourceX = Int(visibleBox.minX)
-    let sourceY = Int(visibleBox.minY)
-    let sourceWidth = Int(visibleBox.width)
-    let sourceHeight = Int(visibleBox.height)
-    guard sourceWidth > 0, sourceHeight > 0 else { continue }
+    // 9) Compose according to sort order. Scale each instance's Float logits before thresholding so edges are
+    // high-resolution binary masks, not blurred RGBA pixels.
+    for (originalIndex, _, classID, _) in sortedObjects {
+      let maskBox = maskBoxes[originalIndex]
+      guard maskBox.x1 < maskBox.x2, maskBox.y1 < maskBox.y2 else { continue }
 
-    let targetX1 = max(0, Int(((visibleBox.minX - outputRect.minX) * displayScaleX).rounded(.down)))
-    let targetY1 = max(0, Int(((visibleBox.minY - outputRect.minY) * displayScaleY).rounded(.down)))
-    let targetX2 = min(
-      targetWidth, Int(((visibleBox.maxX - outputRect.minX) * displayScaleX).rounded(.up)))
-    let targetY2 = min(
-      targetHeight, Int(((visibleBox.maxY - outputRect.minY) * displayScaleY).rounded(.up)))
-    let targetBoxWidth = targetX2 - targetX1
-    let targetBoxHeight = targetY2 - targetY1
-    guard targetBoxWidth > 0, targetBoxHeight > 0 else { continue }
+      let startIdx = originalIndex * HW
+      let visibleBox = CGRect(
+        x: maskBox.x1, y: maskBox.y1, width: maskBox.x2 - maskBox.x1,
+        height: maskBox.y2 - maskBox.y1
+      ).intersection(outputRect).integral
+      let sourceX = Int(visibleBox.minX)
+      let sourceY = Int(visibleBox.minY)
+      let sourceWidth = Int(visibleBox.width)
+      let sourceHeight = Int(visibleBox.height)
+      guard sourceWidth > 0, sourceHeight > 0 else { continue }
 
-    // Get class color
-    let _colorIndex = classID % ultralyticsColors.count
-    guard let color = ultralyticsColors[_colorIndex].toRGBComponents() else {
-      continue
-    }
-    let r = UInt8(color.red)
-    let g = UInt8(color.green)
-    let b = UInt8(color.blue)
-    let colorWord = UInt32(r) | UInt32(g) << 8 | UInt32(b) << 16 | 0xFF00_0000
+      let targetX1 = max(0, Int(((visibleBox.minX - outputRect.minX) * displayScaleX).rounded(.down)))
+      let targetY1 = max(0, Int(((visibleBox.minY - outputRect.minY) * displayScaleY).rounded(.down)))
+      let targetX2 = min(targetWidth, Int(((visibleBox.maxX - outputRect.minX) * displayScaleX).rounded(.up)))
+      let targetY2 = min(targetHeight, Int(((visibleBox.maxY - outputRect.minY) * displayScaleY).rounded(.up)))
+      let targetBoxWidth = targetX2 - targetX1
+      let targetBoxHeight = targetY2 - targetY1
+      guard targetBoxWidth > 0, targetBoxHeight > 0 else { continue }
 
-    let scaledCount = targetBoxWidth * targetBoxHeight
-    if scaledMask.count < scaledCount {
-      scaledMask = [Float](repeating: 0, count: scaledCount)
-    }
-    let scaleError = combinedMask.withUnsafeBufferPointer { sourceBuffer in
-      scaledMask.withUnsafeMutableBufferPointer { targetBuffer in
-        var source = vImage_Buffer(
-          data: UnsafeMutableRawPointer(
-            mutating: sourceBuffer.baseAddress! + startIdx + sourceY * maskWidth + sourceX),
-          height: vImagePixelCount(sourceHeight),
-          width: vImagePixelCount(sourceWidth),
-          rowBytes: maskWidth * MemoryLayout<Float>.stride)
-        var target = vImage_Buffer(
-          data: targetBuffer.baseAddress!,
-          height: vImagePixelCount(targetBoxHeight),
-          width: vImagePixelCount(targetBoxWidth),
-          rowBytes: targetBoxWidth * MemoryLayout<Float>.stride)
-        return vImageScale_PlanarF(&source, &target, nil, vImage_Flags(kvImageNoFlags))
+      // Get class color
+      let _colorIndex = classID % ultralyticsColors.count
+      guard let color = ultralyticsColors[_colorIndex].toRGBComponents() else {
+        continue
       }
-    }
-    guard scaleError == kvImageNoError else { continue }
+      let r = UInt8(color.red)
+      let g = UInt8(color.green)
+      let b = UInt8(color.blue)
+      let colorWord = UInt32(r) | UInt32(g) << 8 | UInt32(b) << 16 | 0xFF00_0000
 
-    for y in 0..<targetBoxHeight {
-      let sourceRow = y * targetBoxWidth
-      let targetRow = (targetY1 + y) * targetWidth + targetX1
-      for x in 0..<targetBoxWidth where scaledMask[sourceRow + x] > threshold {
-        mergedPixels[targetRow + x] = colorWord
+      let scaledCount = targetBoxWidth * targetBoxHeight
+      if scaledMask.count < scaledCount {
+        scaledMask = [Float](repeating: 0, count: scaledCount)
+      }
+      let scaleError = combinedMask.withUnsafeBufferPointer { sourceBuffer in
+        scaledMask.withUnsafeMutableBufferPointer { targetBuffer in
+          var source = vImage_Buffer(
+            data: UnsafeMutableRawPointer(
+              mutating: sourceBuffer.baseAddress! + startIdx + sourceY * maskWidth + sourceX),
+            height: vImagePixelCount(sourceHeight),
+            width: vImagePixelCount(sourceWidth),
+            rowBytes: maskWidth * MemoryLayout<Float>.stride)
+          var target = vImage_Buffer(
+            data: targetBuffer.baseAddress!,
+            height: vImagePixelCount(targetBoxHeight),
+            width: vImagePixelCount(targetBoxWidth),
+            rowBytes: targetBoxWidth * MemoryLayout<Float>.stride)
+          return vImageScale_PlanarF(&source, &target, nil, vImage_Flags(kvImageNoFlags))
+        }
+      }
+      guard scaleError == kvImageNoError else { continue }
+
+      for y in 0..<targetBoxHeight {
+        let sourceRow = y * targetBoxWidth
+        let targetRow = (targetY1 + y) * targetWidth + targetX1
+        for x in 0..<targetBoxWidth where scaledMask[sourceRow + x] > threshold {
+          mergedPixels[targetRow + x] = colorWord
+        }
       }
     }
   }
@@ -427,10 +429,7 @@ func generateCombinedMaskImage(
     }
   }
 
-  let pixelData = mergedPixels.withUnsafeBufferPointer { Data(buffer: $0) }
-  return (
-    makeRGBAImage(from: pixelData, width: targetWidth, height: targetHeight), probabilityMasks
-  )
+  return (makeRGBAImage(from: pixelData, width: targetWidth, height: targetHeight), probabilityMasks)
 }
 
 public func drawYOLOClassifications(on ciImage: CIImage, result: YOLOResult) -> UIImage {

--- a/Sources/UltralyticsYOLO/SemanticSegmenter.swift
+++ b/Sources/UltralyticsYOLO/SemanticSegmenter.swift
@@ -326,18 +326,6 @@ public final class SemanticSegmenter: BasePredictor, @unchecked Sendable {
   }
 
   private func makeImage(fromRGBA pixels: Data, width: Int, height: Int) -> CGImage? {
-    guard let provider = CGDataProvider(data: pixels as CFData) else { return nil }
-    return CGImage(
-      width: width,
-      height: height,
-      bitsPerComponent: 8,
-      bitsPerPixel: 32,
-      bytesPerRow: width * 4,
-      space: CGColorSpaceCreateDeviceRGB(),
-      bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue),
-      provider: provider,
-      decode: nil,
-      shouldInterpolate: true,
-      intent: .defaultIntent)
+    makeRGBAImage(from: pixels, width: width, height: height)
   }
 }

--- a/Tests/YOLOTests/PlotTests.swift
+++ b/Tests/YOLOTests/PlotTests.swift
@@ -238,6 +238,9 @@ class PlotTests: XCTestCase {
       return
     }
 
+    XCTAssertEqual(result.0?.width, W)
+    XCTAssertEqual(result.0?.height, H)
+    XCTAssertEqual(result.0?.shouldInterpolate, true)
     XCTAssertEqual(masks.count, 1)
     XCTAssertEqual(masks[0].count, H)
     XCTAssertEqual(masks[0][0].count, W)
@@ -279,6 +282,34 @@ class PlotTests: XCTestCase {
         XCTAssertEqual(masks[0][y][x], expected, accuracy: 1e-4)
       }
     }
+  }
+
+  func testGenerateCombinedMaskImageUpscalesCompositeToInputResolution() {
+    let C = 1
+    let H = 4
+    let W = 4
+    let protos = try! MLMultiArray(shape: [1, C, H, W] as [NSNumber], dataType: .float32)
+    let pPtr = protos.dataPointer.assumingMemoryBound(to: Float.self)
+    for i in 0..<(H * W) { pPtr[i] = 1 }
+
+    let detected: [(CGRect, Int, Float, [Float])] = [
+      (CGRect(x: 0, y: 0, width: 8, height: 8), 0, 0.9, [1])
+    ]
+
+    guard
+      let result = generateCombinedMaskImage(
+        detectedObjects: detected, protos: protos,
+        inputWidth: 8, inputHeight: 8,
+        cropRect: nil, returnIndividualMasks: true)
+    else {
+      XCTFail("generateCombinedMaskImage returned nil")
+      return
+    }
+
+    XCTAssertEqual(result.0?.width, 8)
+    XCTAssertEqual(result.0?.height, 8)
+    XCTAssertEqual(result.1?.first?.count, H)
+    XCTAssertEqual(result.1?.first?.first?.count, W)
   }
 
   func testGenerateCombinedMaskImageEmptyDetectionsReturnsGracefully() {

--- a/UltralyticsYOLO.podspec
+++ b/UltralyticsYOLO.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'UltralyticsYOLO'
-  s.version          = '8.9.7'
+  s.version          = '8.9.8'
   s.summary          = 'Ultralytics YOLO core inference for iOS (CoreML/Vision).'
   s.homepage         = 'https://github.com/ultralytics/yolo-ios-app'
   s.license          = { :type => 'AGPL-3.0', :file => 'LICENSE' }

--- a/YOLOiOSApp/YOLOiOSApp.xcodeproj/project.pbxproj
+++ b/YOLOiOSApp/YOLOiOSApp.xcodeproj/project.pbxproj
@@ -389,7 +389,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.9.7;
+				MARKETING_VERSION = 8.9.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ultralytics.iDetection;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -416,7 +416,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.9.7;
+				MARKETING_VERSION = 8.9.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ultralytics.iDetection;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";


### PR DESCRIPTION
## Summary
- render segment composite masks at display resolution while keeping per-instance masks at prototype resolution
- share RGBA image construction with semantic masks
- bump version to 8.9.8

## Validation
- git diff --check
- xcodebuild -scheme UltralyticsYOLO -destination "generic/platform=iOS" build-for-testing
- xcodebuild -project YOLOiOSApp/YOLOiOSApp.xcodeproj -scheme YOLOiOSApp -destination "platform=iOS,id=00008150-001A5CA82E08401C" build

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR improves iOS mask rendering quality and performance in `ultralytics/yolo-ios-app`, while also tightening up non-max suppression and adding test coverage 🚀

### 📊 Key Changes
- Improved `nonMaxSuppression()` for efficiency and safety:
  - Returns early for 0 or 1 boxes
  - Simplifies score sorting
  - Pre-reserves output storage
  - Replaces `CGRect.intersection()` area calculation with faster manual overlap checks ⚡
- Upgraded segmentation mask rendering in `generateCombinedMaskImage()`:
  - Masks are now composited at the model input resolution instead of staying at the smaller prototype resolution
  - This avoids blocky upscaled masks and produces sharper visible edges 🖼️
- Added a reusable `makeRGBAImage()` helper in `Plot.swift`:
  - Centralizes RGBA-to-`CGImage` creation
  - Reused by `SemanticSegmenter` to reduce duplicate code 🧩
- Switched mask composition to a more efficient pixel-writing path using `Data` and `UInt32` buffers for RGBA output
- Added tests to confirm:
  - Output mask images preserve expected width and height
  - Interpolation settings are correct
  - Composite masks upscale properly to input resolution ✅
- Bumped the package/app version from `8.9.7` to `8.9.8` 📦

### 🎯 Purpose & Impact
- Sharper segmentation overlays make results look cleaner and more accurate in the iOS app, especially for larger displayed masks 🎨
- Faster overlap and mask-processing logic can improve runtime efficiency during inference and visualization ⚙️
- Shared image-conversion code makes the codebase easier to maintain and less error-prone over time 🛠️
- New tests reduce the chance of regressions in mask rendering behavior, improving reliability for developers and users alike 🔒