### PR TITLE
Clear stale segment mask overlays

### DIFF
--- a/Sources/UltralyticsYOLO/YOLOView.swift
+++ b/Sources/UltralyticsYOLO/YOLOView.swift
@@ -81,15 +81,18 @@ public final class YOLOView: UIView, VideoCaptureDelegate {
     task == .obb ? showOBBs(predictions: result) : showBoxes(predictions: result)
 
     if task == .segment || task == .semantic {
+      guard let maskLayer = self.maskLayer else {
+        return
+      }
       if let maskImage = task == .segment
         ? result.masks?.combinedMask : result.semanticMask?.maskImage
       {
-        guard let maskLayer = self.maskLayer else {
-          return
-        }
         maskLayer.isHidden = false
         maskLayer.frame = imageFrameInOverlay(for: result.orig_shape)
         maskLayer.contents = maskImage
+      } else {
+        maskLayer.contents = nil
+        maskLayer.isHidden = true
       }
     } else if task == .classify {
       self.overlayYOLOClassificationsCALayer(on: self, result: result)

--- a/UltralyticsYOLO.podspec
+++ b/UltralyticsYOLO.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'UltralyticsYOLO'
-  s.version          = '8.9.8'
+  s.version          = '8.9.9'
   s.summary          = 'Ultralytics YOLO core inference for iOS (CoreML/Vision).'
   s.homepage         = 'https://github.com/ultralytics/yolo-ios-app'
   s.license          = { :type => 'AGPL-3.0', :file => 'LICENSE' }

--- a/YOLOiOSApp/YOLOiOSApp.xcodeproj/project.pbxproj
+++ b/YOLOiOSApp/YOLOiOSApp.xcodeproj/project.pbxproj
@@ -389,7 +389,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.9.8;
+				MARKETING_VERSION = 8.9.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ultralytics.iDetection;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -416,7 +416,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.9.8;
+				MARKETING_VERSION = 8.9.9;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ultralytics.iDetection;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";


### PR DESCRIPTION
## Summary
- Clear and hide the segment/semantic mask layer when the current result has no mask
- Prevent stale masks from remaining over the live camera preview after rapid movement
- Bump the release version to 8.9.9 for the hotfix

## Validation
- git diff --check
- xcodebuild -project YOLOiOSApp/YOLOiOSApp.xcodeproj -scheme YOLOiOSApp -destination "platform=iOS,id=00008150-001A5CA82E08401C" build
- xcodebuild -scheme UltralyticsYOLO -destination "generic/platform=iOS" build-for-testing
- Installed and launched on connected iPhone

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR fixes stale or lingering segmentation mask overlays in the iOS app and bumps the app/package version to `8.9.9`.

### 📊 Key Changes
- Fixed `YOLOView.swift` mask rendering logic for `.segment` and `.semantic` tasks.
- Added a safer early check to ensure `maskLayer` exists before trying to update it.
- Updated behavior when no mask image is returned:
  - clears `maskLayer.contents`
  - hides the mask layer
- Previously, the mask layer was only updated when a mask existed, which could leave an old mask visible on screen.
- Bumped version numbers from `8.9.8` to `8.9.9` in:
  - `UltralyticsYOLO.podspec`
  - Xcode project marketing version

### 🎯 Purpose & Impact
- ✅ Prevents outdated segmentation masks from remaining visible when a new frame has no mask output.
- 📱 Improves visual correctness and reliability for iOS apps using segmentation or semantic segmentation.
- 🔒 Adds a small safety improvement by guarding access to the mask layer earlier.
- 🚀 Ships the fix as a new patch release, making it easier for users to adopt through the updated `8.9.9` package/app version.