### PR TITLE
Make Codecov upload best effort

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,7 @@ jobs:
           mv info.filtered.lcov info.lcov
 
       - name: Upload to Codecov
+        continue-on-error: true
         uses: codecov/codecov-action@v7
         with:
           files: ./info.lcov
@@ -130,7 +131,7 @@ jobs:
           use_oidc: true
           disable_search: true
           plugins: noop
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
   periphery:
     runs-on: macos-26


### PR DESCRIPTION
## Summary
- make the Codecov upload step non-blocking with continue-on-error
- set Codecov fail_ci_if_error to false
- keep coverage tests authoritative while Codecov upload/reporting flakes stay best-effort

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'
- git diff --check

Deleted: nothing; this only changes existing CI reporting settings so test jobs remain authoritative while Codecov upload flakes do not fail CI.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Makes Codecov upload failures non-blocking in CI to improve workflow reliability and reduce unnecessary failed checks 🚦

### 📊 Key Changes
- Added `continue-on-error: true` to the Codecov upload step ✅
- Changed Codecov configuration from `fail_ci_if_error: true` to `fail_ci_if_error: false` 🛠️
- Keeps coverage upload enabled while preventing external Codecov issues from failing the full CI pipeline 📈

### 🎯 Purpose & Impact
- Reduces false-negative CI failures caused by temporary Codecov outages, authentication issues, or upload errors 🌐
- Helps developers focus on real build, test, and lint problems instead of third-party service instability 👨‍💻
- Improves contributor experience by making PR checks more resilient and less noisy 🚀