### PR TITLE
Release UltralyticsYOLO 8.9.12

### DIFF
--- a/UltralyticsYOLO.podspec
+++ b/UltralyticsYOLO.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'UltralyticsYOLO'
-  s.version          = '9.0.0'
+  s.version          = '8.9.12'
   s.summary          = 'Ultralytics YOLO core inference for iOS (CoreML/Vision).'
   s.homepage         = 'https://github.com/ultralytics/yolo-ios-app'
   s.license          = { :type => 'AGPL-3.0', :file => 'LICENSE' }

--- a/UltralyticsYOLO.podspec
+++ b/UltralyticsYOLO.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'UltralyticsYOLO'
-  s.version          = '8.9.11'
+  s.version          = '9.0.0'
   s.summary          = 'Ultralytics YOLO core inference for iOS (CoreML/Vision).'
   s.homepage         = 'https://github.com/ultralytics/yolo-ios-app'
   s.license          = { :type => 'AGPL-3.0', :file => 'LICENSE' }

--- a/YOLOiOSApp/YOLOiOSApp.xcodeproj/project.pbxproj
+++ b/YOLOiOSApp/YOLOiOSApp.xcodeproj/project.pbxproj
@@ -389,7 +389,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 9.0.0;
+				MARKETING_VERSION = 8.9.12;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ultralytics.iDetection;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -416,7 +416,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 9.0.0;
+				MARKETING_VERSION = 8.9.12;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ultralytics.iDetection;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/YOLOiOSApp/YOLOiOSApp.xcodeproj/project.pbxproj
+++ b/YOLOiOSApp/YOLOiOSApp.xcodeproj/project.pbxproj
@@ -389,7 +389,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.9.11;
+				MARKETING_VERSION = 9.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ultralytics.iDetection;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -416,7 +416,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.9.11;
+				MARKETING_VERSION = 9.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ultralytics.iDetection;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";


### PR DESCRIPTION
## Summary
- bump the app marketing version to 8.9.12
- bump the CocoaPods specification to 8.9.12
- publish the depth and profiling improvements as a patch release

## Validation
- `pod lib lint UltralyticsYOLO.podspec --allow-warnings`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📦 Bumps the UltralyticsYOLO iOS app and CocoaPods package version from **8.9.11 to 8.9.12**.

### 📊 Key Changes
- Updated the `UltralyticsYOLO.podspec` version to **8.9.12**.
- Updated the Xcode project’s `MARKETING_VERSION` to **8.9.12** for both build configurations.
- No source-code or runtime behavior changes were introduced.

### 🎯 Purpose & Impact
- ✅ Keeps the CocoaPods package and iOS app versions synchronized.
- 🚀 Enables publishing and distributing the updated **8.9.12** release.
- 🔒 Existing app functionality and inference behavior remain unchanged.