### PR TITLE
Use shared setup-uv action everywhere

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,9 +45,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: false
+      - uses: ultralytics/actions/setup-uv@main
       - run: uv pip install --system --no-cache ultralytics-actions
       - id: check_version
         shell: python
@@ -94,9 +92,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: false
+      - uses: ultralytics/actions/setup-uv@main
       - run: uv pip install --system --no-cache ultralytics-actions
       - name: Create tag and release
         env:


### PR DESCRIPTION
## Summary
- replace all 2 Astral uv setup steps with the shared retried owner
- preserve existing Python and environment behavior

Reused: ultralytics/actions/setup-uv@main is the single latest-uv installer owner.

Deleted: 2 direct astral-sh/setup-uv dependencies and obsolete Astral-only cache inputs where present.

## Validation
- zero executable astral-sh/setup-uv occurrences
- all setup callers are exactly ultralytics/actions/setup-uv@main
- actionlint on changed workflows; any reported warnings are pre-existing on unchanged lines
- git diff --check
- shared owner passed Windows, Ubuntu, and macOS CI

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated the publishing workflow to use Ultralytics’ shared `setup-uv` GitHub Action. ⚙️

### 📊 Key Changes

- Replaced `astral-sh/setup-uv@v7` with `ultralytics/actions/setup-uv@main`.
- Applied the change to both publishing jobs.
- Removed the previous `enable-cache: false` configuration.

### 🎯 Purpose & Impact

- ✅ Standardizes Python package setup across Ultralytics repositories.
- 🔧 Centralizes `uv` configuration and maintenance in the shared Ultralytics action.
- 🚀 Simplifies the release workflow while preserving existing publishing and tagging behavior.
- 📦 No direct changes are expected for app users; the impact is limited to CI/CD reliability and maintainability.