### PR TITLE
Bump actions/setup-python from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.13"
       - name: Run Ultralytics Actions

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets._GITHUB_TOKEN }}
           ref: ${{ inputs.source_branch || 'main' }}
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.x"
       - uses: ultralytics/actions/setup-uv@main
@@ -89,7 +89,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets._GITHUB_TOKEN }}
           ref: ${{ inputs.source_branch || 'main' }}
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.x"
       - uses: ultralytics/actions/setup-uv@main


### PR DESCRIPTION
Bump actions/setup-python from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

⚙️ Updated GitHub Actions to use the latest `setup-python` release across formatting and publishing workflows.

### 📊 Key Changes

- Upgraded `actions/setup-python` from `v6` to `v7` in:
  - The formatting workflow.
  - Both publishing workflow jobs.
- No application or model functionality was changed.

### 🎯 Purpose & Impact

- ✅ Keeps CI/CD workflows aligned with the latest GitHub Actions tooling.
- 🚀 May improve Python environment setup reliability and compatibility.
- 🔒 Maintains consistent Python configuration for formatting and package publishing.
- 👥 Changes are primarily for repository maintainers and should have no direct impact on app users.