### PR TITLE
Queue publish workflow runs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}
-  cancel-in-progress: false
+  queue: max
 
 jobs:
   check:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,10 @@ on:
         type: boolean
         default: true
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   check:
     if: github.repository == 'ultralytics/yolo-ios-app' && github.actor == 'glenn-jocher'


### PR DESCRIPTION
## Summary

- Serialize publish workflows with `queue: max`.
- Preserve up to 100 pending release runs instead of replacing older pending releases.
- Align release robustness with [ultralytics/ultralytics#25331](https://github.com/ultralytics/ultralytics/pull/25331) without changing the repository-specific publisher.

Deleted: nothing — GitHub owns workflow scheduling, so preserving pending release runs requires workflow-level concurrency configuration.

## Validation

- `git diff --check`
- GitHub's documented `concurrency.queue: max` syntax; local actionlint 1.7.12 predates this property

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Adds workflow concurrency controls to prevent overlapping publish runs in the iOS app repository. ⚙️

### 📊 Key Changes

- Added a GitHub Actions concurrency group based on the workflow name.
- Configured queued execution with `queue: max`, allowing runs to wait rather than cancel or overlap.
- Applies to the publish workflow, including its existing repository and actor checks.

### 🎯 Purpose & Impact

- Prevents multiple publish workflows from running simultaneously. 🚦
- Reduces the risk of conflicting releases, duplicate publishing, or inconsistent build artifacts.
- Ensures queued publish requests are processed in order, improving release reliability. ✅