### PR TITLE
Make coverage informational and correct the CI note

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -4,7 +4,7 @@ coverage:
   status:
     project:
       default:
-        target: auto
+        informational: true
     patch:
       default:
-        target: auto
+        informational: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ periphery scan --project YOLOiOSApp/YOLOiOSApp.xcodeproj --schemes YOLOiOSApp \
 uv venv --python 3.13 .venv && uv pip install -e "../ultralytics[export]"
 ```
 
-CI (`ci.yml`) runs two jobs on `macos-26`: `test` (build + test + Codecov with `fail_ci_if_error: true`) and `periphery` (dead-code scan, `--strict` fails on any unused declaration). `Package.swift` is pinned to `swift-tools-version: 5.10` for CI compatibility — do not raise it.
+CI (`ci.yml`) runs two jobs on `macos-26`: `test` (build + test + a non-blocking Codecov upload) and `periphery` (dead-code scan, `--strict` fails on any unused declaration). `Package.swift` is pinned to `swift-tools-version: 5.10` for CI compatibility — do not raise it.
 
 ## Architecture
 


### PR DESCRIPTION


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Makes Codecov reporting non-blocking so coverage issues no longer fail CI builds. ✅

### 📊 Key Changes

- Updated `.github/codecov.yml` to mark project and patch coverage checks as informational.
- Updated `AGENTS.md` to document that Codecov uploads are now non-blocking.
- Build, test, and Periphery dead-code checks remain unchanged.

### 🎯 Purpose & Impact

- Prevents CI failures caused solely by coverage thresholds or Codecov upload issues. 🚦
- Keeps coverage data available for visibility without blocking development workflows.
- Maintains existing code quality safeguards, including tests and strict unused-code detection. 🔍