### PR TITLE
Increase focused predictor test coverage

### DIFF
--- a/Tests/YOLOTests/BasePredictorTests.swift
+++ b/Tests/YOLOTests/BasePredictorTests.swift
@@ -38,6 +38,11 @@ class BasePredictorTests: XCTestCase {
     XCTAssertEqual(predictor.t3, 10)
     XCTAssertEqual(predictor.t4, 0.05)
     XCTAssertGreaterThan(predictor.timingBreakdownMs().post, 0)
+
+    var result = YOLOResult.empty
+    predictor.applyTimingBreakdown(&result, smoothed: true)
+    XCTAssertEqual(result.inferenceMs, 60, accuracy: 0.001)
+    XCTAssertEqual(result.postMs, 40, accuracy: 0.001)
   }
 
   func testConfidenceThresholdSetting() {
@@ -454,6 +459,38 @@ class BasePredictorTests: XCTestCase {
     XCTAssertEqual(result.keypoints.xy.count, 17)
     XCTAssertEqual(result.keypoints.xyn[16].x, 0.26, accuracy: 0.001)
     XCTAssertEqual(result.keypoints.conf[16], 0.8, accuracy: 0.001)
+  }
+
+  func testPoseEstimatorDecodesEndToEndTensorLayouts() throws {
+    let pose = PoseEstimator()
+    pose.labels = ["person"]
+    pose.modelInputSize = (width: 100, height: 100)
+    pose.inputSize = CGSize(width: 100, height: 100)
+
+    let withClass = try makeArray(shape: [1, 10, 9]) { write in
+      for (field, value) in [10, 20, 40, 60, 0.9, 0, 25, 35, 0.8].enumerated() {
+        write([0, 0, field], Float(value))
+      }
+    }
+    let classResults = pose.PostProcessPose(
+      prediction: withClass, confidenceThreshold: 0.25, iouThreshold: 0.5)
+
+    XCTAssertEqual(classResults.first?.box.xywh, CGRect(x: 10, y: 20, width: 30, height: 40))
+    XCTAssertEqual(classResults.first?.keypoints.xy.first?.x ?? -1, 25, accuracy: 0.001)
+    XCTAssertEqual(classResults.first?.keypoints.xyn.first?.y ?? -1, 0.35, accuracy: 0.001)
+    XCTAssertEqual(classResults.first?.keypoints.conf, [0.8])
+
+    let withoutClass = try makeArray(shape: [1, 9, 8]) { write in
+      for (field, value) in [5, 10, 15, 30, 0.7, 8, 12, 0.6].enumerated() {
+        write([0, 0, field], Float(value))
+      }
+    }
+    let noClassResults = pose.PostProcessPose(
+      prediction: withoutClass, confidenceThreshold: 0.25, iouThreshold: 0.5)
+
+    XCTAssertEqual(noClassResults.first?.box.xywh, CGRect(x: 5, y: 10, width: 10, height: 20))
+    XCTAssertEqual(noClassResults.first?.keypoints.xy.first?.x ?? -1, 8, accuracy: 0.001)
+    XCTAssertEqual(noClassResults.first?.keypoints.conf, [0.6])
   }
 
   func testObbDetectorDecodesTraditionalTensorAndRunsRotatedNMS() throws {

--- a/Tests/YOLOTests/SemanticSegmenterTests.swift
+++ b/Tests/YOLOTests/SemanticSegmenterTests.swift
@@ -70,4 +70,33 @@ final class SemanticSegmenterTests: XCTestCase {
       XCTAssertEqual(data[o + 3], 255, "alpha, pixel \(pixel)")
     }
   }
+
+  func testNonContiguousClassMapUsesStrides() throws {
+    let segmenter = SemanticSegmenter()
+    segmenter.labels = ["a", "b", "c"]
+    let pointer = UnsafeMutableRawPointer.allocate(
+      byteCount: 8 * MemoryLayout<Float>.stride, alignment: MemoryLayout<Float>.alignment)
+    pointer.initializeMemory(as: Float.self, repeating: 0, count: 8)
+    let values = pointer.assumingMemoryBound(to: Float.self)
+    values[0] = 1
+    values[2] = 0
+    values[4] = 2
+    values[6] = 1
+    let classMap = try MLMultiArray(
+      dataPointer: pointer, shape: [1, 2, 2], dataType: .float32, strides: [8, 4, 2]
+    ) { pointer in
+      pointer.deallocate()
+    }
+
+    let mask = try XCTUnwrap(segmenter.postProcessSemantic(classMap))
+
+    XCTAssertEqual(mask.classMap, [1, 0, 2, 1])
+  }
+
+  func testInvalidSemanticShapeReturnsNil() throws {
+    let segmenter = SemanticSegmenter()
+    let invalid = try MLMultiArray(shape: [2, 2], dataType: .float32)
+
+    XCTAssertNil(segmenter.postProcessSemantic(invalid))
+  }
 }

--- a/Tests/YOLOTests/YOLOMainTests.swift
+++ b/Tests/YOLOTests/YOLOMainTests.swift
@@ -130,6 +130,7 @@ class YOLOMainTests: XCTestCase {
     try Data(repeating: 1, count: 16).write(to: packageURL.appendingPathComponent("weights.bin"))
 
     XCTAssertEqual(cache.getCachedModelPath(url: sourceURL, task: .detect), packageURL)
+    XCTAssertTrue(cache.isCached(url: sourceURL, task: .detect))
     XCTAssertTrue(try cache.listCachedModels().contains(key))
     XCTAssertGreaterThanOrEqual(try cache.getCacheSize(), 18)
     XCTAssertNotEqual(cache.cacheKey(for: sourceURL, task: .detect), cache.cacheKey(for: sourceURL))

--- a/Tests/YOLOTests/YOLOSSOTMergeTests.swift
+++ b/Tests/YOLOTests/YOLOSSOTMergeTests.swift
@@ -35,7 +35,8 @@ final class YOLOSSOTMergeTests: XCTestCase {
     _ name: String,
     task: YOLOTask,
     useGpu: Bool = false,
-    numItemsThreshold: Int = 30
+    numItemsThreshold: Int = 30,
+    capturesOriginalImage: Bool = false
   ) throws -> BasePredictor {
     let expectation = XCTestExpectation(description: "Load \(name)")
     let url = try modelURL(name)
@@ -53,6 +54,7 @@ final class YOLOSSOTMergeTests: XCTestCase {
 
     wait(for: [expectation], timeout: 30)
     let predictor = try XCTUnwrap(loaded.load()).get()
+    predictor.capturesOriginalImage = capturesOriginalImage
     let expectedInputSize = task == .classify ? 224 : 640
     XCTAssertEqual(predictor.modelInputSize.width, expectedInputSize)
     XCTAssertEqual(predictor.modelInputSize.height, expectedInputSize)
@@ -147,65 +149,97 @@ final class YOLOSSOTMergeTests: XCTestCase {
     let modelPath = try modelURL("yolo26n").path
     var yolo: YOLO?
     var threshold: Int?
+    var confidence: Double?
+    var iou: Double?
+    var isLoaded = false
 
     yolo = YOLO(modelPath, task: .detect, useGpu: false, numItemsThreshold: 4) { result in
       if case .success(let yolo) = result {
         threshold = yolo.getNumItemsThreshold()
+        confidence = yolo.getConfidenceThreshold()
+        iou = yolo.getIouThreshold()
+        isLoaded = yolo.isLoaded
       }
       expectation.fulfill()
     }
+    yolo?.setConfidenceThreshold(0.4)
+    yolo?.setIouThreshold(0.6)
 
     wait(for: [expectation], timeout: 30)
     XCTAssertNotNil(yolo)
     XCTAssertEqual(threshold, 4)
+    XCTAssertEqual(confidence ?? -1, 0.4, accuracy: 0.001)
+    XCTAssertEqual(iou ?? -1, 0.6, accuracy: 0.001)
+    XCTAssertTrue(isLoaded)
   }
 
   func testRepresentativeStaticImageOutputShapes() throws {
     let image = testImage()
     let imageSize = image.extent.size
 
-    let detect = try loadPredictor("yolo26n", task: .detect, numItemsThreshold: 5)
+    let detect = try loadPredictor(
+      "yolo26n", task: .detect, numItemsThreshold: 5, capturesOriginalImage: true
+    )
       .predictOnImage(image: image)
     XCTAssertEqual(detect.orig_shape, imageSize)
     XCTAssertLessThanOrEqual(detect.boxes.count, 5)
     XCTAssertNil(detect.masks)
     XCTAssertNil(detect.probs)
     XCTAssertNil(detect.semanticMask)
+    XCTAssertNotNil(detect.originalImage)
 
-    let segment = try loadPredictor("yolo26n-seg", task: .segment, numItemsThreshold: 5)
+    let segment = try loadPredictor(
+      "yolo26n-seg", task: .segment, numItemsThreshold: 5, capturesOriginalImage: true
+    )
       .predictOnImage(image: image)
     XCTAssertEqual(segment.orig_shape, imageSize)
     XCTAssertLessThanOrEqual(segment.boxes.count, 5)
     XCTAssertNotNil(segment.masks)
     XCTAssertNil(segment.probs)
+    XCTAssertNotNil(segment.originalImage)
 
-    let classify = try loadPredictor("yolo26n-cls", task: .classify, numItemsThreshold: 5)
+    let classify = try loadPredictor(
+      "yolo26n-cls", task: .classify, numItemsThreshold: 5, capturesOriginalImage: true
+    )
       .predictOnImage(image: image)
     XCTAssertEqual(classify.orig_shape, imageSize)
     XCTAssertNotNil(classify.probs)
     XCTAssertLessThanOrEqual(classify.probs?.top5.count ?? 0, 5)
+    XCTAssertNotNil(classify.originalImage)
 
-    let pose = try loadPredictor("yolo26n-pose", task: .pose, numItemsThreshold: 5)
+    let pose = try loadPredictor(
+      "yolo26n-pose", task: .pose, numItemsThreshold: 5, capturesOriginalImage: true
+    )
       .predictOnImage(image: image)
     XCTAssertEqual(pose.orig_shape, imageSize)
     XCTAssertLessThanOrEqual(pose.boxes.count, 5)
     XCTAssertLessThanOrEqual(pose.keypointsList.count, 5)
+    XCTAssertNotNil(pose.originalImage)
 
-    let obb = try loadPredictor("yolo26n-obb", task: .obb, numItemsThreshold: 5)
+    let obb = try loadPredictor(
+      "yolo26n-obb", task: .obb, numItemsThreshold: 5, capturesOriginalImage: true
+    )
       .predictOnImage(image: image)
     XCTAssertEqual(obb.orig_shape, imageSize)
     XCTAssertLessThanOrEqual(obb.obb.count, 5)
+    XCTAssertNotNil(obb.originalImage)
 
-    let semantic = try loadPredictor("yolo26n-sem", task: .semantic, numItemsThreshold: 5)
+    let semantic = try loadPredictor(
+      "yolo26n-sem", task: .semantic, numItemsThreshold: 5, capturesOriginalImage: true
+    )
       .predictOnImage(image: image)
     XCTAssertEqual(semantic.orig_shape, imageSize)
     XCTAssertNotNil(semantic.semanticMask)
+    XCTAssertNotNil(semantic.originalImage)
 
-    let depth = try loadPredictor("yolo26n-depth", task: .depth, numItemsThreshold: 5)
+    let depth = try loadPredictor(
+      "yolo26n-depth", task: .depth, numItemsThreshold: 5, capturesOriginalImage: true
+    )
       .predictOnImage(image: image)
     XCTAssertEqual(depth.orig_shape, imageSize)
     let depthMap = try XCTUnwrap(depth.depthMap)
     XCTAssertEqual(depthMap.values.count, depthMap.width * depthMap.height)
     XCTAssertLessThan(depthMap.minDepth, depthMap.maxDepth)
+    XCTAssertNotNil(depth.originalImage)
   }
 }

--- a/Tests/YOLOTests/YOLOSSOTMergeTests.swift
+++ b/Tests/YOLOTests/YOLOSSOTMergeTests.swift
@@ -180,7 +180,7 @@ final class YOLOSSOTMergeTests: XCTestCase {
     let detect = try loadPredictor(
       "yolo26n", task: .detect, numItemsThreshold: 5, capturesOriginalImage: true
     )
-      .predictOnImage(image: image)
+    .predictOnImage(image: image)
     XCTAssertEqual(detect.orig_shape, imageSize)
     XCTAssertLessThanOrEqual(detect.boxes.count, 5)
     XCTAssertNil(detect.masks)
@@ -191,7 +191,7 @@ final class YOLOSSOTMergeTests: XCTestCase {
     let segment = try loadPredictor(
       "yolo26n-seg", task: .segment, numItemsThreshold: 5, capturesOriginalImage: true
     )
-      .predictOnImage(image: image)
+    .predictOnImage(image: image)
     XCTAssertEqual(segment.orig_shape, imageSize)
     XCTAssertLessThanOrEqual(segment.boxes.count, 5)
     XCTAssertNotNil(segment.masks)
@@ -201,7 +201,7 @@ final class YOLOSSOTMergeTests: XCTestCase {
     let classify = try loadPredictor(
       "yolo26n-cls", task: .classify, numItemsThreshold: 5, capturesOriginalImage: true
     )
-      .predictOnImage(image: image)
+    .predictOnImage(image: image)
     XCTAssertEqual(classify.orig_shape, imageSize)
     XCTAssertNotNil(classify.probs)
     XCTAssertLessThanOrEqual(classify.probs?.top5.count ?? 0, 5)
@@ -210,7 +210,7 @@ final class YOLOSSOTMergeTests: XCTestCase {
     let pose = try loadPredictor(
       "yolo26n-pose", task: .pose, numItemsThreshold: 5, capturesOriginalImage: true
     )
-      .predictOnImage(image: image)
+    .predictOnImage(image: image)
     XCTAssertEqual(pose.orig_shape, imageSize)
     XCTAssertLessThanOrEqual(pose.boxes.count, 5)
     XCTAssertLessThanOrEqual(pose.keypointsList.count, 5)
@@ -219,7 +219,7 @@ final class YOLOSSOTMergeTests: XCTestCase {
     let obb = try loadPredictor(
       "yolo26n-obb", task: .obb, numItemsThreshold: 5, capturesOriginalImage: true
     )
-      .predictOnImage(image: image)
+    .predictOnImage(image: image)
     XCTAssertEqual(obb.orig_shape, imageSize)
     XCTAssertLessThanOrEqual(obb.obb.count, 5)
     XCTAssertNotNil(obb.originalImage)
@@ -227,7 +227,7 @@ final class YOLOSSOTMergeTests: XCTestCase {
     let semantic = try loadPredictor(
       "yolo26n-sem", task: .semantic, numItemsThreshold: 5, capturesOriginalImage: true
     )
-      .predictOnImage(image: image)
+    .predictOnImage(image: image)
     XCTAssertEqual(semantic.orig_shape, imageSize)
     XCTAssertNotNil(semantic.semanticMask)
     XCTAssertNotNil(semantic.originalImage)
@@ -235,7 +235,7 @@ final class YOLOSSOTMergeTests: XCTestCase {
     let depth = try loadPredictor(
       "yolo26n-depth", task: .depth, numItemsThreshold: 5, capturesOriginalImage: true
     )
-      .predictOnImage(image: image)
+    .predictOnImage(image: image)
     XCTAssertEqual(depth.orig_shape, imageSize)
     let depthMap = try XCTUnwrap(depth.depthMap)
     XCTAssertEqual(depthMap.values.count, depthMap.width * depthMap.height)


### PR DESCRIPTION
## Summary

- cover end-to-end pose tensors with and without class IDs
- cover strided semantic class maps and invalid output shapes
- verify pre-load thresholds, model readiness, original-image capture, cache lookup, and smoothed timing through existing test owners

## Coverage

- baseline CI-filtered line coverage: 6,829 / 7,524 = 90.76%
- branch CI-filtered line coverage: 7,082 / 7,677 = 92.25%
- no production changes, coverage filters, new files, or UI/camera scaffolding

## Validation

- xcodebuild -scheme UltralyticsYOLO -sdk iphonesimulator -derivedDataPath Build/ -destination platform=iOS\ Simulator,id=CC69A7E3-91C5-4B4C-894D-FE69ADDB8028,arch=arm64 -enableCodeCoverage YES IPHONEOS_DEPLOYMENT_TARGET=16.0 clean build test
- 109 tests passed
- git diff --check

swift-format is not installed locally; the repository format workflow will apply and validate its canonical formatting.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🧪 Expands YOLO iOS test coverage across prediction outputs, segmentation, caching, thresholds, timing, and original-image capture.

### 📊 Key Changes

- Added timing assertions for smoothed inference and post-processing breakdowns.
- Added end-to-end pose tests for tensor layouts with and without class fields.
- Added semantic segmentation tests for:
  - Non-contiguous `MLMultiArray` strides.
  - Invalid input shapes returning `nil`.
- Verified model cache status with `isCached`.
- Expanded YOLO configuration tests for confidence and IoU thresholds, item limits, and loaded state.
- Added coverage confirming `originalImage` is preserved across detection, segmentation, classification, pose, OBB, semantic segmentation, and depth tasks.
- Extended representative output-shape tests for YOLO26 models across supported tasks.

### 🎯 Purpose & Impact

- ✅ Improves confidence that post-processing correctly handles different model output formats and memory layouts.
- 🛡️ Helps prevent regressions when processing malformed or unsupported semantic segmentation tensors.
- 🎛️ Verifies runtime prediction settings are applied and exposed correctly.
- 🖼️ Confirms users can access the source image alongside predictions when image capture is enabled.
- 📈 Strengthens regression protection for YOLO26 task support, model caching, and performance reporting.