### PR TITLE
Use the canonical Contact heading in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Ultralytics provides two licensing options to accommodate diverse use cases:
 - **AGPL-3.0 License**: An [OSI-approved](https://opensource.org/license/agpl-3.0) open-source license ideal for academic research, personal projects, and experimentation. It promotes open collaboration and knowledge sharing. See the [LICENSE](https://github.com/ultralytics/yolo-ios-app/blob/main/LICENSE) file for the full license text.
 - **Enterprise License**: Tailored for commercial applications, this license allows the integration of Ultralytics software and AI models into commercial products and services without the open-source requirements of AGPL-3.0. If your scenario involves commercial use, please contact us via [Ultralytics Licensing](https://www.ultralytics.com/license).
 
-## 🤝 Contact
+## 📮 Contact
 
 - For bug reports and feature requests related to this iOS project, please use [GitHub Issues](https://github.com/ultralytics/yolo-ios-app/issues).
 - For questions, discussions, and support regarding Ultralytics technologies, join our active [Discord](https://discord.com/invite/ultralytics) community!

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -205,7 +205,7 @@ Ultralytics 提供两种许可证选项，以适配不同的使用场景：
 - **AGPL-3.0 License**：这是一个经 [OSI 批准](https://opensource.org/license/agpl-3.0)的开源许可证，适用于学术研究、个人项目和实验用途。它鼓励开放协作与知识共享。完整许可证文本请参阅 [LICENSE](https://github.com/ultralytics/yolo-ios-app/blob/main/LICENSE) 文件。
 - **Enterprise License**：面向商业应用场景，允许将 Ultralytics 软件和 AI 模型集成到商业产品与服务中，而无需遵循 AGPL-3.0 的开源要求。如果你的场景涉及商业用途，请通过 [Ultralytics Licensing](https://www.ultralytics.com/license) 与我们联系。
 
-## 🤝 联系我们
+## 📮 联系我们
 
 - 如需提交与该 iOS 项目相关的 bug 报告或功能请求，请使用 [GitHub Issues](https://github.com/ultralytics/yolo-ios-app/issues)。
 - 如需咨询、讨论或获取与 Ultralytics 技术相关的支持，欢迎加入我们的 [Discord](https://discord.com/invite/ultralytics) 社区。


### PR DESCRIPTION
Align the README tail with the canonical Ultralytics structure: the Contact section used `## 🤝 Contact` instead of `## 📮 Contact`. Mirrored in the 简体中文 README. Section content is unchanged.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated the README contact section emoji in both English and Chinese documentation for clearer visual consistency. 📮

### 📊 Key Changes

- Changed the English heading from `🤝 Contact` to `📮 Contact`.
- Changed the Chinese heading from `🤝 联系我们` to `📮 联系我们`.
- No code, functionality, or user-facing app behavior was modified.

### 🎯 Purpose & Impact

- 📚 Improves the visual association between the contact section and communication channels.
- 🌍 Keeps the English and Chinese README files consistent.
- ✅ Has no impact on iOS app performance, features, or model usage.