### PR TITLE
Gate publish Slack notification on all release jobs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -187,7 +187,7 @@ jobs:
         run: git push --force origin testflight
 
   notify:
-    needs: [check, release, testflight]
+    needs: [check, release, pod, testflight]
     if: always() && needs.check.outputs.new_version == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -204,7 +204,7 @@ jobs:
           TITLE=$(printf '%s' "$TITLE" | sed -E "s@#([0-9]+)@<https://github.com/$GH_REPO/pull/\1|#\1>@g")
           echo "title=$TITLE" >> "$GITHUB_OUTPUT"
       - name: Notify Success
-        if: needs.release.result == 'success' && github.event_name == 'push'
+        if: needs.release.result == 'success' && needs.pod.result == 'success' && needs.testflight.result == 'success' && github.event_name == 'push'
         uses: slackapi/slack-github-action@v4.0.0
         with:
           webhook-type: incoming-webhook
@@ -212,7 +212,7 @@ jobs:
           payload: |
             text: "<!subteam^S07NKMNECKH> *${{ github.workflow }}* ✅ `${{ github.repository }}` ${{ steps.release.outputs.title || needs.check.outputs.current_tag }}  <https://github.com/${{ github.repository }}/releases/tag/${{ needs.check.outputs.current_tag }}|*Release*>  ·  <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Run*>"
       - name: Notify Failure
-        if: needs.release.result != 'success'
+        if: needs.release.result == 'failure' || needs.pod.result == 'failure' || needs.testflight.result == 'failure'
         uses: slackapi/slack-github-action@v4.0.0
         with:
           webhook-type: incoming-webhook

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -188,7 +188,7 @@ jobs:
 
   notify:
     needs: [check, release, pod, testflight]
-    if: always() && needs.check.outputs.new_version == 'true'
+    if: always() && (needs.check.outputs.new_version == 'true' || needs.testflight.result == 'failure')
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

The notify job only checked `release`, so a failed CocoaPods trunk push or TestFlight upload still posted ✅ to Slack (and `pod` wasn't even in `needs`). Aligns with the org standard where success requires every publish job to pass:

- `pod` added to `needs`; success now requires `release`, `pod`, and `testflight` all green.
- Failure fires when any of the three actually fails (`== 'failure'` rather than `!= 'success'`), so dispatch runs that intentionally skip `release`/`pod` (e.g. TestFlight-only) no longer risk posting ❌ for skipped jobs.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves release workflow notifications to include CocoaPods and TestFlight results, with more accurate success and failure alerts. 🔔

### 📊 Key Changes
- Adds the `pod` job as a dependency of the notification job.
- Sends success notifications only when release, CocoaPods, and TestFlight jobs all complete successfully.
- Triggers notifications for TestFlight failures, even when no new version is detected.
- Sends failure alerts when the release, CocoaPods, or TestFlight job fails.

### 🎯 Purpose & Impact
- Provides more reliable visibility into the complete publishing pipeline. ✅
- Helps the team quickly identify failures affecting app releases, CocoaPods distribution, or TestFlight builds.
- Prevents premature success messages when any publishing step has failed.
- Improves release monitoring without changing the app itself.