### PR TITLE
Standardize .github configuration

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -51,10 +51,9 @@ body:
       description: Share the platform and version information relevant to your report.
       placeholder: |
         Please include:
-        - OS / platform (e.g., iOS version, Xcode version, macOS version)
-        - Language or framework version (Python, Swift, Flutter, etc.)
-        - Package or app version
-        - Hardware (e.g., CPU, GPU model, device model)
+        - Device and iOS version (e.g., iPhone 15 / iOS 18.2)
+        - Xcode and macOS versions (e.g., Xcode 26.0 / macOS 26.0)
+        - UltralyticsYOLO package or app version
         - Any other environment details
     validations:
       required: true
@@ -65,8 +64,8 @@ body:
       description: >
         Provide the smallest possible snippet, command, or steps required to reproduce the issue. This helps us pinpoint problems faster.
       placeholder: |
-        ```python
-        # Code or commands to reproduce your issue here
+        ```swift
+        // Code or commands to reproduce your issue here
         ```
     validations:
       required: false

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -29,13 +29,12 @@ jobs:
         uses: ultralytics/actions@main
         with:
           token: ${{ secrets._GITHUB_TOKEN || secrets.GITHUB_TOKEN }} # Auto-generated token
-          python-version: "3.13" # Pin to 3.13, docformatter is not yet compatible with Python 3.14
           labels: true # Auto-label issues/PRs using AI
-          python: true # Format Python with Ruff and docformatter
+          python: true # Format Python with Ruff
           prettier: true # Format YAML, JSON, Markdown, CSS
           swift: true # Format Swift (requires a macOS runner)
           spelling: true # Check spelling with codespell
-          links: false # Check broken links with Lychee
+          links: true # Check broken links with Lychee
           summary: true # Generate AI-powered PR summaries
           openai_api_key: ${{ secrets.OPENAI_API_KEY }} # Powers PR summaries, labels and comments
           brave_api_key: ${{ secrets.BRAVE_API_KEY }} # Used for broken link resolution

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -34,7 +34,7 @@ jobs:
           prettier: true # Format YAML, JSON, Markdown, CSS
           swift: true # Format Swift (requires a macOS runner)
           spelling: true # Check spelling with codespell
-          links: true # Check broken links with Lychee
+          links: false # Lychee link check does not run on macOS runners
           summary: true # Generate AI-powered PR summaries
           openai_api_key: ${{ secrets.OPENAI_API_KEY }} # Powers PR summaries, labels and comments
           brave_api_key: ${{ secrets.BRAVE_API_KEY }} # Used for broken link resolution


### PR DESCRIPTION
Aligns the .github directory with the current Ultralytics reference configuration (sdk, skills, openapi, lite).

- format.yml: drop the Python 3.13 pin added for docformatter on Python 3.14; Ultralytics Actions replaced docformatter with its own docstring formatter in Nov 2025, so the pin is dead. The Lychee link check stays disabled because lychee-action does not run on macOS runners (it downloads a Linux binary), and this workflow needs macOS for Swift formatting.
- bug-report.yml: iOS/Xcode environment fields and a Swift code fence in the minimal reproducible example instead of Python.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated the GitHub issue template and formatting workflow to match the current Ultralytics configuration for this iOS/Swift repository.

### 📊 Key Changes

- Removed the Python 3.13 pin from `.github/workflows/format.yml`.
- Updated the workflow’s Python formatting description to reference Ruff only.
- Clarified that Lychee link checking remains disabled because it does not run on macOS runners.
- Adjusted `.github/ISSUE_TEMPLATE/bug-report.yml` to request device, iOS, Xcode, and macOS details.
- Changed the minimal reproduction example from a Python code block to a Swift code block.

### 🎯 Purpose & Impact

- Bug reports now collect iOS- and Swift-specific environment information and examples.
- The formatting workflow no longer configures the removed docformatter dependency while continuing Swift formatting on macOS.
- No change to the enabled workflow checks or application runtime behavior.