### PR TITLE
Enable link checks in Ultralytics Actions

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -34,7 +34,7 @@ jobs:
           prettier: true # Format YAML, JSON, Markdown, CSS
           swift: true # Format Swift (requires a macOS runner)
           spelling: true # Check spelling with codespell
-          links: false # Lychee link check does not run on macOS runners
+          links: true # Check broken links with Lychee
           summary: true # Generate AI-powered PR summaries
           openai_api_key: ${{ secrets.OPENAI_API_KEY }} # Powers PR summaries, labels and comments
           brave_api_key: ${{ secrets.BRAVE_API_KEY }} # Used for broken link resolution


### PR DESCRIPTION
Ultralytics Actions now installs Lychee per runner platform, so link checks work on macOS runners.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Enabled Lychee link checking in the GitHub Actions formatting workflow now that the action installs Lychee on macOS runners.

### 📊 Key Changes
- Changed the `links` option in `.github/workflows/format.yml` from `false` to `true`.
- Link checks now run alongside Prettier, Swift formatting, spelling checks, and other configured workflow steps.

### 🎯 Purpose & Impact
- Pull requests processed by this workflow will check for broken links, including on macOS runners.
- No application code or user-facing app behavior changed.