### PR TITLE
Make the BasePredictor label parser public for SDK consumers

### DIFF
--- a/Sources/UltralyticsYOLO/BasePredictor.swift
+++ b/Sources/UltralyticsYOLO/BasePredictor.swift
@@ -114,7 +114,7 @@ public class BasePredictor: Predictor, @unchecked Sendable {
   /// Supports comma-separated `classes` metadata and dictionary/list-style `names` metadata. Sparse keyed `names`
   /// preserve their numeric indexes by filling missing slots with empty strings so `labelName(for:)` can fall back
   /// deterministically.
-  static func parseLabels(from userDefined: [String: String]) -> [String] {
+  public static func parseLabels(from userDefined: [String: String]) -> [String] {
     if let labelsData = userDefined["classes"] {
       return
         labelsData

--- a/UltralyticsYOLO.podspec
+++ b/UltralyticsYOLO.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'UltralyticsYOLO'
-  s.version          = '8.9.13'
+  s.version          = '8.9.14'
   s.summary          = 'Ultralytics YOLO core inference for iOS (CoreML/Vision).'
   s.homepage         = 'https://github.com/ultralytics/yolo-ios-app'
   s.license          = { :type => 'AGPL-3.0', :file => 'LICENSE' }

--- a/YOLOiOSApp/YOLOiOSApp.xcodeproj/project.pbxproj
+++ b/YOLOiOSApp/YOLOiOSApp.xcodeproj/project.pbxproj
@@ -389,7 +389,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.9.13;
+				MARKETING_VERSION = 8.9.14;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ultralytics.iDetection;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -416,7 +416,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.9.13;
+				MARKETING_VERSION = 8.9.14;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ultralytics.iDetection;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";


### PR DESCRIPTION
`BasePredictor.parseLabels` has no access modifier, so it is internal to the `UltralyticsYOLO` module. Consumers that need to turn Ultralytics creator-defined metadata into labels cannot reach it, and the Flutter plugin has consequently carried its own 48-line fork of this function since it was written.

That fork has drifted, and the drift is not cosmetic — it produces three wrong results this parser handles correctly:

- **List-style `names`** (`"['person','car']"`) — the fork never strips `[`/`]` and `guard components.count >= 2 else { return nil }` rejects every unkeyed entry, so it returns `[]` and every detection renders as `class 0`.
- **Double-quoted keys** (`{"0": "person"}`) — the fork strips only `'`, and only from the value, so `Int("\"0\"")` is `nil` and the entry is dropped; surviving labels keep literal quote characters.
- **Negative key in `names`** — the fork writes `labels[key]` with no lower bound, so a negative index traps with `Index out of range` inside a background dispatch. This parser guards with `where key >= 0`.

Making the function public lets that fork be deleted rather than repaired in two places, which is the follow-up in ultralytics/yolo-flutter-app.

No new API and no new tests: `Tests/YOLOTests/YOLOSSOTMergeTests.swift:88` already covers the parser and simply switches from `@testable` reach to public reach. `periphery --strict` stays green because `create` still calls it.

Version bumped to 8.9.14 so the plugin has a release to pin.

## Validation

`xcodebuild -scheme UltralyticsYOLO -sdk iphonesimulator -only-testing:YOLOTests/YOLOSSOTMergeTests build test` — builds clean, `testMetadataLabelParsingAndFallbacks` passes. Three model-backed tests (`testNumItemsThresholdAtCreateAndLoad`, `testRepresentativeStaticImageOutputShapes`, `testYOLO26NMSFreeEffectiveIoUStaysOne`) fail identically on unmodified `main` in the same environment, so they are pre-existing and unrelated.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

`BasePredictor.parseLabels` is now publicly accessible to SDK consumers, and the iOS package and app versions were bumped from 8.9.13 to 8.9.14.

### 📊 Key Changes

- Changed `BasePredictor.parseLabels(from:)` from internal to `public static`, exposing the existing metadata label parser outside the `UltralyticsYOLO` module.
- Preserved the parser’s existing handling for comma-separated `classes`, list- and dictionary-style `names`, sparse indexes, and non-negative keys.
- Updated `UltralyticsYOLO.podspec` and both Xcode marketing-version entries to `8.9.14`.

### 🎯 Purpose & Impact

- SDK consumers, including the Flutter integration, can use the shared parser instead of maintaining a separate parsing implementation.
- No parsing logic changed in this PR; existing label handling remains available through the newly public API.